### PR TITLE
mass-rename of chart repo

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -1,13 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v0.102.0
 description: DNS proxy as ad-blocker for local network
 name: adguard-home
-version: 1.2.0
+version: 2.0.0
 keywords:
   - adguard-home
   - adguard
   - dns
-home: https://github.com/billimek/billimek-charts/tree/master/charts/adguard-home
+home: https://github.com/k8s-at-home/charts/tree/master/charts/adguard-home
 icon: https://avatars3.githubusercontent.com/u/8361145?s=200&v=4?sanitize=true
 sources:
   - https://github.com/AdguardTeam/AdGuardHome

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -7,8 +7,8 @@ The default values and container images used in this chart will allow for runnin
 ## TL;DR
 
 ```shell
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/adguard-home
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/adguard-home
 ```
 
 ## Installing the Chart
@@ -16,7 +16,7 @@ helm install billimek/adguard-home
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name adguard-home billimek/adguard-home
+helm install --name adguard-home k8s-at-home/adguard-home
 ```
 
 ## Uninstalling the Chart
@@ -31,20 +31,20 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/adguard-home/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/adguard-home/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name adguard-home \
   --set timeZone="America/New York" \
-    billimek/adguard-home
+    k8s-at-home/adguard-home
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name adguard-home -f values.yaml billimek/adguard-home
+helm install --name adguard-home -f values.yaml k8s-at-home/adguard-home
 ```
 
 #### Helm force upgrade

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v0.8.4.2-ls72
 description: Bazarr is a companion application to Sonarr and Radarr. It manages and downloads subtitles based on your requirements
 name: bazarr
-version: 2.0.2
+version: 3.0.0
 keywords:
   - bazarr
   - radarr
@@ -10,7 +10,7 @@ keywords:
   - subtitles
   - usenet
   - bittorrent
-home: https://github.com/billimek/billimek-charts/tree/master/charts/bazarr
+home: https://github.com/k8s-at-home/charts/tree/master/charts/bazarr
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bazarr.png
 sources:
   - https://hub.docker.com/r/linuxserver/bazarr/

--- a/charts/bazarr/README.md
+++ b/charts/bazarr/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [bazarr](https://github.com/morpheus65535/bazarr) lever
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/bazarr
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/bazarr
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/bazarr
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/bazarr
+helm install --name my-release k8s-at-home/bazarr
 ```
 
 ## Upgrading
@@ -97,7 +97,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/bazarr
+    k8s-at-home/bazarr
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -114,4 +114,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/bazarr/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/bazarr/values.yaml) file. It has several commented out suggested values.

--- a/charts/bitwardenrs/Chart.yaml
+++ b/charts/bitwardenrs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bitwardenrs
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 0.1.0
+version: 1.0.0
 appVersion: 1.16.3
 keywords:
   - bitwarden
@@ -10,7 +10,7 @@ keywords:
   - bitwarden_rs
   - password
   - rust
-home: https://github.com/billimek/billimek-charts/tree/master/charts/bitwarden_rs
+home: https://github.com/k8s-at-home/charts/tree/master/charts/bitwarden_rs
 sources:
   - https://github.com/dani-garcia/bitwarden_rs
 maintainers:

--- a/charts/bitwardenrs/README.md
+++ b/charts/bitwardenrs/README.md
@@ -7,8 +7,8 @@ The default values and container images used in this chart will allow for runnin
 ## TL;DR
 
 ```console
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/bitwardenrs
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/bitwardenrs
 ```
 
 ## Installing the Chart
@@ -16,7 +16,7 @@ helm install billimek/bitwardenrs
 To install the chart with the release name `bitwarden`:
 
 ```console
-helm install bitwarden billimek/bitwardenrs
+helm install bitwarden k8s-at-home/bitwardenrs
 ```
 
 ## Uninstalling the Chart
@@ -31,18 +31,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/bitwardenrs/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/bitwardenrs/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install bitwarden \
   --set timeZone="America/New York" \
-    billimek/bitwardenrs
+    k8s-at-home/bitwardenrs
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install bitwarden billimek/bitwardenrs  --values values.yaml 
+helm install bitwarden k8s-at-home/bitwardenrs  --values values.yaml 
 ```

--- a/charts/blocky/Chart.yaml
+++ b/charts/blocky/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "v0.8"
 description: DNS proxy as ad-blocker for local network
 name: blocky
-version: 3.3.0
+version: 4.0.0
 keywords:
   - blocky
   - dbs
-home: https://github.com/billimek/billimek-charts/tree/master/charts/blocky
+home: https://github.com/k8s-at-home/charts/tree/master/charts/blocky
 icon: https://github.com/0xERR0R/blocky/raw/master/docs/blocky.svg?sanitize=true
 sources:
   - https://github.com/0xERR0R/blocky

--- a/charts/blocky/README.md
+++ b/charts/blocky/README.md
@@ -7,8 +7,8 @@ The default values and container images used in this chart will allow for runnin
 ## TL;DR
 
 ```shell
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/blocky
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/blocky
 ```
 
 ## Installing the Chart
@@ -16,7 +16,7 @@ helm install billimek/blocky
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name blocky billimek/blocky
+helm install --name blocky k8s-at-home/blocky
 ```
 
 ## Uninstalling the Chart
@@ -31,20 +31,20 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/blocky/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/blocky/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name blocky \
   --set timeZone="America/New York" \
-    billimek/blocky
+    k8s-at-home/blocky
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name blocky -f values.yaml billimek/blocky
+helm install --name blocky -f values.yaml k8s-at-home/blocky
 ```
 
 ## Upgrading an existing Release to a new major version

--- a/charts/calibre-web/Chart.yaml
+++ b/charts/calibre-web/Chart.yaml
@@ -10,11 +10,11 @@ name: calibre-web
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 2.0.0
 keywords:
   - calibre
   - ebook
-home: https://github.com/billimek/billimek-charts/tree/master/charts/calibre-web
+home: https://github.com/k8s-at-home/charts/tree/master/charts/calibre-web
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/calibre-web-icon.png
 sources:
   - https://hub.docker.com/r/linuxserver/calibre-web/

--- a/charts/calibre-web/README.md
+++ b/charts/calibre-web/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [calibre-web](https://github.com/janeczku/calibre-web) 
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.github.io/billimek-charts/
-$ helm install billimek/calibre-web
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/calibre-web
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/calibre-web
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/calibre-web
+helm install --name my-release k8s-at-home/calibre-web
 ```
 
 ## Uninstalling the Chart
@@ -87,7 +87,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/calibre-web
+    k8s-at-home/calibre-web
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -104,4 +104,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/calibre-web/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/calibre-web/values.yaml) file. It has several commented out suggested values.

--- a/charts/comcast/Chart.yaml
+++ b/charts/comcast/Chart.yaml
@@ -1,17 +1,17 @@
-apiVersion: v1
+apiVersion: v2
 name: comcast
-version: 2.0.1
+version: 3.0.0
 appVersion: 1.0.0
 description: periodic comcast data usage checks and save the results to InfluxDB
 keywords:
 - comcast
 - influxdb
 - xfinity
-home: https://github.com/billimek/billimek-charts/tree/master/charts/comcast
+home: https://github.com/k8s-at-home/charts/tree/master/charts/comcast
 icon: https://i.imgur.com/iR1dUpp.png
 sources:
 - https://github.com/billimek/comcastUsage-for-influxdb
-- https://github.com/billimek/billimek-charts
+- https://github.com/k8s-at-home/charts
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/comcast/README.md
+++ b/charts/comcast/README.md
@@ -7,8 +7,8 @@ This tool allows you to run periodic comcast data usage checks and save the resu
 ## TL;DR;
 
 ```console
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/comcast
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/comcast
 ```
 
 ## Introduction
@@ -20,7 +20,7 @@ This code is adopted from the work done by [barrycarey](https://github.com/barry
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release billimek/comcast
+$ helm install --name my-release k8s-at-home/comcast
 ```
 ## Uninstalling the Chart
 
@@ -62,16 +62,16 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set config.comcast.username=tonystark,config.comcast.password=mypassword \
-    billimek/comcast
+    k8s-at-home/comcast
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/comcast
+helm install --name my-release -f values.yaml k8s-at-home/comcast
 ```
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/comcast/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/comcast/values.yaml) file. It has several commented out suggested values.
 
 ## InfluxDB metrics
 ```

--- a/charts/couchpotato/Chart.yaml
+++ b/charts/couchpotato/Chart.yaml
@@ -1,13 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 7260c12f-ls33
 description: couchpotato is a movie downloading client
 name: couchpotato
-version: 1.0.2
+version: 2.0.0
 keywords:
   - couchpotato
   - usenet
   - bittorrent
-home: https://github.com/billimek/billimek-charts/tree/master/charts/couchpotato
+home: https://github.com/k8s-at-home/charts/tree/master/charts/couchpotato
 icon: https://github.com/CouchPotato/CouchPotatoServer/raw/master/couchpotato/static/images/icons/android.png
 sources:
   - https://hub.docker.com/r/linuxserver/couchpotato/

--- a/charts/couchpotato/README.md
+++ b/charts/couchpotato/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [couchpotato](https://github.com/couchpotato/couchpotat
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/couchpotato
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/couchpotato
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/couchpotato
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/couchpotato
+helm install --name my-release k8s-at-home/couchpotato
 ```
 
 ## Uninstalling the Chart
@@ -89,7 +89,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/couchpotato
+    k8s-at-home/couchpotato
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -105,4 +105,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/couchpotato/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/couchpotato/values.yaml) file. It has several commented out suggested values.

--- a/charts/deconz/Chart.yaml
+++ b/charts/deconz/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: deconz
 description: A Helm chart for deploying deCONZ
-version: 1.0.2
+version: 2.0.0
 appVersion: 2.05.80
 keywords:
   - deconz
   - home-automation
   - zigbee
-home: https://github.com/billimek/billimek-charts/tree/master/charts/deconz
+home: https://github.com/k8s-at-home/charts/tree/master/charts/deconz
 icon: https://avatars1.githubusercontent.com/u/4217524?s=400&v=4
 sources:
   - https://github.com/dresden-elektronik/deconz-rest-plugin

--- a/charts/deconz/README.md
+++ b/charts/deconz/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [deCONZ](https://www.dresden-elektronik.de/funk/softwar
 ## TL;DR
 
 ```shell
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/deconz
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/deconz
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ helm install billimek/deconz
 To install the chart with the release name `my-release`:
 
 ```shell
-helm install my-release billimek/deconz
+helm install my-release k8s-at-home/deconz
 ```
 
 ## Uninstalling the Chart
@@ -30,7 +30,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Configuration
 
 The following tables lists the configurable parameters of the Sentry chart and their default values.
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/deconz/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/deconz/values.yaml) file. It has several commented out suggested values.
 
 | Parameter                                   | Description                                                                                  | Default                                        |
 | ------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------- |
@@ -91,11 +91,11 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install my-release \
   --set timezone="Europe/Amsterdam" \
-    billimek/deconz
+    k8s-at-home/deconz
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install my-release -f values.yaml billimek/deconz
+helm install my-release -f values.yaml k8s-at-home/deconz
 ```

--- a/charts/digitalocean-dyndns/Chart.yaml
+++ b/charts/digitalocean-dyndns/Chart.yaml
@@ -1,16 +1,16 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: Dynamic DNS using DigitalOcean's DNS Services
 name: digitalocean-dyndns
-version: 1.0.1
+version: 2.0.0
 keywords:
 - digitalocean
 - dynamicdns
-home: https://github.com/billimek/billimek-charts/tree/master/charts/digitalocean-dyndns
+home: https://github.com/k8s-at-home/charts/tree/master/charts/digitalocean-dyndns
 icon: https://i.imgur.com/cS6iqXD.png
 sources:
 - https://github.com/tunix/digitalocean-dyndns
-- https://github.com/billimek/billimek-charts
+- https://github.com/k8s-at-home/charts
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/digitalocean-dyndns/README.md
+++ b/charts/digitalocean-dyndns/README.md
@@ -5,8 +5,8 @@ A script that pushes the public IP address of the running machine to DigitalOcea
 ## TL;DR;
 
 ```console
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/digitalocean-dyndns
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/digitalocean-dyndns
 ```
 
 ## Introduction
@@ -18,7 +18,7 @@ This code is adopted from [this original repo](https://github.com/tunix/digitalo
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release billimek/digitalocean-dyndns
+$ helm install --name my-release k8s-at-home/digitalocean-dyndns
 ```
 ## Uninstalling the Chart
 
@@ -50,13 +50,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set config.digitalocean.token=thisismyapikey \
-    billimek/digitalocean-dyndns
+    k8s-at-home/digitalocean-dyndns
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/digitalocean-dyndns
+helm install --name my-release -f values.yaml k8s-at-home/digitalocean-dyndns
 ```
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/digitalocean-dyndns/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/digitalocean-dyndns/values.yaml) file. It has several commented out suggested values.

--- a/charts/duplicati/Chart.yaml
+++ b/charts/duplicati/Chart.yaml
@@ -1,11 +1,11 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v2.0.5.1-2.0.5.1_beta_2020-01-18-ls58
 description: Store securely encrypted backups on cloud storage services!
 name: duplicati
-version: 1.0.2
+version: 2.0.0
 keywords:
   - duplicati
-home: https://github.com/billimek/billimek-charts/tree/master/charts/duplicati
+home: https://github.com/k8s-at-home/charts/tree/master/charts/duplicati
 icon: https://i.imgur.com/KjnkhUJ.png
 sources:
   - https://hub.docker.com/r/linuxserver/duplicati/

--- a/charts/duplicati/README.md
+++ b/charts/duplicati/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [duplicati](https://github.com/duplicati/duplicati) lev
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/duplicati
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/duplicati
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/duplicati
 To install the chart with the release name `my-release`:
 
 ```console
-helm install my-release billimek/duplicati
+helm install my-release k8s-at-home/duplicati
 ```
 
 ## Uninstalling the Chart
@@ -90,13 +90,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install my-release \
   --set timezone="America/New York" \
-    billimek/duplicati
+    k8s-at-home/duplicati
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install my-release -f values.yaml billimek/duplicati
+helm install my-release -f values.yaml k8s-at-home/duplicati
 ```
 
 ---
@@ -106,4 +106,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/duplicati/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/duplicati/values.yaml) file. It has several commented out suggested values.

--- a/charts/esphome/Chart.yaml
+++ b/charts/esphome/Chart.yaml
@@ -1,11 +1,11 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 1.14.5
 description: ESPHome
 name: esphome
-version: 1.0.1
+version: 2.0.0
 keywords:
 - esphome
-home: https://github.com/billimek/billimek-charts/tree/master/charts/esphome
+home: https://github.com/k8s-at-home/charts/tree/master/charts/esphome
 icon: https://esphome.io/_images/logo-text.svg
 sources:
 - https://github.com/esphome/esphome

--- a/charts/esphome/README.md
+++ b/charts/esphome/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [ESPHome](https://esphome.io)
 ## TL;DR;
 
 ```shell
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/esphome
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/esphome
 ```
 
 ## Introduction
@@ -18,7 +18,7 @@ This code is adapted for [the official esphome docker image](https://hub.docker.
 To install the chart with the release name `my-release`:
 
 ```shell
-helm install --name my-release billimek/esphome
+helm install --name my-release k8s-at-home/esphome
 ```
 ## Uninstalling the Chart
 
@@ -101,13 +101,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```shell
 helm install --name my-release \
   --set image.tag=latest \
-    billimek/esphome
+    k8s-at-home/esphome
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```shell
-helm install --name my-release -f values.yaml billimek/esphome
+helm install --name my-release -f values.yaml k8s-at-home/esphome
 ```
 
 Read through the [values.yaml](values.yaml) file. It has several commented out suggested values.

--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -1,13 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "0.5.2"
 description: Realtime object detection on RTSP cameras with the Google Coral
 name: frigate
-version: 3.2.0
+version: 4.0.0
 keywords:
   - tensorflow
   - coral
   - ml
-home: https://github.com/billimek/billimek-charts/tree/master/charts/frigate
+home: https://github.com/k8s-at-home/charts/tree/master/charts/frigate
 icon: https://upload.wikimedia.org/wikipedia/commons/a/a4/Lutine1.jpg
 sources:
   - https://github.com/blakeblackshear/frigate

--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [frigate](https://github.com/blakeblackshear/frigate)
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/frigate
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/frigate
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/frigate
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/frigate
+helm install --name my-release k8s-at-home/frigate
 ```
 
 ~~**IMPORTANT NOTE:** the [Google Coral USB Accelerator](https://coral.withgoogle.com/products/accelerator/) must be accessible on the node where this pod runs, in order for this chart to function properly.~~
@@ -87,7 +87,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set rtspPassword="nosecrets" \
-    billimek/frigate
+    k8s-at-home/frigate
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -96,4 +96,4 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 helm install --name my-release -f values.yaml stable/frigate
 ```
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/frigate/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/frigate/values.yaml) file. It has several commented out suggested values.

--- a/charts/grocy/Chart.yaml
+++ b/charts/grocy/Chart.yaml
@@ -1,11 +1,11 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v2.6.1
 description: ERP beyond your fridge - grocy is a web-based self-hosted groceries & household management solution for your home
 name: grocy
-version: 1.0.2
+version: 2.0.0
 keywords:
   - grocy
-home: https://github.com/billimek/billimek-charts/tree/master/charts/grocy
+home: https://github.com/k8s-at-home/charts/tree/master/charts/grocy
 icon: https://github.com/grocy/grocy/raw/master/public/img/appicons/mstile-150x150.png
 sources:
   - https://github.com/grocy/grocy

--- a/charts/grocy/README.md
+++ b/charts/grocy/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [Grocy](https://grocy.info/) leveraging the [Linuxserve
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/grocy
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/grocy
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/grocy
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/grocy
+helm install --name my-release k8s-at-home/grocy
 ```
 
 ## Uninstalling the Chart
@@ -79,13 +79,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/grocy
+    k8s-at-home/grocy
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/grocy
+helm install --name my-release -f values.yaml k8s-at-home/grocy
 ```
 
 ---
@@ -95,4 +95,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/grocy/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/grocy/values.yaml) file. It has several commented out suggested values.

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -1,11 +1,11 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 2.2.2-ls84
 description: An Application dashboard and launcher
 name: heimdall
-version: 1.0.3
+version: 2.0.0
 keywords:
   - heimdall
-home: https://github.com/billimek/billimek-charts/tree/master/charts/heimdall
+home: https://github.com/k8s-at-home/charts/tree/master/charts/heimdall
 icon: https://i.imgur.com/mM4tcO5.png
 sources:
   - https://hub.docker.com/r/linuxserver/heimdall/

--- a/charts/heimdall/README.md
+++ b/charts/heimdall/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [heimdall](https://github.com/heimdall/heimdall) levera
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/heimdall
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/heimdall
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/heimdall
 To install the chart with the release name `my-release`:
 
 ```console
-helm install my-release billimek/heimdall
+helm install my-release k8s-at-home/heimdall
 ```
 
 ## Uninstalling the Chart
@@ -77,13 +77,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install my-release \
   --set timezone="America/New York" \
-    billimek/heimdall
+    k8s-at-home/heimdall
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install my-release -f values.yaml billimek/heimdall
+helm install my-release -f values.yaml k8s-at-home/heimdall
 ```
 
 ---
@@ -93,4 +93,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/heimdall/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/heimdall/values.yaml) file. It has several commented out suggested values.

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,18 +2,18 @@ apiVersion: v2
 appVersion: 0.114.0
 description: Home Assistant
 name: home-assistant
-version: 1.2.0
+version: 2.0.0
 keywords:
 - home-assistant
 - hass
 - homeassistant
-home: https://github.com/billimek/billimek-charts/tree/master/charts/home-assistant
+home: https://github.com/k8s-at-home/charts/tree/master/charts/home-assistant
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Home_Assistant_Logo.svg/519px-Home_Assistant_Logo.svg.png
 sources:
 - https://github.com/home-assistant/home-assistant
 - https://github.com/danielperna84/hass-configurator
 - https://github.com/cdr/code-server
-- https://github.com/billimek/billimek-charts/tree/master/charts/home-assistant
+- https://github.com/k8s-at-home/charts/tree/master/charts/home-assistant
 maintainers:
 - name: billimek
   email: jeff@billimek.com
@@ -21,7 +21,7 @@ maintainers:
   email: phil@hellmi.de
 dependencies:
 - name: esphome
-  repository: https://billimek.com/billimek-charts
+  repository: https://k8s-at-home.com/charts/
   version: ~1.0.0
   condition: esphome.enabled
 - name: postgresql

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [Home Assistant](https://www.home-assistant.io/)
 ## TL;DR;
 
 ```shell
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/home-assistant
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/home-assistant
 ```
 
 ## Introduction
@@ -18,7 +18,7 @@ This code is adapted for [the official home assistant docker image](https://hub.
 To install the chart with the release name `my-release`:
 
 ```shell
-helm install --name my-release billimek/home-assistant
+helm install --name my-release k8s-at-home/home-assistant
 ```
 
 ## Uninstalling the Chart
@@ -96,7 +96,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `extraEnv`                                      | Extra ENV vars to pass to the home-assistant container                                                                                                                                                                                    | `{}`                                |
 | `extraEnvSecrets`                               | Extra env vars to pass to the home-assistant container from k8s secrets - see `values.yaml` for an example                                                                                                                                | `{}`                                |
 | `configurator.enabled`                          | Enable the optional [configuration UI](https://github.com/danielperna84/hass-configurator)                                                                                                                                                | `false`                             |
-| `configurator.image.repository`                 | Image repository                                                                                                                                                                                                                          | `billimek/hass-configurator-docker` |
+| `configurator.image.repository`                 | Image repository                                                                                                                                                                                                                          | `k8s-at-home/hass-configurator-docker` |
 | `configurator.image.tag`                        | Image tag                                                                                                                                                                                                                                 | `0.3.5-x86_64`                      |
 | `configurator.image.pullPolicy`                 | Image pull policy                                                                                                                                                                                                                         | `IfNotPresent`                      |
 | `configurator.hassApiUrl`                       | Home Assistant API URL (e.g. 'http://home-assistant:8123/api/') - will auto-configure to proper URL if not set                                                                                                                            | ``                                  |
@@ -193,13 +193,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```shell
 helm install --name my-release \
   --set configurator.hassApiPassword="$HASS_API_PASSWORD" \
-    billimek/home-assistant
+    k8s-at-home/home-assistant
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```shell
-helm install --name my-release -f values.yaml billimek/home-assistant
+helm install --name my-release -f values.yaml k8s-at-home/home-assistant
 ```
 
 Read through the [values.yaml](values.yaml) file. It has several commented out suggested values.

--- a/charts/icantbelieveitsnotvaletudo/Chart.yaml
+++ b/charts/icantbelieveitsnotvaletudo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: 0.3.0
-version: 0.1.0
+version: 1.0.0
 name: icantbelieveitsnotvaletudo
 description: Create live map data from Valetudo powered robots
 type: application

--- a/charts/icantbelieveitsnotvaletudo/README.md
+++ b/charts/icantbelieveitsnotvaletudo/README.md
@@ -5,8 +5,8 @@ Map generation companion service for [Valetudo](valetudo.cloud)
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/icantbelieveitsnotvaletudo
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/icantbelieveitsnotvaletudo
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/icantbelieveitsnotvaletudo
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/icantbelieveitsnotvaletudo
+helm install --name my-release k8s-at-home/icantbelieveitsnotvaletudo
 ```
 
 ## Uninstalling the Chart
@@ -29,18 +29,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/icantbelieveitsnotvaletudo/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/icantbelieveitsnotvaletudo/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name my-release \
   --set config.mqtt.broker_url="mqtt://mymqttbroker" \
-    billimek/icantbelieveitsnotvaletudo
+    k8s-at-home/icantbelieveitsnotvaletudo
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/icantbelieveitsnotvaletudo
+helm install --name my-release -f values.yaml k8s-at-home/icantbelieveitsnotvaletudo
 ```

--- a/charts/jackett/Chart.yaml
+++ b/charts/jackett/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v0.13.446-ls55
 description: API Support for your favorite torrent trackers
 name: jackett
-version: 2.3.2
+version: 3.0.0
 keywords:
   - jackett
   - torrent
-home: https://github.com/billimek/billimek-charts/tree/master/charts/jackett
+home: https://github.com/k8s-at-home/charts/tree/master/charts/jackett
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/jackett-banner.png
 sources:
   - https://hub.docker.com/r/linuxserver/jackett/

--- a/charts/jackett/README.md
+++ b/charts/jackett/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [Jackett](https://github.com/Jackett/Jackett) leveragin
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/jackett
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/jackett
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/jackett
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/jackett
+helm install --name my-release k8s-at-home/jackett
 ```
 
 ## Uninstalling the Chart
@@ -86,13 +86,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/jackett
+    k8s-at-home/jackett
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/jackett
+helm install --name my-release -f values.yaml k8s-at-home/jackett
 ```
 
 ---
@@ -102,4 +102,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/jackett/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/jackett/values.yaml) file. It has several commented out suggested values.

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v10.5.3-ls45
 description: Jellyfin is a Free Software Media System
 name: jellyfin
-version: 1.0.3
+version: 2.0.0
 keywords:
   - Jellyfin
   - mediaplayer
-home: https://github.com/billimek/billimek-charts/tree/master/charts/Jellyfin
+home: https://github.com/k8s-at-home/charts/tree/master/charts/Jellyfin
 icon: https://github.com/jellyfin/jellyfin-ux/blob/master/branding/SVG/icon-solid-black.svg
 sources:
   - https://hub.docker.com/r/linuxserver/Jellyfin/

--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [Jellyfin](https://github.com/jellyfin/jellyfin) levera
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/jellyfin
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/jellyfin
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/jellyfin
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/jellyfin
+helm install --name my-release k8s-at-home/jellyfin
 ```
 
 ## Uninstalling the Chart
@@ -90,7 +90,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/jellyfin
+    k8s-at-home/jellyfin
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -106,4 +106,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/jellyfin/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/jellyfin/values.yaml) file. It has several commented out suggested values.

--- a/charts/lazylibrarian/Chart.yaml
+++ b/charts/lazylibrarian/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: lazylibrarian
 description: A Helm chart for deploying LazyLibrarian
-version: 1.0.0
+version: 2.0.0
 appVersion: 581cdfb3-ls23
 keywords:
   - lazylibrarian
   - ebooks
-home: https://github.com/billimek/charts/lazylibrarian
+home: https://github.com/k8s-at-home/charts/lazylibrarian
 icon: https://lazylibrarian.gitlab.io/logo.svg
 sources:
   - https://gitlab.com/LazyLibrarian/LazyLibrarian.git

--- a/charts/lazylibrarian/README.md
+++ b/charts/lazylibrarian/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [LazyLibrarian](https://gitlab.com/LazyLibrarian/LazyLi
 ## TL;DR
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/lazylibrarian
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/lazylibrarian
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/lazylibrarian
 To install the chart with the release name `my-release`:
 
 ```shell
-helm install my-release billimek/lazylibrarian
+helm install my-release k8s-at-home/lazylibrarian
 ```
 
 ## Uninstalling the Chart
@@ -87,15 +87,15 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install my-release \
   --set timezone="Europe/Amsterdam" \
-    billimek/lazylibrarian
+    k8s-at-home/lazylibrarian
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install my-release -f values.yaml billimek/lazylibrarian
+helm install my-release -f values.yaml k8s-at-home/lazylibrarian
 ```
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/charts/lazylibrarian/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/lazylibrarian/values.yaml) file. It has several commented out suggested values.

--- a/charts/librespeed/Chart.yaml
+++ b/charts/librespeed/Chart.yaml
@@ -1,16 +1,16 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 1.0.6-12
 description: Librespeed is a HTML5 webpage to test upload and download speeds
 name: librespeed
-version: 1.0.0
+version: 2.0.0
 keywords:
   - librespeed
-home: https://github.com/billimek/billimek-charts/tree/master/charts/librespeed
+home: https://github.com/k8s-at-home/charts/tree/master/charts/librespeed
 icon: https://github.com/librespeed/speedtest/blob/master/.logo/logo3.png?raw=true
 sources:
   - https://github.com/librespeed/speedtest
   - https://hub.docker.com/r/linuxserver/librespeed
-  - https://github.com/billimek/billimek-charts/tree/master/charts/librespeed
+  - https://github.com/k8s-at-home/charts/tree/master/charts/librespeed
 maintainers:
   - name: billimek
     email: jeff@billimek.com

--- a/charts/librespeed/README.md
+++ b/charts/librespeed/README.md
@@ -2,13 +2,13 @@
 
 HTML5 based speedtest with password protected history
 
-**This chart is not maintained by the Librespeed project and any issues with the chart should be raised [here](https://github.com/billimek/billimek-charts/issues/new)**
+**This chart is not maintained by the Librespeed project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new)**
 
 ## TL;DR;
 
 ```shell
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/librespeed
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/librespeed
 ```
 
 ## Introduction
@@ -20,7 +20,7 @@ This code is adopted from the [Linuxserver Librespeed docker image](https://hub.
 To install the chart with the release name `my-release`:
 
 ```shell
-helm install --name my-release billimek/librespeed
+helm install --name my-release k8s-at-home/librespeed
 ```
 ## Uninstalling the Chart
 
@@ -84,13 +84,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```shell
 helm install --name my-release \
   --set config.timezone="America/New_York" \
-    billimek/librespeed
+    k8s-at-home/librespeed
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```shell
-helm install --name my-release -f values.yaml billimek/librespeed
+helm install --name my-release -f values.yaml k8s-at-home/librespeed
 ```
 
 Read through the [values.yaml](values.yaml) file. It has several commented out suggested values.

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -1,13 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 0.7.1.1381-ls7
 description: Looks and smells like Sonarr but made for music.
 name: lidarr
-version: 2.0.2
+version: 3.0.0
 keywords:
   - lidarr
   - usenet
   - bittorrent
-home: https://github.com/billimek/billimek-charts/tree/master/charts/lidarr
+home: https://github.com/k8s-at-home/charts/tree/master/charts/lidarr
 icon: https://lidarr.audio/img/logo.png
 sources:
   - https://hub.docker.com/r/linuxserver/lidarr/

--- a/charts/lidarr/README.md
+++ b/charts/lidarr/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [lidarr](https://github.com/lidarr/Lidarr) leveraging t
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/lidarr
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/lidarr
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/lidarr
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/lidarr
+helm install --name my-release k8s-at-home/lidarr
 ```
 
 ## Upgrading
@@ -96,7 +96,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/lidarr
+    k8s-at-home/lidarr
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -112,4 +112,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/lidarr/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/lidarr/values.yaml) file. It has several commented out suggested values.

--- a/charts/modem-stats/Chart.yaml
+++ b/charts/modem-stats/Chart.yaml
@@ -1,16 +1,16 @@
-apiVersion: v1
+apiVersion: v2
 name: modem-stats
-version: 2.0.1
+version: 3.0.0
 appVersion: 1.0.0
 description: periodic cable modem data collection and save the results to InfluxDB
 keywords:
 - sb6183
 - influxdb
-home: https://github.com/billimek/billimek-charts/tree/master/charts/modem-stats
+home: https://github.com/k8s-at-home/charts/tree/master/charts/modem-stats
 icon: https://i.imgur.com/NprLyFf.png
 sources:
-- https://github.com/billimek/SB6183-stats-for-influxdb
-- https://github.com/billimek/billimek-charts
+- https://github.com/k8s-at-home/SB6183-stats-for-influxdb
+- https://github.com/k8s-at-home/charts
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/modem-stats/README.md
+++ b/charts/modem-stats/README.md
@@ -7,8 +7,8 @@ This tool allows you to run periodic scanning of the sb6183 cable modem and save
 ## TL;DR;
 
 ```console
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/modem-stats
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/modem-stats
 ```
 
 ## Installing the Chart
@@ -16,7 +16,7 @@ $ helm install billimek/modem-stats
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release billimek/modem-stats
+$ helm install --name my-release k8s-at-home/modem-stats
 ```
 ## Uninstalling the Chart
 
@@ -57,13 +57,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 $ helm install --name my-release \
   --set onfig.influxdb.host=some-influx-host \
-    billimek/modem-stats
+    k8s-at-home/modem-stats
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml billimek/modem-stats
+$ helm install --name my-release -f values.yaml k8s-at-home/modem-stats
 ```
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/modem-stats/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/modem-stats/values.yaml) file. It has several commented out suggested values.

--- a/charts/node-feature-discovery/Chart.yaml
+++ b/charts/node-feature-discovery/Chart.yaml
@@ -1,17 +1,17 @@
-apiVersion: v1
+apiVersion: v2
 name: node-feature-discovery
-version: 1.0.0
+version: 2.0.0
 appVersion: 0.6.0
 description: Detect hardware features available on each node in a Kubernetes cluster, and advertises those features using node labels
 keywords:
   - kubernetes
   - cluster
   - hardware
-home: https://github.com/billimek/billimek-charts/tree/master/charts/node-feature-discovery
+home: https://github.com/k8s-at-home/charts/tree/master/charts/node-feature-discovery
 icon: https://avatars1.githubusercontent.com/u/36015203?s=400&v=4
 sources:
   - https://github.com/kubernetes-sigs/node-feature-discovery
-  - https://github.com/billimek/billimek-charts
+  - https://github.com/k8s-at-home/charts
 maintainers:
   - name: billimek
     email: jeff@billimek.com

--- a/charts/node-feature-discovery/README.md
+++ b/charts/node-feature-discovery/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [node-feature-discovery](https://github.com/kubernetes-
 ## TL;DR
 
 ```shell
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/node-feature-discovery
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/node-feature-discovery
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ helm install billimek/node-feature-discovery
 To install the chart with the release name `my-release`:
 
 ```shell
-helm install my-release billimek/node-feature-discovery
+helm install my-release k8s-at-home/node-feature-discovery
 ```
 
 ## Uninstalling the Chart
@@ -30,7 +30,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Configuration
 
 The following tables lists the configurable parameters of the Sentry chart and their default values.
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/node-feature-discovery/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/node-feature-discovery/values.yaml) file. It has several commented out suggested values.
 
 | Parameter                                   | Description                                                                                  | Default                                               |
 | ------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
@@ -50,8 +50,8 @@ Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/
 | `master.replicaCount`                       | Number of replicas to scale the master component to                                          | `1`                                                   |
 | `master.resources`                          | CPU/Memory resource requests/limits for master component                                     | `{}`                                                  |
 | `master.nodeSelector`                       | Node labels for master component pod assignment                                              | `{}`                                                  |
-| `master.tolerations`                        | Toleration labels for master component pod assignment                                        | See [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/node-feature-discovery/values.yaml)                                                  |
-| `master.affinity`                           | Affinity settings for master component pod assignment                                        | See [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/node-feature-discovery/values.yaml)                                                  |
+| `master.tolerations`                        | Toleration labels for master component pod assignment                                        | See [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/node-feature-discovery/values.yaml)                                                  |
+| `master.affinity`                           | Affinity settings for master component pod assignment                                        | See [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/node-feature-discovery/values.yaml)                                                  |
 | `worker.resources`                          | CPU/Memory resource requests/limits for worker component                                     | `{}`                                                  |
 | `worker.nodeSelector`                       | Node labels for worker component pod assignment                                              | `{}`                                                  |
 | `worker.tolerations`                        | Toleration labels for worker component pod assignment                                        | `[]`                                                  |
@@ -62,11 +62,11 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install my-release \
   --set image.pullPolicy="Always" \
-    billimek/node-feature-discovery
+    k8s-at-home/node-feature-discovery
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install my-release -f values.yaml billimek/node-feature-discovery
+helm install my-release -f values.yaml k8s-at-home/node-feature-discovery
 ```

--- a/charts/node-red/Chart.yaml
+++ b/charts/node-red/Chart.yaml
@@ -1,16 +1,16 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 1.0.6-12
 description: Node-RED is low-code programming for event-driven applications
 name: node-red
-version: 2.0.2
+version: 3.0.0
 keywords:
   - nodered
   - node-red
-home: https://github.com/billimek/billimek-charts/tree/master/charts/node-red
+home: https://github.com/k8s-at-home/charts/tree/master/charts/node-red
 icon: https://nodered.org/about/resources/media/node-red-icon-2.png
 sources:
   - https://github.com/node-red/node-red-docker
-  - https://github.com/billimek/billimek-charts/tree/master/charts/node-red
+  - https://github.com/k8s-at-home/charts/tree/master/charts/node-red
 maintainers:
   - name: billimek
     email: jeff@billimek.com

--- a/charts/node-red/README.md
+++ b/charts/node-red/README.md
@@ -2,13 +2,13 @@
 
 Low-code programming for event-driven applications
 
-**This chart is not maintained by the Node-RED project and any issues with the chart should be raised [here](https://github.com/billimek/billimek-charts/issues/new)**
+**This chart is not maintained by the Node-RED project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new)**
 
 ## TL;DR;
 
 ```shell
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/node-red
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/node-red
 ```
 
 ## Introduction
@@ -20,7 +20,7 @@ This code is adopted from the [official node-red docker image](https://hub.docke
 To install the chart with the release name `my-release`:
 
 ```shell
-helm install --name my-release billimek/node-red
+helm install --name my-release k8s-at-home/node-red
 ```
 ## Uninstalling the Chart
 
@@ -81,13 +81,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```shell
 helm install --name my-release \
   --set config.timezone="America/New_York" \
-    billimek/node-red
+    k8s-at-home/node-red
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```shell
-helm install --name my-release -f values.yaml billimek/node-red
+helm install --name my-release -f values.yaml k8s-at-home/node-red
 ```
 
 Read through the [values.yaml](values.yaml) file. It has several commented out suggested values.

--- a/charts/nzbget/Chart.yaml
+++ b/charts/nzbget/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v21.0-ls14
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 3.3.2
+version: 4.0.0
 keywords:
   - nzbget
   - usenet
-home: https://github.com/billimek/billimek-charts/tree/master/charts/nzbget
+home: https://github.com/k8s-at-home/charts/tree/master/charts/nzbget
 icon: https://avatars1.githubusercontent.com/u/3368377?s=400&v=4
 sources:
   - https://hub.docker.com/r/linuxserver/nzbget/

--- a/charts/nzbget/README.md
+++ b/charts/nzbget/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [NZBGet](https://nzbget.net/) leveraging the [Linuxserv
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/nzbget
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/nzbget
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/nzbget
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/nzbget
+helm install --name my-release k8s-at-home/nzbget
 ```
 
 The default login details (change ASAP) are:
@@ -88,7 +88,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/nzbget
+    k8s-at-home/nzbget
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -104,4 +104,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/nzbget/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/nzbget/values.yaml) file. It has several commented out suggested values.

--- a/charts/nzbhydra2/Chart.yaml
+++ b/charts/nzbhydra2/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v2.22.2-ls9
 description: Usenet meta search
 name: nzbhydra2
-version: 2.3.2
+version: 3.0.0
 keywords:
   - nzbhydra2
   - usenet
-home: https://github.com/billimek/billimek-charts/tree/master/charts/nzbhydra2
+home: https://github.com/k8s-at-home/charts/tree/master/charts/nzbhydra2
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/hydra-icon.png
 sources:
   - https://hub.docker.com/r/linuxserver/nzbhydra2/

--- a/charts/nzbhydra2/README.md
+++ b/charts/nzbhydra2/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [nzbhydra2](https://github.com/theotherp/nzbhydra2) lev
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/nzbhydra2
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/nzbhydra2
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/nzbhydra2
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/nzbhydra2
+helm install --name my-release k8s-at-home/nzbhydra2
 ```
 
 ## Uninstalling the Chart
@@ -78,13 +78,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/nzbhydra2
+    k8s-at-home/nzbhydra2
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/nzbhydra2
+helm install --name my-release -f values.yaml k8s-at-home/nzbhydra2
 ```
 
 ---
@@ -94,4 +94,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/nzbhydra2/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/nzbhydra2/values.yaml) file. It has several commented out suggested values.

--- a/charts/ombi/Chart.yaml
+++ b/charts/ombi/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v3.0.4892-ls61
 description: Want a Movie or TV Show on Plex or Emby? Use Ombi!
 name: ombi
-version: 2.2.3
+version: 3.0.0
 keywords:
   - ombi
   - plex
-home: https://github.com/billimek/billimek-charts/tree/master/charts/ombi
+home: https://github.com/k8s-at-home/charts/tree/master/charts/ombi
 icon: https://ombi.io/img/logo-orange-small.png
 sources:
   - https://hub.docker.com/r/linuxserver/ombi/

--- a/charts/ombi/README.md
+++ b/charts/ombi/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [Ombi](https://ombi.io/) leveraging the [Linuxserver.io
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/ombi
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/ombi
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/ombi
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/ombi
+helm install --name my-release k8s-at-home/ombi
 ```
 
 ## Uninstalling the Chart
@@ -78,13 +78,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/ombi
+    k8s-at-home/ombi
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/ombi
+helm install --name my-release -f values.yaml k8s-at-home/ombi
 ```
 
 ---
@@ -94,4 +94,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/ombi/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/ombi/values.yaml) file. It has several commented out suggested values.

--- a/charts/piaware/Chart.yaml
+++ b/charts/piaware/Chart.yaml
@@ -1,13 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "3.8.1"
 description: Program for forwarding ADS-B data to FlightAware
 name: piaware
-version: 1.0.0
+version: 2.0.0
 keywords:
   - piaware
   - flight-aware
   - flight-tracker
-home: https://github.com/billimek/billimek-charts/tree/master/charts/piaware
+home: https://github.com/k8s-at-home/charts/tree/master/charts/piaware
 icon: https://pbs.twimg.com/profile_images/964269455483088897/mr2UgvfG_400x400.jpg
 sources:
   - https://github.com/flightaware/piaware

--- a/charts/piaware/README.md
+++ b/charts/piaware/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [piaware](https://github.com/flightaware/piaware)
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/piaware
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/piaware
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/piaware
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/piaware
+helm install --name my-release k8s-at-home/piaware
 ```
 
 **IMPORTANT NOTE:** a flight-aware USB device must be accessible on the node where this pod runs, in order for this chart to function properly.
@@ -47,14 +47,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/piaware/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/piaware/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name my-release \
   --set rtspPassword="nosecrets" \
-    billimek/piaware
+    k8s-at-home/piaware
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -1,14 +1,14 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 1.19.5.3112-b23ab3896
 description: Plex Media Server
 name: plex
-version: 1.8.3
+version: 2.0.0
 keywords:
   - plex
 home: https://plex.tv/
 icon: https://www.plex.tv/wp-content/uploads/2018/01/pmp-icon-1.png
 sources:
-  - https://github.com/billimek/billimek-charts/tree/master/charts/plex
+  - https://github.com/k8s-at-home/charts/tree/master/charts/plex
   - https://hub.docker.com/r/plexinc/pms-docker/
 maintainers:
   - name: billimek

--- a/charts/plex/README.md
+++ b/charts/plex/README.md
@@ -7,8 +7,8 @@ This chart is 'forked' from the excellent [munnerz/kube-plex](https://github.com
 ## TL;DR
 
 ```shell
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/plex
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/plex
 ```
 
 ## Installing the Chart
@@ -16,7 +16,7 @@ helm install billimek/plex
 To install the chart with the release name `plex`:
 
 ```console
-helm install plex billimek/plex
+helm install plex k8s-at-home/plex
 ```
 
 ## Uninstalling the Chart
@@ -31,18 +31,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/plex/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/plex/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install plex \
   --set timezone="America/New York" \
-    billimek/plex
+    k8s-at-home/plex
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install plex -f values.yaml billimek/plex
+helm install plex -f values.yaml k8s-at-home/plex
 ```

--- a/charts/powerdns/Chart.yaml
+++ b/charts/powerdns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: PowerDNS is a DNS server, written in C++ and licensed under the GPL. It runs on most Unix derivatives. PowerDNS features a large number of different backends ranging from simple BIND style zonefiles to relational databases and load balancing/failover algorithms. A DNS recursor is provided as a separate program.
 name: powerdns
-version: 1.0.1
+version: 2.0.0
 home: https://www.powerdns.com/
 sources:
   - http://www.github.com/PowerDNS/

--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 14.2.0.99201912180418-6819-118af03ubuntu18.04.1-ls62
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 name: qbittorrent
-version: 3.2.2
+version: 4.0.0
 keywords:
   - qbittorrent
   - torrrent
-home: https://github.com/billimek/billimek-charts/tree/master/charts/qbittorrent
+home: https://github.com/k8s-at-home/charts/tree/master/charts/qbittorrent
 icon: https://cloud.githubusercontent.com/assets/14862437/23586868/89ef2922-01c4-11e7-869c-52aafcece17f.png
 sources:
   - https://hub.docker.com/r/linuxserver/qbittorrent/

--- a/charts/qbittorrent/README.md
+++ b/charts/qbittorrent/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [qbittorrent](https://qbittorrent.org/) leveraging the 
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/qbittorrent
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/qbittorrent
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/qbittorrent
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/qbittorrent
+helm install --name my-release k8s-at-home/qbittorrent
 ```
 
 The default login details (change ASAP) are:
@@ -95,13 +95,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/qbittorrent
+    k8s-at-home/qbittorrent
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/qbittorrent
+helm install --name my-release -f values.yaml k8s-at-home/qbittorrent
 ```
 
 ---
@@ -111,4 +111,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/qbittorrent/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/qbittorrent/values.yaml) file. It has several commented out suggested values.

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -1,13 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v0.2.0.1480-ls58
 description: Radarr is a movie downloading client
 name: radarr
-version: 4.1.3
+version: 5.0.0
 keywords:
   - radarr
   - usenet
   - bittorrent
-home: https://github.com/billimek/billimek-charts/tree/master/charts/radarr
+home: https://github.com/k8s-at-home/charts/tree/master/charts/radarr
 icon: https://avatars3.githubusercontent.com/u/25025331?s=400&v=4
 sources:
   - https://hub.docker.com/r/linuxserver/radarr/

--- a/charts/radarr/README.md
+++ b/charts/radarr/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [radarr](https://github.com/Radarr/Radarr/) leveraging 
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/radarr
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/radarr
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/radarr
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/radarr
+helm install --name my-release k8s-at-home/radarr
 ```
 
 ## Upgrading
@@ -111,7 +111,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/radarr
+    k8s-at-home/radarr
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -128,4 +128,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/radarr/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/radarr/values.yaml) file. It has several commented out suggested values.

--- a/charts/rtorrent-flood/Chart.yaml
+++ b/charts/rtorrent-flood/Chart.yaml
@@ -1,13 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 1.0.0
 description: rtorrent and flood co-located in the same deployment
 name: rtorrent-flood
-version: 4.1.1
+version: 5.0.0
 keywords:
   - rtorrent
   - flood
   - torrrent
-home: https://github.com/billimek/billimek-charts/tree/master/charts/rtorrent-flood
+home: https://github.com/k8s-at-home/charts/tree/master/charts/rtorrent-flood
 icon: https://github.com/jfurrow/flood/blob/master/flood.png?raw=true
 sources:
   - https://hub.docker.com/r/looselyrigorous/rtorrent

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 2.3.9
 description: Free and easy binary newsreader
 name: sabnzbd
-version: 1.0.2
+version: 2.0.0
 keywords:
   - sabnzbd
   - usenet
-home: https://github.com/billimek/billimek-charts/tree/master/charts/sabnzbd
+home: https://github.com/k8s-at-home/charts/tree/master/charts/sabnzbd
 icon: https://avatars1.githubusercontent.com/u/960698?s=400&v=4
 sources:
   - https://hub.docker.com/r/linuxserver/sabnzbd/

--- a/charts/sabnzbd/README.md
+++ b/charts/sabnzbd/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [SABnzbd](https://sabnzbd.org/) leveraging the [Linuxse
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/sabnzbd
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/sabnzbd
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/sabnzbd
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/sabnzbd
+helm install --name my-release k8s-at-home/sabnzbd
 ```
 
 ## Uninstalling the Chart
@@ -83,7 +83,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/sabnzbd
+    k8s-at-home/sabnzbd
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -99,4 +99,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/sabnzbd/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/sabnzbd/values.yaml) file. It has several commented out suggested values.

--- a/charts/ser2sock/Chart.yaml
+++ b/charts/ser2sock/Chart.yaml
@@ -1,11 +1,11 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: Serial to Socket Redirector
 name: ser2sock
-version: 1.1.0
+version: 2.0.0
 keywords:
   - ser2sock
-home: https://github.com/billimek/billimek-charts/tree/master/charts/ser2sock
+home: https://github.com/k8s-at-home/charts/tree/master/charts/ser2sock
 icon: https://i.imgur.com/GfZ7McO.png
 sources:
   - https://github.com/nutechsoftware/ser2sock

--- a/charts/ser2sock/README.md
+++ b/charts/ser2sock/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [ser2sock](https://github.com/nutechsoftware/ser2sock)
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/ser2sock
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/ser2sock
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/ser2sock
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/ser2sock
+helm install --name my-release k8s-at-home/ser2sock
 ```
 
 **IMPORTANT NOTE:** the USB device must be accessible on the node where this pod runs, in order for this chart to function properly.
@@ -74,13 +74,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 helm install --name my-release \
-    billimek/ser2sock
+    k8s-at-home/ser2sock
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/ser2sock
+helm install --name my-release -f values.yaml k8s-at-home/ser2sock
 ```
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/ser2sock/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/ser2sock/values.yaml) file. It has several commented out suggested values.

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -1,13 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 2.0.0.5344-ls60
 description: Sonarr is a television show downloading client
 name: sonarr
-version: 4.1.3
+version: 5.0.0
 keywords:
   - sonarr
   - usenet
   - bittorrent
-home: https://github.com/billimek/billimek-charts/tree/master/charts/sonarr
+home: https://github.com/k8s-at-home/charts/tree/master/charts/sonarr
 icon: https://avatars1.githubusercontent.com/u/1082903?s=400&v=4
 sources:
   - https://hub.docker.com/r/linuxserver/sonarr/

--- a/charts/sonarr/README.md
+++ b/charts/sonarr/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [sonarr](https://github.com/sonarr/sonarr/) leveraging 
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/sonarr
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/sonarr
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/sonarr
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/sonarr
+helm install --name my-release k8s-at-home/sonarr
 ```
 
 ## Upgrading
@@ -112,7 +112,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/sonarr
+    k8s-at-home/sonarr
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -129,4 +129,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/sonarr/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/sonarr/values.yaml) file. It has several commented out suggested values.

--- a/charts/speedtest-prometheus/Chart.yaml
+++ b/charts/speedtest-prometheus/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: speedtest-prometheus
 description: Prometheus Exporter for the official Speedtest CLI
 type: application
-version: 1.0.1
+version: 2.0.0
 appVersion: 1.1.0
 keywords:
 - speedtest
 - influxdb
 - grafana
-home: https://github.com/billimek/billimek-charts/tree/master/charts/speedtest-prometheus
+home: https://github.com/k8s-at-home/charts/tree/master/charts/speedtest-prometheus
 icon: https://cdn.speedcheck.org/images/reviews/ookla-logo.png
 sources:
 - https://github.com/billimek/prometheus-speedtest-exporter

--- a/charts/speedtest-prometheus/README.md
+++ b/charts/speedtest-prometheus/README.md
@@ -7,8 +7,8 @@ This is a helm chart provising a prometheus exporter (with optional ServiceMonto
 ## TL;DR;
 
 ```console
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/speedtest-prometheus
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/speedtest-prometheus
 ```
 
 ## Installing the Chart
@@ -16,7 +16,7 @@ helm install billimek/speedtest-prometheus
 To install the chart with the release name `speedtest-prometheus`:
 
 ```console
-helm install --name speedtest-prometheus billimek/speedtest-prometheus
+helm install --name speedtest-prometheus k8s-at-home/speedtest-prometheus
 ```
 
 ## Uninstalling the Chart
@@ -31,20 +31,20 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/speedtest-prometheus/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/speedtest-prometheus/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name speedtest-prometheus \
    --set serviceMonitor.enabled=true \
-    billimek/speedtest-prometheus
+    k8s-at-home/speedtest-prometheus
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name speedtest-prometheus -f values.yaml billimek/speedtest-prometheus
+helm install --name speedtest-prometheus -f values.yaml k8s-at-home/speedtest-prometheus
 ```
 
 ## Grafana Dashboard

--- a/charts/speedtest/Chart.yaml
+++ b/charts/speedtest/Chart.yaml
@@ -1,17 +1,17 @@
-apiVersion: v1
+apiVersion: v2
 name: speedtest
-version: 2.0.1
+version: 3.0.0
 appVersion: 1.0.0
 description: periodic speedtest and save the results to InfluxDB
 keywords:
 - speedtest
 - influxdb
 - grafana
-home: https://github.com/billimek/billimek-charts/tree/master/charts/speedtest
+home: https://github.com/k8s-at-home/charts/tree/master/charts/speedtest
 icon: https://i.imgur.com/nDYjKk8.png
 sources:
-- https://github.com/billimek/Speedtest-for-InfluxDB-and-Grafana
-- https://github.com/billimek/billimek-charts
+- https://github.com/k8s-at-home/Speedtest-for-InfluxDB-and-Grafana
+- https://github.com/k8s-at-home/charts
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/speedtest/README.md
+++ b/charts/speedtest/README.md
@@ -7,8 +7,8 @@ This tool is a wrapper for speedtest-cli which allows you to run periodic speedt
 ## TL;DR;
 
 ```console
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/speedtest
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/speedtest
 ```
 
 ## Installing the Chart
@@ -16,7 +16,7 @@ $ helm install billimek/speedtest
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release billimek/speedtest
+$ helm install --name my-release k8s-at-home/speedtest
 ```
 
 ## Uninstalling the Chart
@@ -39,7 +39,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 
 | Parameter                            | Description                                | Default                                                    |
 | -------------------------------      | -------------------------------            | ---------------------------------------------------------- |
-| `image.repository`                   | speedtest image                                | `billimek/speedtestusage-for-influxdb`                     |
+| `image.repository`                   | speedtest image                                | `k8s-at-home/speedtestusage-for-influxdb`                     |
 | `image.tag`                          | speedtest image tag                            | `latest`                                                 |
 | `image.pullPolicy`                   | speedtest image pull policy                    | `IfNotPresent`                                           |
 | `debug`                              | Display debugging output                     | `false`                                                  |
@@ -59,14 +59,14 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 $ helm install --name my-release \
   --set config.influxdb.host=some-influx-host \
-    billimek/speedtest
+    k8s-at-home/speedtest
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml billimek/speedtest
+$ helm install --name my-release -f values.yaml k8s-at-home/speedtest
 ```
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/speedtest/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/speedtest/values.yaml) file. It has several commented out suggested values.
 

--- a/charts/tautulli/Chart.yaml
+++ b/charts/tautulli/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: v2.1.44-ls34
 description: A Python based monitoring and tracking tool for Plex Media Server.
 name: tautulli
-version: 2.3.2
+version: 3.0.0
 keywords:
   - tautulli
   - plex
-home: https://github.com/billimek/billimek-charts/tree/master/charts/tautulli
+home: https://github.com/k8s-at-home/charts/tree/master/charts/tautulli
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/tautulli-icon.png
 sources:
   - https://hub.docker.com/r/linuxserver/tautulli/

--- a/charts/tautulli/README.md
+++ b/charts/tautulli/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [Tautulli](https://tautulli.com/) leveraging the [Linux
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/tautulli
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/tautulli
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/tautulli
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/tautulli
+helm install --name my-release k8s-at-home/tautulli
 ```
 
 ## Uninstalling the Chart
@@ -77,13 +77,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install --name my-release \
   --set timezone="America/New York" \
-    billimek/tautulli
+    k8s-at-home/tautulli
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/tautulli
+helm install --name my-release -f values.yaml k8s-at-home/tautulli
 ```
 
 ---
@@ -93,4 +93,4 @@ If you get `Error: rendered manifests contain a resource that already exists. Un
 
 ---
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/tautulli/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/tautulli/values.yaml) file. It has several commented out suggested values.

--- a/charts/teslamate/Chart.yaml
+++ b/charts/teslamate/Chart.yaml
@@ -10,6 +10,11 @@ home: https://github.com/k8s-at-home/charts/tree/master/charts/teslamate
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Tesla_Motors.svg/793px-Tesla_Motors.svg.png
 sources:
   - https://github.com/adriankumpf/teslamate
+dependencies:
+- name: postgresql
+  version: 8.1.0
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: postgresql.enabled
 maintainers:
   - name: billimek
     email: jeff@billimek.com

--- a/charts/teslamate/Chart.yaml
+++ b/charts/teslamate/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "v1.19.3"
 description: A self-hosted data logger for your Tesla 🚘
 name: teslamate
-version: 2.0.4
+version: 3.0.0
 keywords:
   - teslamate
   - tesla
-home: https://github.com/billimek/billimek-charts/tree/master/charts/teslamate
+home: https://github.com/k8s-at-home/charts/tree/master/charts/teslamate
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Tesla_Motors.svg/793px-Tesla_Motors.svg.png
 sources:
   - https://github.com/adriankumpf/teslamate

--- a/charts/teslamate/README.md
+++ b/charts/teslamate/README.md
@@ -7,8 +7,8 @@ The default values and container images used in this chart will allow for runnin
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/teslamate
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/teslamate
 ```
 
 ## Installing the Chart
@@ -16,7 +16,7 @@ $ helm install billimek/teslamate
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name teslamate billimek/teslamate
+helm install --name teslamate k8s-at-home/teslamate
 ```
 
 ## Uninstalling the Chart
@@ -31,14 +31,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/teslamate/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/teslamate/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name teslamate \
   --set timeZone="America/New York" \
-    billimek/teslamate
+    k8s-at-home/teslamate
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/charts/teslamate/requirements.lock
+++ b/charts/teslamate/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.1.0
-digest: sha256:45a6e2b72556d60b954a11ef8de75a48678c6117c2e78a33619b277c3d893fd0
-generated: 2019-12-22T03:34:50.317972Z

--- a/charts/teslamate/requirements.yaml
+++ b/charts/teslamate/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-- name: postgresql
-  version: 8.1.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  condition: postgresql.enabled

--- a/charts/unifi-poller/Chart.yaml
+++ b/charts/unifi-poller/Chart.yaml
@@ -1,12 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "2.0.1"
 description: Collect ALL UniFi Controller, Site, Device & Client Data - Export to InfluxDB or Prometheus
 name: unifi-poller
-version: 1.0.1
+version: 2.0.0
 keywords:
   - unifi
   - unifi-poller
-home: https://github.com/billimek/billimek-charts/tree/master/charts/unifi-poller
+home: https://github.com/k8s-at-home/charts/tree/master/charts/unifi-poller
 icon: https://raw.githubusercontent.com/wiki/unifi-poller/unifi-poller/images/unifi-poller-logo.png
 sources:
   - https://github.com/unifi-poller/unifi-poller

--- a/charts/unifi-poller/README.md
+++ b/charts/unifi-poller/README.md
@@ -9,8 +9,8 @@ The default values and container images used in this chart will allow for runnin
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/unifi-poller
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/unifi-poller
 ```
 
 ## Installing the Chart
@@ -18,7 +18,7 @@ $ helm install billimek/unifi-poller
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name unifi-poller billimek/unifi-poller
+helm install --name unifi-poller k8s-at-home/unifi-poller
 ```
 
 ## Uninstalling the Chart
@@ -33,13 +33,13 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/unifi-poller/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/unifi-poller/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name unifi-poller \
-    billimek/unifi-poller
+    k8s-at-home/unifi-poller
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/charts/uptimerobot-prometheus/Chart.yaml
+++ b/charts/uptimerobot-prometheus/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: uptimerobot-prometheus
 description: Prometheus Exporter for the official uptimerobot CLI
 type: application
-version: 1.0.0
+version: 2.0.0
 appVersion: 0.0.1
 keywords:
 - uptimerobot
 - prometheus
 - grafana
-home: https://github.com/billimek/billimek-charts/tree/master/charts/uptimerobot-prometheus
+home: https://github.com/k8s-at-home/charts/tree/master/charts/uptimerobot-prometheus
 icon: https://cdn.foliovision.com/images/2019/03/icon-uptimerobot-1024.png
 sources:
 - https://github.com/lekpamartin/uptimerobot_exporter
-- https://github.com/billimek/billimek-charts/tree/master/charts/uptimerobot-prometheus
+- https://github.com/k8s-at-home/charts/tree/master/charts/uptimerobot-prometheus
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/uptimerobot-prometheus/README.md
+++ b/charts/uptimerobot-prometheus/README.md
@@ -7,8 +7,8 @@ This is a helm chart providing a prometheus exporter to query the uptimerobot AP
 ## TL;DR;
 
 ```console
-helm repo add billimek https://billimek.com/billimek-charts/
-helm install billimek/uptimerobot-prometheus
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/uptimerobot-prometheus
 ```
 
 ## Installing the Chart
@@ -16,7 +16,7 @@ helm install billimek/uptimerobot-prometheus
 To install the chart with the release name `uptimerobot-prometheus`:
 
 ```console
-helm install --name uptimerobot-prometheus billimek/uptimerobot-prometheus
+helm install --name uptimerobot-prometheus k8s-at-home/uptimerobot-prometheus
 ```
 
 ## Uninstalling the Chart
@@ -31,20 +31,20 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/uptimerobot-prometheus/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/uptimerobot-prometheus/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name uptimerobot-prometheus \
    --set serviceMonitor.enabled=true \
-    billimek/uptimerobot-prometheus
+    k8s-at-home/uptimerobot-prometheus
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name uptimerobot-prometheus -f values.yaml billimek/uptimerobot-prometheus
+helm install --name uptimerobot-prometheus -f values.yaml k8s-at-home/uptimerobot-prometheus
 ```
 
 ## Grafana Dashboard

--- a/charts/uptimerobot/Chart.yaml
+++ b/charts/uptimerobot/Chart.yaml
@@ -1,17 +1,17 @@
-apiVersion: v1
+apiVersion: v2
 name: uptimerobot
-version: 2.0.1
+version: 3.0.0
 appVersion: 1.1.0
 description: A tool to get statistics from Uptime Robot and log it into InfluxDB
 keywords:
 - uptimerobot
 - influxdb
 - grafana
-home: https://github.com/billimek/billimek-charts/tree/master/charts/uptimerobot
+home: https://github.com/k8s-at-home/charts/tree/master/charts/uptimerobot
 icon: https://i.imgur.com/ARSSILk.png
 sources:
 - https://github.com/trojanc/node-influx-uptimerobot
-- https://github.com/billimek/billimek-charts
+- https://github.com/k8s-at-home/charts
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/uptimerobot/README.md
+++ b/charts/uptimerobot/README.md
@@ -7,8 +7,8 @@ This tool allows you to run periodic uptimerobot data usage checks and save the 
 ## TL;DR;
 
 ```console
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/uptimerobot
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/uptimerobot
 ```
 
 ## Introduction
@@ -20,7 +20,7 @@ This code is adopted from [this original repo](https://github.com/trojanc/node-i
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release billimek/uptimerobot
+$ helm install --name my-release k8s-at-home/uptimerobot
 ```
 ## Uninstalling the Chart
 
@@ -61,13 +61,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 $ helm install --name my-release \
   --set config.uptimerobot.apikey=thisismyapikey \
-    billimek/uptimerobot
+    k8s-at-home/uptimerobot
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml billimek/uptimerobot
+$ helm install --name my-release -f values.yaml k8s-at-home/uptimerobot
 ```
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/uptimerobot/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/uptimerobot/values.yaml) file. It has several commented out suggested values.

--- a/charts/xteve/Chart.yaml
+++ b/charts/xteve/Chart.yaml
@@ -1,14 +1,14 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "2.1.2"
 description: M3U Proxy for Plex DVR and Emby Live TV.
 name: xteve
-version: 1.0.0
+version: 2.0.0
 keywords:
   - xteve
   - iptv
   - plex
   - emby
-home: https://github.com/billimek/billimek-charts/tree/master/charts/xteve
+home: https://github.com/k8s-at-home/charts/tree/master/charts/xteve
 icon: https://raw.githubusercontent.com/xteve-project/xTeVe/master/html/img/logo_b_880x200.jpg
 sources:
   - https://xteve.de

--- a/charts/xteve/README.md
+++ b/charts/xteve/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [xTeVe](https://github.com/xteve-project/xTeVe)
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/xteve
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/xteve
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/xteve
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/xteve
+helm install --name my-release k8s-at-home/xteve
 ```
 
 ## Uninstalling the Chart
@@ -29,14 +29,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/xteve/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/xteve/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name my-release \
   --set timezone="America/New_York" \
-    billimek/xteve
+    k8s-at-home/xteve
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/charts/zigbee2mqtt/Chart.yaml
+++ b/charts/zigbee2mqtt/Chart.yaml
@@ -3,7 +3,7 @@ name: zigbee2mqtt
 type: application
 description: Bridges events and allows you to control your Zigbee devices via MQTT
 appVersion: 1.14.1
-version: 0.2.0
+version: 1.0.0
 keywords:
   - zigbee
   - mqtt

--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [zigbee2mqtt](https://www.zigbee2mqtt.io)
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/zigbee2mqtt
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/zigbee2mqtt
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/zigbee2mqtt
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/zigbee2mqtt
+helm install --name my-release k8s-at-home/zigbee2mqtt
 ```
 
 **IMPORTANT NOTE:** a [supported Zigbee sniffer](https://www.zigbee2mqtt.io/getting_started/what_do_i_need.html) must be accessible on the node where this pod runs, in order for this chart to function properly.
@@ -49,18 +49,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/zigbee2mqtt/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/zigbee2mqtt/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name my-release \
   --set config.mqtt.server="mqtt://mymqttbroker" \
-    billimek/zigbee2mqtt
+    k8s-at-home/zigbee2mqtt
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-helm install --name my-release -f values.yaml billimek/zigbee2mqtt
+helm install --name my-release -f values.yaml k8s-at-home/zigbee2mqtt
 ```

--- a/charts/zwave2mqtt/Chart.yaml
+++ b/charts/zwave2mqtt/Chart.yaml
@@ -1,13 +1,13 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "3.0.0"
 description: Fully configurable Zwave to MQTT gateway and Control Panel using NodeJS and Vue
 name: zwave2mqtt
-version: 2.1.0
+version: 3.0.0
 keywords:
   - zwave
   - mqtt
   - home-assistant
-home: https://github.com/billimek/billimek-charts/tree/master/charts/zwave2mqtt
+home: https://github.com/k8s-at-home/charts/tree/master/charts/zwave2mqtt
 icon: https://github.com/OpenZWave/Zwave2Mqtt/raw/master/docs/OZW_Logo.png
 sources:
   - https://github.com/OpenZWave/Zwave2Mqtt

--- a/charts/zwave2mqtt/README.md
+++ b/charts/zwave2mqtt/README.md
@@ -5,8 +5,8 @@ This is a helm chart for [zwave2mqtt](https://github.com/OpenZWave/Zwave2Mqtt)
 ## TL;DR;
 
 ```shell
-$ helm repo add billimek https://billimek.com/billimek-charts/
-$ helm install billimek/zwave2mqtt
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/zwave2mqtt
 ```
 
 ## Installing the Chart
@@ -14,7 +14,7 @@ $ helm install billimek/zwave2mqtt
 To install the chart with the release name `my-release`:
 
 ```console
-helm install --name my-release billimek/zwave2mqtt
+helm install --name my-release k8s-at-home/zwave2mqtt
 ```
 
 **IMPORTANT NOTE:** a zwave controller device must be accessible on the node where this pod runs, in order for this chart to function properly.
@@ -47,14 +47,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Read through the [values.yaml](https://github.com/billimek/billimek-charts/blob/master/charts/zwave2mqtt/values.yaml) file. It has several commented out suggested values.
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/zwave2mqtt/values.yaml) file. It has several commented out suggested values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 helm install --name my-release \
   --set rtspPassword="nosecrets" \
-    billimek/zwave2mqtt
+    k8s-at-home/zwave2mqtt
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/unifi/README.md
+++ b/unifi/README.md
@@ -1,1 +1,0 @@
-The Unifi chart is now an official helm chart: https://github.com/helm/charts/tree/master/stable/unifi


### PR DESCRIPTION
* update all Chart.yaml files to replace references from old repo to new
repo
* update all Chart.yaml files to set apiVersion to v2 where necessary
* update all README.md files to replace references from old repo to new
repo
* bumped the version of all charts to the next major version in order to sort the new home ahead of the old repo, when searching

#### Special notes for your reviewer:

This will most likely break CI tests as it will be trying to do deployment testing of all charts in one go.
