### PR TITLE
[plex] Fix values reference for "customCertificateDomain"

### DIFF
--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.20.1.3252
 description: Plex Media Server
 name: plex
-version: 2.0.1
+version: 2.0.2
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -188,7 +188,7 @@ spec:
                 name: {{ .Values.certificate.pkcsMangler.pfxPassword.secretName }}
                 key: {{ .Values.certificate.pkcsMangler.pfxPassword.passwordKey }}
           - name: "PKCSMANGLER_CUSTOMCERTDOMAIN"
-            value: "customCertificateDomain={{.Values.certificate.pkcsMangler.plexPreferences.customCertificateDomain}}"
+            value: "customCertificateDomain={{.Values.certificate.pkcsMangler.setPlexPreferences.customCertificateDomain}}"
 {{- end }}
 {{- end }}
           readinessProbe:


### PR DESCRIPTION
The deployment template references `.Values.certificate.pkcsMangler.plexPreferences.customCertificateDomain` instead of `.Values.certificate.pkcsMangler.setPlexPreferences.customCertificateDomain`.

#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
