### PR TITLE
Add pre-commit support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# See https://pre-commit.com for more information
+repos:
+- repo: local
+  hooks:
+  - id: ct-lint
+    name: "Chart Test: Lint"
+    language: docker_image
+    pass_filenames: false
+    entry: -u 0 quay.io/helmpack/chart-testing:v3.0.0 ct
+    args:
+    - lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@ repos:
     name: "Chart Test: Lint"
     language: docker_image
     pass_filenames: false
+    types: ['file']
+    files: '^charts/.*(\.ya?ml|\.tpl|\.helmignore|NOTES.txt)'
     entry: -u 0 quay.io/helmpack/chart-testing:v3.0.0 ct
     args:
     - lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,4 +54,4 @@ Charts should start at `1.0.0`. Any breaking (backwards incompatible) changes to
 
 ### pre-commit
 
-This repo supports the [pre-commit](https://pre-commit.com) framework. By installing the framework (see docs) it is possible to perform the chart linting step before committing your code. This can help prevent linter issues in the pipeline. Note that this requires having Docker running on your development environment.
+This repo supports the [pre-commit](https://pre-commit.com) framework. By installing the framework (see [docs](https://pre-commit.com/#install)) it is possible to perform the chart linting step before committing your code. This can help prevent linter issues in the pipeline. Note that this requires having Docker running on your development environment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,9 @@ See `git help commit`:
 
 ### Technical Requirements
 
-* Must follow [Charts best practices](https://helm.sh/docs/topics/chart_best_practices/)
-* Must pass CI jobs for linting and installing changed charts with the [chart-testing](https://github.com/helm/chart-testing) tool
-* Any change to a chart requires a version bump following [semver](https://semver.org/) principles. See [Immutability(#immutability) and [Versioning](#versioning) below
+* Must follow [Charts best practices](https://helm.sh/docs/topics/chart_best_practices/).
+* Must pass CI jobs for linting and installing changed charts with the [chart-testing](https://github.com/helm/chart-testing) tool See [pre-commit](#pre-commit) below.
+* Any change to a chart requires a version bump following [semver](https://semver.org/) principles. See [Immutability](#immutability) and [Versioning](#versioning) below.
 
 Once changes have been merged, the release job will automatically run to package and release changed charts.
 
@@ -51,3 +51,7 @@ Charts should start at `1.0.0`. Any breaking (backwards incompatible) changes to
 
 1. Bump the MAJOR version
 2. In the README, under a section called "Upgrading", describe the manual steps necessary to upgrade to the new (specified) MAJOR version
+
+### pre-commit
+
+This repo supports the [pre-commit](https://pre-commit.com) framework. By installing the framework (see docs) it is possible to perform the chart linting step before committing your code. This can help prevent linter issues in the pipeline. Note that this requires having Docker running on your development environment.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![](https://github.com/k8s-at-home/charts/workflows/Release%20Charts/badge.svg?branch=master)](https://github.com/k8s-at-home/charts/actions)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 ## Usage
 


### PR DESCRIPTION
This adds support for pre-commit. It will run the chart-test lint before creating the commit, potentially reducing the number of linting failures in the pipeline. 