### PR TITLE
[media-common] Add openvpn add-on

### DIFF
--- a/charts/media-common/Chart.yaml
+++ b/charts/media-common/Chart.yaml
@@ -2,10 +2,16 @@ apiVersion: v2
 name: media-common
 description: Common dependancy chart for media ecosystem containers
 type: application
-version: 1.0.1
+version: 1.1.0
 keywords:
   - media-common
 home: https://github.com/k8s-at-home/charts/tree/master/charts/media-common
 maintainers:
   - name: DirtyCajunRice
     email: nick@cajun.pro
+dependencies:
+  - name: media-common-openvpn
+    repository: https://k8s-at-home.com/charts/
+    version: 1.0.0
+    condition: openvpn.enabled
+    alias: openvpn

--- a/charts/media-common/Chart.yaml
+++ b/charts/media-common/Chart.yaml
@@ -12,6 +12,6 @@ maintainers:
 dependencies:
   - name: media-common-openvpn
     repository: https://k8s-at-home.com/charts/
-    version: 1.0.0
+    version: ^1.0.0
     condition: openvpn.enabled
     alias: openvpn

--- a/charts/media-common/README.md
+++ b/charts/media-common/README.md
@@ -23,3 +23,8 @@ These values will normally be nested as it is a dependency, for example:
 radarr:
   <values>
 ```
+
+## Add-ons
+
+### OpenVPN
+It is possible to enable an OpenVPN add-on by setting `openvpn.enabled: true`. For more information refer to [k8s-at-home/media-common-openvpn](https://github.com/k8s-at-home/charts/tree/master/charts/media-common-openvpn)

--- a/charts/media-common/ci/ct-values.yaml
+++ b/charts/media-common/ci/ct-values.yaml
@@ -1,6 +1,22 @@
+---
 image:
   organization: linuxserver
   repository: radarr
   tag: latest
 service:
   port: 7878
+
+openvpn:
+  enabled: true
+
+  image:
+    repository: dperson/openvpn-client
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  scripts:
+    up:
+    down:
+
+  networkPolicy:
+    enabled: false

--- a/charts/media-common/ci/ct-values.yaml
+++ b/charts/media-common/ci/ct-values.yaml
@@ -20,3 +20,11 @@ openvpn:
 
   networkPolicy:
     enabled: false
+
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    exec:
+      command:
+        - echo
+        - success

--- a/charts/media-common/templates/_helpers.tpl
+++ b/charts/media-common/templates/_helpers.tpl
@@ -50,3 +50,27 @@ Selector labels
 app.kubernetes.io/name: {{ include "media-common.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Additional Containers
+*/}}
+{{- define "media-common.additionalContainers" -}}
+{{- if .Values.additionalContainers }}
+{{- toYaml .Values.additionalContainers }}
+{{- end }}
+{{- if .Values.openvpn.enabled }}
+{{ include "media-common.openvpn.container" . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Additional Volumes
+*/}}
+{{- define "media-common.additionalVolumes" -}}
+{{- if .Values.additionalVolumes }}
+{{- toYaml .Values.additionalVolumes }}
+{{- end }}
+{{- if .Values.openvpn.enabled }}
+{{ include "media-common.openvpn.volume" . }}
+{{- end }}
+{{- end -}}

--- a/charts/media-common/templates/addon-openvpn.yaml
+++ b/charts/media-common/templates/addon-openvpn.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.openvpn.enabled -}}
+---
+{{ include "media-common.openvpn.configmap" . }}
+---
+{{ include "media-common.openvpn.secret" . }}
+---
+{{ include "media-common.openvpn.networkpolicy" . }}
+{{- end -}}

--- a/charts/media-common/templates/deployment.yaml
+++ b/charts/media-common/templates/deployment.yaml
@@ -74,6 +74,7 @@ spec:
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- include "media-common.additionalContainers" . | nindent 8 }}
       volumes:
         - name: config
           {{- if .Values.persistence.config.enabled }}
@@ -87,9 +88,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.media.existingClaim }}{{ .Values.persistence.media.existingClaim }}{{- else }}{{ template "media-common.fullname" . }}-media{{- end }}
         {{- end }}
-        {{- if .Values.additionalVolumes }}
-        {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "media-common.additionalVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{ toYaml . | indent 8 }}

--- a/charts/media-common/templates/statefulset.yaml
+++ b/charts/media-common/templates/statefulset.yaml
@@ -75,6 +75,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- include "media-common.additionalContainers" . | nindent 8 }}
       volumes:
         - name: config
           {{- if .Values.persistence.config.enabled }}
@@ -88,9 +89,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.media.existingClaim }}{{ .Values.persistence.media.existingClaim }}{{- else }}{{ template "media-common.fullname" . }}-media{{- end }}
         {{- end }}
-        {{- if .Values.additionalVolumes }}
-        {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "media-common.additionalVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{ toYaml . | indent 8 }}

--- a/charts/media-common/values.yaml
+++ b/charts/media-common/values.yaml
@@ -113,9 +113,16 @@ persistence:
     ## Do not delete the pvc upon helm uninstall
     skipuninstall: false
 
+additionalContainers: []
+
 additionalVolumes: []
 
 additionalVolumeMounts: []
+
+# Enable the OpenVPN add-on here
+# See https://github.com/k8s-at-home/charts/tree/master/charts/media-common-openvpn for more details
+openvpn:
+  enabled: false
 
 podSecurityContext: {}
 # fsGroup: 2000


### PR DESCRIPTION
#### Special notes for your reviewer:
Adds `media-common-openvpn` add-on to `media-common`. Lays the foundation for migrating helm charts (#37) that use a VPN sidecar to the new media-common chart.

**Note** this PR depends on #46 being merged

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
