### PR TITLE
[prometheus-nut-exporter] New chart

### DIFF
--- a/charts/prometheus-nut-exporter/.helmignore
+++ b/charts/prometheus-nut-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/prometheus-nut-exporter/Chart.yaml
+++ b/charts/prometheus-nut-exporter/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: prometheus-nut-exporter
+description: A Helm chart for Kubernetes
+type: application
+version: 1.0.0
+appVersion: 1.0.1
+keywords:
+- nut
+- prometheus
+home: https://github.com/k8s-at-home/charts/tree/master/charts/prometheus-nut-exporter
+icon: https://www.iconfinder.com/data/icons/wpzoom-developer-icon-set/500/125-512.png
+sources:
+- https://github.com/HON95/prometheus-nut-exporter
+maintainers:
+- name: billimek
+  email: jeff@billimek.com

--- a/charts/prometheus-nut-exporter/README.md
+++ b/charts/prometheus-nut-exporter/README.md
@@ -1,0 +1,50 @@
+# Prometheus NUT Exporter
+
+This is a helm chart provides a service monitor to send NUT server metrics to a Prometheus instance. Based on [Prometheus NUT Exporter](https://github.com/HON95/prometheus-nut-exporter).
+
+## TL;DR;
+
+```console
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm install k8s-at-home/prometheus-nut-exporter
+```
+
+## Installing the Chart
+
+To install the chart with the release name `prometheus-nut-exporter`:
+
+```console
+helm install --name prometheus-nut-exporter k8s-at-home/prometheus-nut-exporter
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `prometheus-nut-exporter` deployment:
+
+```console
+helm delete prometheus-nut-exporter
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Read through the [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/prometheus-nut-exporter/values.yaml) file. It has several commented out suggested values.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install --name prometheus-nut-exporter \
+   --set serviceMonitor.enabled=true \
+    k8s-at-home/prometheus-nut-exporter
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install --name prometheus-nut-exporter -f values.yaml k8s-at-home/prometheus-nut-exporter
+```
+
+## Metrics
+
+You can find the exported metrics here: [metrics](https://github.com/HON95/prometheus-nut-exporter/blob/master/metrics.md).

--- a/charts/prometheus-nut-exporter/templates/NOTES.txt
+++ b/charts/prometheus-nut-exporter/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prometheus-nut-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "prometheus-nut-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "prometheus-nut-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "prometheus-nut-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/prometheus-nut-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-nut-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-nut-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-nut-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-nut-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prometheus-nut-exporter.labels" -}}
+helm.sh/chart: {{ include "prometheus-nut-exporter.chart" . }}
+{{ include "prometheus-nut-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus-nut-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-nut-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-nut-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prometheus-nut-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-nut-exporter/templates/deployment.yaml
+++ b/charts/prometheus-nut-exporter/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "prometheus-nut-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-nut-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-nut-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "prometheus-nut-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "prometheus-nut-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- if .Values.env }}
+          env:
+          {{- range $key, $value := .Values.env }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/prometheus-nut-exporter/templates/service.yaml
+++ b/charts/prometheus-nut-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-nut-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-nut-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "prometheus-nut-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/prometheus-nut-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-nut-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus-nut-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "prometheus-nut-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/prometheus-nut-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-nut-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "prometheus-nut-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-nut-exporter.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "prometheus-nut-exporter.selectorLabels" . | nindent 4 }}
+  endpoints:
+    {{- range .Values.serviceMonitor.targets }}
+    - port: http
+      interval: 15s
+      scrapeTimeout: 10s
+      path: "/nut"
+      params:
+        target:
+          - "{{ .hostname }}:{{ .port }}"
+    {{- end }}
+{{- end }}

--- a/charts/prometheus-nut-exporter/values.yaml
+++ b/charts/prometheus-nut-exporter/values.yaml
@@ -1,0 +1,79 @@
+# Default values for prometheus-nut-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: hon95/prometheus-nut-exporter
+  pullPolicy: IfNotPresent
+  tag: "1.0.1"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+env: {}
+  # TZ: UTC
+
+serviceMonitor:
+  enabled: false
+  # Specify the list of NUT servers that should be monitored
+  targets: []
+    # - hostname: nut-server
+    #   port: 3493
+
+# Probes configuration
+probes:
+  liveness:
+    initialDelaySeconds: 30
+    failureThreshold: 5
+    timeoutSeconds: 10
+  readiness:
+    initialDelaySeconds: 30
+    failureThreshold: 5
+    timeoutSeconds: 10
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 9995
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This PR adds support for [prometheus-nut-exporter](https://github.com/HON95/prometheus-nut-exporter).
It can be used to send remote NUT server metrics to a Prometheus instance for monitoring.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
