### PR TITLE
[home-assistant] Bump Home Assistant to 0.115.2

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.114.0
+appVersion: 0.115.2
 description: Home Assistant
 name: home-assistant
-version: 2.1.0
+version: 2.2.0
 keywords:
 - home-assistant
 - hass

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: homeassistant/home-assistant
-  tag: 0.114.0
+  tag: 0.115.2
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
