### PR TITLE
[statping] Allow annotations in service

### DIFF
--- a/charts/statping/Chart.yaml
+++ b/charts/statping/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: statping
 description: Status page for monitoring your websites and applications
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: v0.90.65
 keywords:
   - statping

--- a/charts/statping/templates/service.yaml
+++ b/charts/statping/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "statping.fullname" . }}
   labels:
     {{- include "statping.labels" . | nindent 4 }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)

#### Description
values.yaml has service.annotations but they didn't work completely, which rendered automatic provisioning of load balancers impossible (e.g. DigitalOcean requires specific annotations for HTTPS/SSL configuration). Now it works as intended.