### PR TITLE
[media-common] Support additionalPorts

### DIFF
--- a/charts/media-common/Chart.yaml
+++ b/charts/media-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: media-common
 description: Common dependancy chart for media ecosystem containers
 type: application
-version: 1.1.1
+version: 1.2.0
 keywords:
   - media-common
 home: https://github.com/k8s-at-home/charts/tree/master/charts/media-common

--- a/charts/media-common/templates/deployment.yaml
+++ b/charts/media-common/templates/deployment.yaml
@@ -42,6 +42,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- range .Values.service.additionalPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: http

--- a/charts/media-common/templates/deployment.yaml
+++ b/charts/media-common/templates/deployment.yaml
@@ -42,9 +42,9 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-            {{- range .Values.service.additionalPorts }}
-            - name: {{ .name }}
-              containerPort: {{ .port }}
+            {{- range $key, $value := .Values.service.additionalPorts }}
+            - name: {{ $key }}
+              containerPort: {{ $value.port }}
               protocol: TCP
             {{- end }}
           livenessProbe:

--- a/charts/media-common/templates/service.yaml
+++ b/charts/media-common/templates/service.yaml
@@ -22,13 +22,13 @@ spec:
       {{- if (and (eq $svcType "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
-    {{- range .Values.service.additionalPorts }}
-    - name: {{ .name }}
-      port: {{ .port }}
+    {{- range $key, $value := .Values.service.additionalPorts }}
+    - name: {{ $key }}
+      port: {{ $value.port }}
       protocol: TCP
-      targetPort: {{ .name }}
-      {{- if (and (eq $svcType "NodePort") (not (empty .nodePort))) }}
-      nodePort: {{ .nodePort }}
+      targetPort: {{ $key }}
+      {{- if (and (eq $svcType "NodePort") (not (empty $value.nodePort))) }}
+      nodePort: {{ $value.nodePort }}
       {{- end }}
     {{- end }}
   {{- with .Values.service.additionalSpec }}

--- a/charts/media-common/templates/service.yaml
+++ b/charts/media-common/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- $svcType := .Values.service.type -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,15 +13,24 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ $svcType }}
   ports:
     - name: http
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: http
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      {{- if (and (eq $svcType "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
+    {{- range .Values.service.additionalPorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      protocol: TCP
+      targetPort: {{ .name }}
+      {{- if (and (eq $svcType "NodePort") (not (empty .nodePort))) }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
+    {{- end }}
   {{- with .Values.service.additionalSpec }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/media-common/templates/statefulset.yaml
+++ b/charts/media-common/templates/statefulset.yaml
@@ -43,9 +43,9 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-            {{- range .Values.service.additionalPorts }}
-            - name: {{ .name }}
-              containerPort: {{ .port }}
+            {{- range $key, $value := .Values.service.additionalPorts }}
+            - name: {{ $key }}
+              containerPort: {{ $value.port }}
               protocol: TCP
             {{- end }}
           livenessProbe:

--- a/charts/media-common/templates/statefulset.yaml
+++ b/charts/media-common/templates/statefulset.yaml
@@ -43,6 +43,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- range .Values.service.additionalPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: http

--- a/charts/media-common/values.yaml
+++ b/charts/media-common/values.yaml
@@ -40,10 +40,12 @@ service:
   annotations: {}
   labels: {}
   additionalSpec: {}
+
   ## Specify any additional required (TCP) ports here
   additionalPorts: {}
-    # - name: ""
-    #   port: ""
+  ## Example:
+    # bittorrent:
+    #   port: 6881
     #   nodePort:
 
 ingress:

--- a/charts/media-common/values.yaml
+++ b/charts/media-common/values.yaml
@@ -40,6 +40,11 @@ service:
   annotations: {}
   labels: {}
   additionalSpec: {}
+  ## Specify any additional required (TCP) ports here
+  additionalPorts: {}
+    # - name: ""
+    #   port: ""
+    #   nodePort:
 
 ingress:
   enabled: false


### PR DESCRIPTION
#### Special notes for your reviewer:
When migrating the qBittorrent chart to media-common I ran into the issue that I need to specify 2 ports (1 for UI, 1 for bt protocol). 
I don't think I can use `service.additionalSpec` for this because the named ports would not be exposed from the deployment/sts  

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
