### PR TITLE
[adguard-home] enable additional service options

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.102.0
 description: DNS proxy as ad-blocker for local network
 name: adguard-home
-version: 2.0.1
+version: 2.1.0
 keywords:
   - adguard-home
   - adguard

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.102.0
 description: DNS proxy as ad-blocker for local network
 name: adguard-home
-version: 2.0.0
+version: 2.0.1
 keywords:
   - adguard-home
   - adguard

--- a/charts/adguard-home/templates/service-dhcp.yaml
+++ b/charts/adguard-home/templates/service-dhcp.yaml
@@ -17,6 +17,14 @@ spec:
   {{- if .Values.serviceDHCP.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceDHCP.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+  {{ toYaml .Values.service.externalIPs | indent 4 }}
+  {{- end }}
   externalTrafficPolicy: {{ .Values.serviceDHCP.externalTrafficPolicy }}
   ports:
     - port: 67

--- a/charts/adguard-home/templates/service-dns-over-tls.yaml
+++ b/charts/adguard-home/templates/service-dns-over-tls.yaml
@@ -17,6 +17,14 @@ spec:
   {{- if .Values.serviceDNSOverTLS.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceDNSOverTLS.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+  {{ toYaml .Values.service.externalIPs | indent 4 }}
+  {{- end }}
   externalTrafficPolicy: {{ .Values.serviceDNSOverTLS.externalTrafficPolicy }}
   ports:
     - port: 853

--- a/charts/adguard-home/templates/service-tcp.yaml
+++ b/charts/adguard-home/templates/service-tcp.yaml
@@ -17,6 +17,14 @@ spec:
   {{- if .Values.serviceTCP.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceTCP.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+  {{ toYaml .Values.service.externalIPs | indent 4 }}
+  {{- end }}
   externalTrafficPolicy: {{ .Values.serviceTCP.externalTrafficPolicy }}
   ports:
     - port: 53

--- a/charts/adguard-home/templates/service-udp.yaml
+++ b/charts/adguard-home/templates/service-udp.yaml
@@ -17,6 +17,14 @@ spec:
   {{- if .Values.serviceUDP.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceUDP.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+  {{ toYaml .Values.service.externalIPs | indent 4 }}
+  {{- end }}
   externalTrafficPolicy: {{ .Values.serviceUDP.externalTrafficPolicy }}
   ports:
     - port: 53

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -16,6 +16,14 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+  {{ toYaml .Values.service.externalIPs | indent 4 }}
+  {{- end }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   ports:
     - port: 3000

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -224,8 +224,10 @@ probes:
 service:
   type: ClusterIP
   # externalTrafficPolicy: Local
+  # externalIPs: []
   # loadBalancerIP: ""
     # a fixed LoadBalancer IP
+  # loadBalancerSourceRanges: []
   annotations: {}
     # metallb.universe.tf/address-pool: network-services
     # metallb.universe.tf/allow-shared-ip: adguard-home-svc
@@ -234,8 +236,10 @@ serviceTCP:
   enabled: false
   type: NodePort
   # externalTrafficPolicy: Local
+  # externalIPs: []
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
+  # loadBalancerSourceRanges: []
   annotations: {}
     # metallb.universe.tf/address-pool: network-services
     # metallb.universe.tf/allow-shared-ip: adguard-home-svc
@@ -244,8 +248,10 @@ serviceUDP:
   enabled: true
   type: NodePort
   # externalTrafficPolicy: Local
+  # externalIPs: []
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
+  # loadBalancerSourceRanges: []
   annotations: {}
     # metallb.universe.tf/address-pool: network-services
     # metallb.universe.tf/allow-shared-ip: adguard-home-svc
@@ -255,8 +261,10 @@ serviceDNSOverTLS:
   ## Enable if you use AdGuard as a DNS over TLS/HTTPS server
   type: NodePort
   # externalTrafficPolicy: Local
+  # externalIPs: []
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
+  # loadBalancerSourceRanges: []
   annotations: {}
     # metallb.universe.tf/address-pool: network-services
     # metallb.universe.tf/allow-shared-ip: adguard-home-svc
@@ -266,6 +274,7 @@ serviceDHCP:
   ## Enable if you use AdGuard as a DHCP Server
   type: NodePort
   # externalTrafficPolicy: Local
+  # externalIPs: []
   loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}


### PR DESCRIPTION
#### Special notes for your reviewer:
Adds additional parameters to be set on services (externalIPs, etc)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[radarr]`)
