### PR TITLE
[media-common] Fixes HELM error on extraIngresses

### DIFF
--- a/charts/media-common/Chart.yaml
+++ b/charts/media-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: media-common
 description: Common dependancy chart for media ecosystem containers
 type: application
-version: 1.3.0
+version: 1.3.1
 keywords:
   - media-common
 home: https://github.com/k8s-at-home/charts/tree/master/charts/media-common

--- a/charts/media-common/templates/ingress.yaml
+++ b/charts/media-common/templates/ingress.yaml
@@ -64,7 +64,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}-{{ $ingress.nameSuffix | default $index }}
   labels:
-    {{- include "media-common.labels" . | nindent 4 }}
+    {{- include "media-common.labels" $ | nindent 4 }}
     {{- with $ingress.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: Waldemar Faist <cubic@coldice.net>

#### Special notes for your reviewer:
Currently HELM is not able to process the chart if `extraIngresses` is used:
```
install.go:172: [debug] Original chart version: ""
install.go:189: [debug] CHART PATH: [stripped local path]/radarr

Error: template: radarr/charts/radarr/templates/ingress.yaml:67:8: executing "radarr/charts/radarr/templates/ingress.yaml" at <include "media-common.labels" .>: error calling include: template: radarr/charts/radarr/templates/_helpers.tpl:38:18: executing "media-common.labels" at <include "media-common.chart" .>: error calling include: template: radarr/charts/radarr/templates/_helpers.tpl:31:25: executing "media-common.chart" at <.Chart.Name>: nil pointer evaluating interface {}.Name
helm.go:94: [debug] template: radarr/charts/radarr/templates/ingress.yaml:67:8: executing "radarr/charts/radarr/templates/ingress.yaml" at <include "media-common.labels" .>: error calling include: template: radarr/charts/radarr/templates/_helpers.tpl:38:18: executing "media-common.labels" at <include "media-common.chart" .>: error calling include: template: radarr/charts/radarr/templates/_helpers.tpl:31:25: executing "media-common.chart" at <.Chart.Name>: nil pointer evaluating interface {}.Name
```
The reason is the used `.` inside of a `range` which does not resolve to the top level scope anymore and refered `.Chart` becomes `nil` in `media-common.chart`. Fixed by using `$` which always refers to the top level. Change is not breaking, since HELM was not able to process the chart otherwise.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
