### PR TITLE
[media-common] Bump charts depending on media-common

### DIFF
--- a/charts/jackett/Chart.yaml
+++ b/charts/jackett/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.16.1045
 description: API Support for your favorite torrent trackers
 name: jackett
-version: 4.0.0
+version: 4.0.1
 keywords:
   - jackett
   - torrent

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lidarr
 description: Looks and smells like Sonarr but made for music
 type: application
-version: 4.0.1
+version: 4.0.2
 appVersion: 0.7.1.1785-ls18
 keywords:
   - lidarr

--- a/charts/nzbget/Chart.yaml
+++ b/charts/nzbget/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v21.0
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 5.0.0
+version: 5.0.1
 keywords:
   - nzbget
   - usenet

--- a/charts/ombi/Chart.yaml
+++ b/charts/ombi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ombi
 description: Want a Movie or TV Show on Plex or Emby? Use Ombi!
 type: application
-version: 4.0.1
+version: 4.0.2
 appVersion: 4.0.471
 keywords:
   - ombi

--- a/charts/organizr/Chart.yaml
+++ b/charts/organizr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: organizr
 description: HTPC/Homelab Services Organizer - Written in PHP
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: latest
 keywords:
   - organizr

--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.2.5
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 name: qbittorrent
-version: 5.0.0
+version: 5.0.1
 keywords:
   - qbittorrent
   - torrrent

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: radarr
 description: A fork of Sonarr to work with movies à la Couchpotato
 type: application
-version: 6.0.1
+version: 6.0.2
 appVersion: 3.0.0.3591
 keywords:
   - radarr

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarr
 description: Smart PVR for newsgroup and bittorrent users
 type: application
-version: 6.0.1
+version: 6.0.2
 appVersion: 3.0.3.913
 keywords:
   - sonarr

--- a/charts/tautulli/Chart.yaml
+++ b/charts/tautulli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tautulli
 description: A Python based monitoring and tracking tool for Plex Media Server
 type: application
-version: 4.0.1
+version: 4.0.2
 appVersion: v2.5.4
 keywords:
   - tautulli


### PR DESCRIPTION
Signed-off-by: Waldemar Faist <cubic@coldice.net>

#### Special notes for your reviewer:
@carpenike Looks like charts that are depending on `media-common` are not rebuilt using the patch in #84. Haven't take a look in the CI settings on this project. This would require to bump a a patch version on all charts using `media-common`, since the charts use `^1.0.0` as dependent version. Thanks ;)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
