### PR TITLE
[multiple] Bump various chart image versions

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.5.2"
+appVersion: "0.6.0"
 description: Realtime object detection on RTSP cameras with the Google Coral
 name: frigate
-version: 4.0.0
+version: 4.0.1
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -9,7 +9,7 @@ strategyType: Recreate
 
 image:
   repository: blakeblackshear/frigate
-  tag: 0.5.2
+  tag: 0.6.0
   pullPolicy: IfNotPresent
 
 rtspPassword: password

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.115.2
+appVersion: 0.116.1
 description: Home Assistant
 name: home-assistant
-version: 2.5.0
+version: 2.5.1
 keywords:
 - home-assistant
 - hass

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: homeassistant/home-assistant
-  tag: 0.115.2
+  tag: 0.116.1
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.20.1.3252
+appVersion: 1.20.2.3402
 description: Plex Media Server
 name: plex
-version: 2.0.3
+version: 2.0.4
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/plex/values.yaml
+++ b/charts/plex/values.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: plexinc/pms-docker
-  tag: 1.20.1.3252-a78fef9a9
+  tag: 1.20.2.3402-0fec14d92
   pullPolicy: IfNotPresent
 
 #####   START  --> Official PLEX container environment variables

--- a/charts/teslamate/Chart.yaml
+++ b/charts/teslamate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.19.3
+appVersion: v1.20.0
 description: A self-hosted data logger for your Tesla 🚘
 name: teslamate
-version: 3.0.1
+version: 3.0.2
 keywords:
   - teslamate
   - tesla

--- a/charts/teslamate/Chart.yaml
+++ b/charts/teslamate/Chart.yaml
@@ -12,8 +12,8 @@ sources:
   - https://github.com/adriankumpf/teslamate
 dependencies:
 - name: postgresql
-  version: 8.1.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 9.1.2
+  repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 maintainers:
   - name: billimek

--- a/charts/teslamate/values.yaml
+++ b/charts/teslamate/values.yaml
@@ -85,11 +85,9 @@ affinity: {}
 # ... for more options see https://github.com/bitnami/charts/tree/master/bitnami/postgresql
 postgresql:
   enabled: true
-  global:
-    postgresql:
-      postgresqlUsername: teslamate
-      postgresqlPassword: teslamate
-      postgresqlDatabase: teslamate
+  postgresqlUsername: teslamate
+  postgresqlPassword: teslamate
+  postgresqlDatabase: teslamate
   image:
     repository: postgres
     tag: 12.1

--- a/charts/teslamate/values.yaml
+++ b/charts/teslamate/values.yaml
@@ -81,54 +81,23 @@ tolerations: []
 
 affinity: {}
 
-## Configuration values for the postgresql dependency.
-## Ref: https://github.com/helm/charts/blob/master/stable/postgresql/README.md
+# Configuration values for the postgresql dependency.
+# ... for more options see https://github.com/bitnami/charts/tree/master/bitnami/postgresql
 postgresql:
+  enabled: true
+  global:
+    postgresql:
+      postgresqlUsername: teslamate
+      postgresqlPassword: teslamate
+      postgresqlDatabase: teslamate
   image:
     repository: postgres
     tag: 12.1
   postgresqlDataDir: "/data/pgdata"
-
-  ### PostgreSQL User to create.
-  ##
-  postgresqlUsername: teslamate
-
-  ## PostgreSQL Password for the new user.
-  ## If not set, a random 10 characters password will be used.
-  ##
-  postgresqlPassword: teslamate
-
-  ## PostgreSQL Database to create.
-  ##
-  postgresqlDatabase: teslamate
-
-  ## Persistent Volume Storage configuration for PostgreSQL.
-  ##
-  ## Ref: https://kubernetes.io/docs/user-guide/persistent-volumes
-  ##
   persistence:
-    ## Enable PostgreSQL persistence using Persistent Volume Claims.
-    ##
     enabled: true
-
-    ## Persistent Volume Storage Class to be used by PersistentVolumes created
-    ## for PostgreSQL.
-    ##
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
     storageClass:
-
-    ## Persistent Volume Access Mode.
-    ##
     accessModes:
       - ReadWriteOnce
-
-    ## Persistent Volume Storage Size.
-    ##
     size: 8Gi
-
     mountPath: "/data/"

--- a/charts/teslamate/values.yaml
+++ b/charts/teslamate/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: teslamate/teslamate
-  tag: 1.19.3
+  tag: 1.20.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
* friagte: 0.6.0
* home-assistant: 0.116.1
* plex: 1.20.2.3402-0fec14d92
* teslamate: 1.20.0

Additionally, also needed to remediate the `teslamate` chart to use the bitnami postgres subchart instead of the (now deprecated) helm/charts postgres chart.  testlamate wouldn't properly install until this was done.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
