### PR TITLE
[home-assistant] pump up esphome chart version

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.116.1
 description: Home Assistant
 name: home-assistant
-version: 2.5.1
+version: 2.5.2
 keywords:
 - home-assistant
 - hass
@@ -22,7 +22,7 @@ maintainers:
 dependencies:
 - name: esphome
   repository: https://k8s-at-home.com/charts/
-  version: ~1.0.0
+  version: ~2.2.0
   condition: esphome.enabled
 - name: postgresql
   version: 9.1.2


### PR DESCRIPTION
Signed-off-by: nolte <nolte07@googlemail.com>

#### Special notes for your reviewer:

Update Chart Version from esphome to [2.2.0](https://github.com/k8s-at-home/charts/releases/tag/esphome-2.2.0), for arm support.

#### Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
