### PR TITLE
[zwave2mqtt] Remove the persistent /usr/local/etc/openzwave volume

### DIFF
--- a/charts/zwave2mqtt/Chart.yaml
+++ b/charts/zwave2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.3
 description: Fully configurable Zwave to MQTT gateway and Control Panel using NodeJS and Vue
 name: zwave2mqtt
-version: 3.0.1
+version: 3.1.0
 keywords:
   - zwave
   - mqtt

--- a/charts/zwave2mqtt/Chart.yaml
+++ b/charts/zwave2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.3
 description: Fully configurable Zwave to MQTT gateway and Control Panel using NodeJS and Vue
 name: zwave2mqtt
-version: 3.1.0
+version: 4.0.0
 keywords:
   - zwave
   - mqtt

--- a/charts/zwave2mqtt/README.md
+++ b/charts/zwave2mqtt/README.md
@@ -62,3 +62,14 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 helm install --name my-release -f values.yaml stable/zwave2mqtt
 ```
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like 2.2.2 -> 3.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### Upgrading from 3.x.x to 4.x.x
+
+Upgrading to this release it is suggested to enable the flag in Settings > Zwave > Auto update database
+
+In order to use an updated configuration for the devices, you have to send a refreshNodeInfo to that node

--- a/charts/zwave2mqtt/templates/deployment.yaml
+++ b/charts/zwave2mqtt/templates/deployment.yaml
@@ -65,9 +65,6 @@ spec:
               name: usb
             - mountPath: /usr/src/app/store
               name: config
-            - mountPath: /usr/local/etc/openzwave
-              name: config
-              subPath: openzwave
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:


### PR DESCRIPTION
#### Special notes for your reviewer:

Based on the developers this volume does not need to be persistent if we enable `auto update device db`

![image](https://user-images.githubusercontent.com/213795/96000980-842b7d00-0e05-11eb-8059-c62ee35d9c3d.png)

Fixes: #5 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
