### PR TITLE
media-common retro fix (1/3)

### DIFF
--- a/charts/jackett/Chart.yaml
+++ b/charts/jackett/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.16.1045
 description: API Support for your favorite torrent trackers
 name: jackett
-version: 4.0.1
+version: 4.0.2
 keywords:
   - jackett
   - torrent
@@ -17,5 +17,5 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: jackett

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lidarr
 description: Looks and smells like Sonarr but made for music
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: 0.7.1.1785-ls18
 keywords:
   - lidarr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: lidarr
 annotations:
   artifacthub.io/links: |

--- a/charts/media-common/Chart.yaml
+++ b/charts/media-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: media-common
 description: Common dependancy chart for media ecosystem containers
 type: application
-version: 1.3.1
+version: 2.0.0
 keywords:
   - media-common
 home: https://github.com/k8s-at-home/charts/tree/master/charts/media-common

--- a/charts/media-common/Chart.yaml
+++ b/charts/media-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: media-common
 description: Common dependancy chart for media ecosystem containers
 type: application
-version: 2.0.0
+version: 1.3.1
 keywords:
   - media-common
 home: https://github.com/k8s-at-home/charts/tree/master/charts/media-common

--- a/charts/nzbget/Chart.yaml
+++ b/charts/nzbget/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v21.0
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 5.0.1
+version: 5.0.2
 keywords:
   - nzbget
   - usenet
@@ -17,5 +17,5 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: nzbget

--- a/charts/ombi/Chart.yaml
+++ b/charts/ombi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ombi
 description: Want a Movie or TV Show on Plex or Emby? Use Ombi!
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: 4.0.471
 keywords:
   - ombi
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: ombi
 annotations:
   artifacthub.io/links: |

--- a/charts/organizr/Chart.yaml
+++ b/charts/organizr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: organizr
 description: HTPC/Homelab Services Organizer - Written in PHP
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: latest
 keywords:
   - organizr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: organizr
 annotations:
   artifacthub.io/links: |

--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.2.5
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 name: qbittorrent
-version: 5.0.1
+version: 5.0.2
 keywords:
   - qbittorrent
   - torrrent
@@ -16,5 +16,5 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: qbittorrent

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: radarr
 description: A fork of Sonarr to work with movies à la Couchpotato
 type: application
-version: 6.0.2
+version: 6.0.3
 appVersion: 3.0.0.3591
 keywords:
   - radarr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: radarr
 annotations:
   artifacthub.io/links: |

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarr
 description: Smart PVR for newsgroup and bittorrent users
 type: application
-version: 6.0.2
+version: 6.0.3
 appVersion: 3.0.3.913
 keywords:
   - sonarr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: sonarr
 annotations:
   artifacthub.io/links: |

--- a/charts/tautulli/Chart.yaml
+++ b/charts/tautulli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tautulli
 description: A Python based monitoring and tracking tool for Plex Media Server
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: v2.5.4
 keywords:
   - tautulli
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: tautulli
 annotations:
   artifacthub.io/links: |


### PR DESCRIPTION
Fixes #73 
Objective:
1. Create a final version of the charts under this major version that is pinned to the last non-breaking change in media-common
2.  Create another PR that does a major version bump of all charts + media-common using the new features, with a standard notice of the breaking change

Charts affected:
- jackett
- lidarr
- nzbget
- ombi
- organizr
- qbittorrent
- radarr
- sonarr
- tautulli