### PR TITLE
media-common retro fix (3/3)

### DIFF
--- a/charts/jackett/Chart.yaml
+++ b/charts/jackett/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.16.1045
 description: API Support for your favorite torrent trackers
 name: jackett
-version: 4.0.1
+version: 4.0.2
 keywords:
   - jackett
   - torrent
@@ -17,5 +17,5 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: jackett

--- a/charts/jackett/Chart.yaml
+++ b/charts/jackett/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.16.1045
 description: API Support for your favorite torrent trackers
 name: jackett
-version: 4.0.2
+version: 5.0.0
 keywords:
   - jackett
   - torrent
@@ -17,5 +17,5 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: 1.1.1
+    version: ^2.0.0
     alias: jackett

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lidarr
 description: Looks and smells like Sonarr but made for music
 type: application
-version: 4.0.3
+version: 5.0.0
 appVersion: 0.7.1.1785-ls18
 keywords:
   - lidarr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: 1.1.1
+    version: ^2.0.0
     alias: lidarr
 annotations:
   artifacthub.io/links: |

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lidarr
 description: Looks and smells like Sonarr but made for music
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: 0.7.1.1785-ls18
 keywords:
   - lidarr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: lidarr
 annotations:
   artifacthub.io/links: |

--- a/charts/media-common/Chart.yaml
+++ b/charts/media-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: media-common
 description: Common dependancy chart for media ecosystem containers
 type: application
-version: 1.3.1
+version: 2.0.0
 keywords:
   - media-common
 home: https://github.com/k8s-at-home/charts/tree/master/charts/media-common

--- a/charts/media-common/Chart.yaml
+++ b/charts/media-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: media-common
 description: Common dependancy chart for media ecosystem containers
 type: application
-version: 2.0.0
+version: 1.3.1
 keywords:
   - media-common
 home: https://github.com/k8s-at-home/charts/tree/master/charts/media-common

--- a/charts/media-common/templates/_helpers.tpl
+++ b/charts/media-common/templates/_helpers.tpl
@@ -60,16 +60,14 @@ Init Containers
 {{- end }}
 {{- end -}}
 
-{{/*
-Additional Containers
-*/}}
+{{/* Additional Containers */}}
 {{- define "media-common.additionalContainers" -}}
-{{- if .Values.additionalContainers }}
-{{- toYaml .Values.additionalContainers }}
-{{- end }}
-{{- if .Values.openvpn.enabled }}
-{{ include "media-common.openvpn.container" . }}
-{{- end }}
+  {{- with .Values.additionalContainers -}}
+    {{- toYaml . | nindent 8 }}
+  {{- end -}}
+  {{- if .Values.openvpn.enabled -}}
+    {{- include "media-common.openvpn.container" . | nindent 8 }}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/media-common/templates/ingress.yaml
+++ b/charts/media-common/templates/ingress.yaml
@@ -1,46 +1,49 @@
-{{- if .Values.ingress.enabled -}}
-  {{- $kubeVersion := .Capabilities.KubeVersion.GitVersion -}}
-  {{- $fullName := include "media-common.fullname" . -}}
-  {{- $svcPort := .Values.service.port -}}
-  {{- if semverCompare ">= 1.19-0" $kubeVersion -}}
+{{- $fullName := include "media-common.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $apiv1 := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- $apiv1beta1 := .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- $ingresses := concat (list .Values.ingress) .Values.extraIngresses -}}
+{{- range $index, $ingress := $ingresses }}
+  {{- if $ingress.enabled -}}
+    {{- if $apiv1 -}}
 apiVersion: networking.k8s.io/v1
-  {{- else if semverCompare ">= 1.14-0 < 1.19-0" $kubeVersion -}}
+    {{- else if $apiv1beta1 -}}
 apiVersion: networking.k8s.io/v1beta1
-  {{- else -}}
+    {{- else -}}
 apiVersion: extensions/v1beta1
-  {{- end }}
+    {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}{{- if ne $index 0 }}{{- printf "-%s" (default $index $ingress.nameSuffix) }}{{- end }}
   labels:
-  {{- include "media-common.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- include "media-common.labels" $ | nindent 4 }}
+  {{- with $ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.tls }}
+  {{- with $ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
+    {{- range . }}
+    - secretName: {{ .secretName }}
+      hosts:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+  {{- range $ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if semverCompare ">= 1.14-0" $kubeVersion}}
+            {{- if or $apiv1beta1 $apiv1 }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">= 1.19-0" $kubeVersion}}
+              {{- if $apiv1 }}
               service:
                 name: {{ $fullName }}
                 port:
@@ -51,56 +54,6 @@ spec:
               {{- end }}
           {{- end }}
   {{- end }}
-  {{- range $index, $ingress := .Values.ingress.extraIngresses }}
 ---
-  {{- if semverCompare ">= 1.19-0" $kubeVersion -}}
-apiVersion: networking.k8s.io/v1
-  {{- else if semverCompare ">= 1.14-0 < 1.19-0" $kubeVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-  {{- else -}}
-apiVersion: extensions/v1beta1
-    {{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}-{{ $ingress.nameSuffix | default $index }}
-  labels:
-    {{- include "media-common.labels" $ | nindent 4 }}
-    {{- with $ingress.annotations }}
-  annotations:
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if $ingress.tls }}
-  tls:
-    {{- range $ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
-  {{- end }}
-  rules:
-    {{- range $ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if semverCompare ">= 1.14-0" $kubeVersion}}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">= 1.19-0" $kubeVersion}}
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/media-common/templates/statefulset.yaml
+++ b/charts/media-common/templates/statefulset.yaml
@@ -72,14 +72,14 @@ spec:
               subPath: {{ .Values.persistence.media.subPath }}
               {{- end }}
             {{- end }}
-          {{- if .Values.additionalVolumeMounts }}
-          {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+          {{- with .Values.additionalVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- include "media-common.additionalContainers" . | nindent 8 }}
+        {{- include "media-common.additionalContainers" . }}
       volumes:
         - name: config
           {{- if .Values.persistence.config.enabled }}

--- a/charts/media-common/values.yaml
+++ b/charts/media-common/values.yaml
@@ -41,39 +41,44 @@ service:
   labels: {}
   additionalSpec: {}
 
+# ingress and extraIngresses will build the correct ingress based upon your cluster's api capabilities
 ingress:
   enabled: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   labels: {}
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          # Ignored if not kubeVersion >= 1.14-0
-          pathType: Prefix
+  # requires networking.k8s.io/v1beta1
+  className: ""
+  hosts: []
+  # - host: chart-example.local
+  #   paths:
+  #     - path: /
+  #       # Ignored if not kubeVersion >= 1.14-0
+  #       pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-  extraIngresses:
-  # - enabled: false
-  #   nameSuffix: "api"
-  #   annotations: {}
-  #   # kubernetes.io/ingress.class: nginx
-  #   # kubernetes.io/tls-acme: "true"
-  #   labels: {}
-  #   hosts:
-  #     - host: chart-example.local
-  #       paths:
-  #         - path: /api
-  #          # Ignored if not kubeVersion >= 1.14-0
-  #          pathType: Prefix
-  #   tls: []
-  #   #  - secretName: chart-example-tls
-  #   #    hosts:
-  #   #      - chart-example.local
+extraIngresses: []
+# - enabled: false
+#   nameSuffix: "api"
+#   annotations: {}
+#   # kubernetes.io/ingress.class: nginx
+#   # kubernetes.io/tls-acme: "true"
+#   labels: {}
+#   # requires networking.k8s.io/v1beta1
+#   className: ""
+#   hosts:
+#     - host: chart-example.local
+#       paths:
+#         - path: /api
+#           # Ignored if not kubeVersion >= 1.14-0
+#           pathType: Prefix
+#   tls: []
+#   #  - secretName: chart-example-tls
+#   #    hosts:
+#   #      - chart-example.local
 
 persistence:
   # type: options are statefulset or deployment

--- a/charts/nzbget/Chart.yaml
+++ b/charts/nzbget/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v21.0
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 5.0.2
+version: 6.0.0
 keywords:
   - nzbget
   - usenet
@@ -17,5 +17,5 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: 1.1.1
+    version: ^2.0.0
     alias: nzbget

--- a/charts/nzbget/Chart.yaml
+++ b/charts/nzbget/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v21.0
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 5.0.1
+version: 5.0.2
 keywords:
   - nzbget
   - usenet
@@ -17,5 +17,5 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: nzbget

--- a/charts/ombi/Chart.yaml
+++ b/charts/ombi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ombi
 description: Want a Movie or TV Show on Plex or Emby? Use Ombi!
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: 4.0.471
 keywords:
   - ombi
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: ombi
 annotations:
   artifacthub.io/links: |

--- a/charts/ombi/Chart.yaml
+++ b/charts/ombi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ombi
 description: Want a Movie or TV Show on Plex or Emby? Use Ombi!
 type: application
-version: 4.0.3
+version: 5.0.0
 appVersion: 4.0.471
 keywords:
   - ombi
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: 1.1.1
+    version: ^2.0.0
     alias: ombi
 annotations:
   artifacthub.io/links: |

--- a/charts/organizr/Chart.yaml
+++ b/charts/organizr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: organizr
 description: HTPC/Homelab Services Organizer - Written in PHP
 type: application
-version: 1.0.3
+version: 2.0.0
 appVersion: latest
 keywords:
   - organizr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: 1.1.1
+    version: ^2.0.0
     alias: organizr
 annotations:
   artifacthub.io/links: |

--- a/charts/organizr/Chart.yaml
+++ b/charts/organizr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: organizr
 description: HTPC/Homelab Services Organizer - Written in PHP
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: latest
 keywords:
   - organizr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: organizr
 annotations:
   artifacthub.io/links: |

--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.2.5
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 name: qbittorrent
-version: 5.0.1
+version: 5.0.2
 keywords:
   - qbittorrent
   - torrrent
@@ -16,5 +16,5 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: qbittorrent

--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.2.5
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 name: qbittorrent
-version: 5.0.2
+version: 6.0.0
 keywords:
   - qbittorrent
   - torrrent
@@ -16,5 +16,5 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: 1.1.1
+    version: ^2.0.0
     alias: qbittorrent

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: radarr
 description: A fork of Sonarr to work with movies à la Couchpotato
 type: application
-version: 6.0.3
+version: 7.0.0
 appVersion: 3.0.0.3591
 keywords:
   - radarr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: 1.1.1
+    version: ^2.0.0
     alias: radarr
 annotations:
   artifacthub.io/links: |

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: radarr
 description: A fork of Sonarr to work with movies à la Couchpotato
 type: application
-version: 6.0.2
+version: 6.0.3
 appVersion: 3.0.0.3591
 keywords:
   - radarr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: radarr
 annotations:
   artifacthub.io/links: |

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarr
 description: Smart PVR for newsgroup and bittorrent users
 type: application
-version: 6.0.2
+version: 6.0.3
 appVersion: 3.0.3.913
 keywords:
   - sonarr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: sonarr
 annotations:
   artifacthub.io/links: |

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sonarr
 description: Smart PVR for newsgroup and bittorrent users
 type: application
-version: 6.0.3
+version: 7.0.0
 appVersion: 3.0.3.913
 keywords:
   - sonarr
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: 1.1.1
+    version: ^2.0.0
     alias: sonarr
 annotations:
   artifacthub.io/links: |

--- a/charts/tautulli/Chart.yaml
+++ b/charts/tautulli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tautulli
 description: A Python based monitoring and tracking tool for Plex Media Server
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: v2.5.4
 keywords:
   - tautulli
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.0.0
+    version: 1.1.1
     alias: tautulli
 annotations:
   artifacthub.io/links: |

--- a/charts/tautulli/Chart.yaml
+++ b/charts/tautulli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tautulli
 description: A Python based monitoring and tracking tool for Plex Media Server
 type: application
-version: 4.0.3
+version: 5.0.0
 appVersion: v2.5.4
 keywords:
   - tautulli
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: media-common
     repository: https://k8s-at-home.com/charts/
-    version: 1.1.1
+    version: ^2.0.0
     alias: tautulli
 annotations:
   artifacthub.io/links: |


### PR DESCRIPTION
Part 3 of https://github.com/k8s-at-home/charts/pull/96
Objective:
1. Bump all parent versions to new major version and semver match the new 2.0.0 media-common

Charts affected:
- jackett
- lidarr
- nzbget
- ombi
- organizr
- qbittorrent
- radarr
- sonarr
- tautulli