### PR TITLE
[mosquitto] add extraVolumes & extraVolumeMounts support

### DIFF
--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6.12"
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 0.3.3
+version: 0.4.0
 keywords:
   - message queue
   - MQTT

--- a/charts/mosquitto/templates/statefullset.yaml
+++ b/charts/mosquitto/templates/statefullset.yaml
@@ -44,6 +44,7 @@ spec:
               mountPath: /mosquitto/config
             - name: data
               mountPath: /mosquitto/data
+            {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 12 }}{{ end }}
       volumes:
         - name: configmap
           configMap:
@@ -57,6 +58,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim }}
         {{- end }}
+        {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 8 }}{{ end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -74,3 +74,15 @@ persistence:
   size: 5Gi
 
 # customConfig:
+
+# Any extra volumes to define for the pod
+extraVolumes: []
+  # - name: example-name
+  #   hostPath:
+  #     path: /path/on/host
+  #     type: DirectoryOrCreate
+
+# Any extra volume mounts to define for the containers
+extraVolumeMounts: []
+#   - name: example-name
+#     mountPath: /path/in/container


### PR DESCRIPTION
#### Special notes for your reviewer:

This allows to mount extra volumes in the mosquitto pod, for example TLS or password file secrets.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
