### PR TITLE
[zigbee2mqtt] add extraEnv etc., extraVolumes & extraVolumeMounts

### DIFF
--- a/charts/zigbee2mqtt/Chart.yaml
+++ b/charts/zigbee2mqtt/Chart.yaml
@@ -3,7 +3,7 @@ name: zigbee2mqtt
 type: application
 description: Bridges events and allows you to control your Zigbee devices via MQTT
 appVersion: 1.15.0
-version: 2.0.1
+version: 2.1.0
 keywords:
   - zigbee
   - mqtt

--- a/charts/zigbee2mqtt/templates/statefullset.yaml
+++ b/charts/zigbee2mqtt/templates/statefullset.yaml
@@ -41,6 +41,22 @@ spec:
         - name: DEBUG
           value: {{ .Values.debug }}
         {{- end }}
+        {{- range $key, $value := .Values.extraEnv }}
+        - name: {{ $key | quote }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- range $name, $opts := .Values.extraEnvSecrets }}
+        - name: {{ $name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $opts.secret }}
+              key: {{ $opts.key }}
+        {{- end }}
+        envFrom:
+        {{- range .Values.extraSecretForEnvFrom }}
+          - secretRef:
+              name: {{ . }}
+        {{- end }}
         {{- if and .Values.config.frontend .Values.config.experimental }}
         {{- if and .Values.config.frontend.port .Values.config.experimental.new_api }}
         ports:
@@ -59,6 +75,7 @@ spec:
           mountPath: /data
         - name: sniffer
           mountPath: {{ .Values.config.serial.port }}
+        {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 8 }}{{ end }}
       volumes:
       - name: zigbee2mqtt
         configMap:
@@ -75,6 +92,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim }}
       {{- end }}
+      {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 6 }}{{ end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -97,6 +97,28 @@ persistence:
   accessMode: ReadWriteOnce
   size: 100Mi
 
+## Additional zigbee2mqtt container environment variable
+## For instance to add a http_proxy
+##
+extraEnv: {}
+
+## Additional zigbee2mqtt container environment variable from k8s secrets
+## For instance to add a password
+extraEnvSecrets:
+  # Example
+  # This will set ${ZIGBEE2MQTT_CONFIG_MQTT_PASSWORD} to the 'password' key from the 'mqtt' secret
+  # ZIGBEE2MQTT_CONFIG_MQTT_PASSWORD:
+  #   secret: mqtt
+  #   key: password
+
+## If you'd like to provide your own Kubernetes Secret object instead of passing your values
+## individually, pass in the name of a created + populated Secret.
+## All secrets will be mounted as environment variables, with each key/value mapping to a
+## corresponding environment variable.
+##
+extraSecretForEnvFrom: []
+# - zigbee2mqtt-secrets
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -141,3 +163,15 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Any extra volumes to define for the pod
+extraVolumes: []
+  # - name: example-name
+  #   hostPath:
+  #     path: /path/on/host
+  #     type: DirectoryOrCreate
+
+# Any extra volume mounts to define for the containers
+extraVolumeMounts: []
+#   - name: example-name
+#     mountPath: /path/in/container


### PR DESCRIPTION
#### Special notes for your reviewer:

This allows to add extra environment variables and mount extra volumes in the zigbee2mqtt pod, for example TLS files or config overrides (ZIGBEE2MQTT_CONFIG_ environment).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
