### PR TITLE
[home-assistant] Added metricRelabelings for service monitor

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.116.1
 description: Home Assistant
 name: home-assistant
-version: 2.5.2
+version: 2.5.3
 keywords:
 - home-assistant
 - hass

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.116.1
 description: Home Assistant
 name: home-assistant
-version: 2.5.3
+version: 2.6.0
 keywords:
 - home-assistant
 - hass

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -191,6 +191,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `monitoring.serviceMonitor.labels`              | Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator                                                                                                                                           | `{}`                                   |
 | `monitoring.serviceMonitor.bearerTokenFile`     | Set bearerTokenFile for home-assistant auth (use long lived access tokens)                                                                                                                                                                | `nil`                                  |
 | `monitoring.serviceMonitor.bearerTokenSecret`   | Set bearerTokenSecret for home-assistant auth (use long lived access tokens)                                                                                                                                                              | `nil`                                  |
+| `monitoring.serviceMonitor.metricRelabelings`   | Add metricRelabelings [Documentation](https://coreos.com/operators/prometheus/docs/latest/api.html#relabelconfig)                                                                                                                         | `{}`                                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/home-assistant/templates/servicemonitor.yaml
+++ b/charts/home-assistant/templates/servicemonitor.yaml
@@ -27,6 +27,9 @@ spec:
       {{- if .Values.monitoring.serviceMonitor.bearerTokenSecret.optional }}
       optional: {{ .Values.monitoring.serviceMonitor.bearerTokenSecret.optional }}
       {{- end }}
+{{- with .Values.monitoring.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml . | indent 4 }}
 {{- end }}
   jobLabel: {{ template "home-assistant.fullname" . }}-prometheus-exporter
   namespaceSelector:

--- a/charts/home-assistant/templates/servicemonitor.yaml
+++ b/charts/home-assistant/templates/servicemonitor.yaml
@@ -27,9 +27,9 @@ spec:
       {{- if .Values.monitoring.serviceMonitor.bearerTokenSecret.optional }}
       optional: {{ .Values.monitoring.serviceMonitor.bearerTokenSecret.optional }}
       {{- end }}
-{{- with .Values.monitoring.serviceMonitor.metricRelabelings }}
+{{- if .Values.monitoring.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml . | indent 4 }}
+{{ toYaml .Values.monitoring.serviceMonitor.metricRelabelings | indent 4 }}
 {{- end }}
   jobLabel: {{ template "home-assistant.fullname" . }}-prometheus-exporter
   namespaceSelector:

--- a/charts/home-assistant/templates/servicemonitor.yaml
+++ b/charts/home-assistant/templates/servicemonitor.yaml
@@ -27,6 +27,7 @@ spec:
       {{- if .Values.monitoring.serviceMonitor.bearerTokenSecret.optional }}
       optional: {{ .Values.monitoring.serviceMonitor.bearerTokenSecret.optional }}
       {{- end }}
+{{- end }}
 {{- if .Values.monitoring.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ toYaml .Values.monitoring.serviceMonitor.metricRelabelings | indent 4 }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -224,7 +224,18 @@ monitoring:
     # bearerTokenFile:
     # Set bearerTokenSecret for home assistant auth (use long lived access tokens)
     # bearerTokenSecret:
-
+    # Relabel metrics if needed example removes pod and instance labels from metrics beginning with hass
+    metricRelabelings: []
+    #  - regex: hass.*
+    #    replacement: ""
+    #    sourceLabels:
+    #     - __name__
+    #    targetLabel: pod
+    #  - regex: hass_.*
+    #    replacement: ""
+    #    sourceLabels:
+    #     - __name__
+    #    targetLabel: instance
 
 vscode:
   enabled: false

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -225,7 +225,7 @@ monitoring:
     # Set bearerTokenSecret for home assistant auth (use long lived access tokens)
     # bearerTokenSecret:
     # Relabel metrics if needed example removes pod and instance labels from metrics beginning with hass
-    metricRelabelings: []
+    # metricRelabelings: []
     #  - regex: hass.*
     #    replacement: ""
     #    sourceLabels:


### PR DESCRIPTION
#### Special notes for your reviewer:
I want the ability to drop pod and instance labels for home-assistant metrics
See example in values.yaml

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
