### PR TITLE
[unifi] syslog & promtail logging

### DIFF
--- a/charts/unifi/Chart.yaml
+++ b/charts/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 5.12.35
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 1.0.0
+version: 1.1.0
 keywords:
   - ubiquiti
   - unifi

--- a/charts/unifi/README.md
+++ b/charts/unifi/README.md
@@ -86,7 +86,14 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `discoveryService.loadBalancerIP`               | `{}`                         | Loadbalance IP for AP discovery                                                                                        |
 | `discoveryService.loadBalancerSourceRanges`     | None                         | List of IP CIDRs allowed access to load balancer (if supported)                                                        |
 | `discoveryService.externalTrafficPolicy`        | `Cluster`                    | Set the externalTrafficPolicy in the Service to either Cluster or Local                                                |
-| `unifiedService.enabled`                        | `false`                      | Use a single service for GUI, controller, STUN, and discovery                                                          |
+| `syslogService.type`                            | `NodePort`                   | Kubernetes service type for remote syslog capture                                                                      |
+| `syslogService.port`                            | `5514`                       | Kubernetes UDP port for remote syslog capture                                                                          |
+| `syslogService.annotations`                     | `{}`                         | Service annotations for remote syslog capture                                                                          |
+| `syslogService.labels`                          | `{}`                         | Custom labels                                                                                                          |
+| `syslogService.loadBalancerIP`                  | `{}`                         | Loadbalancer IP for remote syslog capture                                                                              |
+| `syslogService.loadBalancerSourceRanges`        | None                         | List of IP CIDRs allowed access to load balancer (if supported)                                                        |
+| `syslogService.externalTrafficPolicy`           | `Cluster`                    | Set the externalTrafficPolicy in the Service to either Cluster or Local                                                |
+| `unifiedService.enabled`                        | `false`                      | Use a single service for GUI, controller, STUN, discovery and syslog                                                   |
 | `unifiedService.type`                           | `ClusterIP`                  | Kubernetes service type for the unified service                                                                        |
 | `unifiedService.annotations`                    | `{}`                         | Annotations for the unified service                                                                                    |
 | `unifiedService.labels`                         | `{}`                         | Custom labels for the unified service                                                                                  |
@@ -108,6 +115,11 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `customCert.certName`                           | `tls.crt`                    | Name of the the certificate file in `<unifi-data>/cert`                                                                |
 | `customCert.keyName`                            | `tls.key`                    | Name of the the private key file in `<unifi-data>/cert`                                                                |
 | `customCert.certSecret`                         | `nil`                        | Name of the the k8s tls secret where the certificate and its key are stored.                                           |
+| `logging.promtail.enabled`                      | `false`                      | Enable a Promtail sidecar to collect controller logs                                                                   |
+| `logging.promtail.image.repository`             | `grafana/promtail`           | Promtail image repository                                                                                              |
+| `logging.promtail.image.tag`                    | `1.6.0`                      | Promtail image tag                                                                                                     |
+| `logging.promtail.image.pullPolicy`             | `IfNotPresent`               | Promtail image pull policy                                                                                             |
+| `logging.promtail.loki.url`                     | `http://loki.logs.svc.cluster.local:3100/loki/api/v1/push` | URL of the Loki push API                                                                 |
 | `mongodb.enabled`                               | `false`                      | Use external MongoDB for data storage                                                                                  |
 | `mongodb.dbUri`                                 | `mongodb://mongo/unifi`      | external MongoDB URI                                                                                                   |
 | `mongodb.statDbUri`                             | `mongodb://mongo/unifi_stat` | external MongoDB statdb URI                                                                                            |
@@ -163,6 +175,9 @@ Read through the [values.yaml](values.yaml) file. It has several commented out s
 - `stunService`: Also used periodically by the unifi devices to communicate
   with the controller using UDP. See [this article][ubnt 3] and [this other
   article][ubnt 4] for more information.
+- `syslogService`: Used to capture syslog from Unifi devices if the feature is 
+  enabled in the site configuration. This needs to be reachable by Unifi devices
+  on port 5514/UDP.
 
 ## Ingress and HTTPS
 

--- a/charts/unifi/templates/deployment.yaml
+++ b/charts/unifi/templates/deployment.yaml
@@ -34,6 +34,21 @@ spec:
       {{- end }}
     spec:
       containers:
+      {{- if .Values.logging.promtail.enabled }}
+        - name: {{ .Chart.Name }}-promtail
+          image: "{{ .Values.logging.promtail.image.repository }}:{{ .Values.logging.promtail.image.tag }}"
+          imagePullPolicy: {{ .Values.logging.promtail.image.pullPolicy }}
+          args:
+          - -config.file=/etc/promtail/promtail.yaml
+          volumeMounts:
+          - name: promtail-config
+            mountPath: /etc/promtail/promtail.yaml
+            subPath: promtail.yaml
+            readOnly: true
+          - mountPath: /unifi/log
+            name: unifi-data
+            subPath: {{ ternary "log" (printf "%s/%s" .Values.persistence.subPath "log") (empty .Values.persistence.subPath) }}
+      {{- end }}      
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -154,6 +169,17 @@ spec:
           secret:
             secretName: "{{ .Values.customCert.certSecret }}"
         {{- end }}
+        {{- if .Values.logging.promtail.enabled }}
+        - name: promtail-config
+          projected:
+            defaultMode: 0444
+            sources:
+            - configMap:
+                name: {{ template "unifi.fullname" . }}-promtail
+                items:
+                  - key: promtail.yaml
+                    path: promtail.yaml
+        {{- end }}        
         {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 8 }}{{ end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/unifi/templates/deployment.yaml
+++ b/charts/unifi/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
             - name: stun
               containerPort: 3478
               protocol: UDP
+            - name: syslog
+              containerPort: 5514
+              protocol: UDP
               {{ if .Values.captivePortalService.enabled }}
             - name: captive-http
               containerPort: 8880

--- a/charts/unifi/templates/promtail-configmap.yaml
+++ b/charts/unifi/templates/promtail-configmap.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.logging.promtail.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "unifi.fullname" . }}-promtail
+  labels:
+    app.kubernetes.io/name: {{ include "unifi.name" . }}
+    helm.sh/chart: {{ include "unifi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  promtail.yaml: |
+    server:
+      disable: true
+    positions:
+      filename: /tmp/positions.yaml
+    clients:
+    - url: {{ .Values.logging.promtail.loki.url }}
+    scrape_configs:
+    - job_name: unifi-logs
+      static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: unifi-logs
+          __path__: "/unifi/log/*.log"
+    - job_name: unifi-remote-logs
+      static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: unifi-remote-logs
+          __path__: "/unifi/log/remote/*.log"
+{{- end }}

--- a/charts/unifi/templates/syslog-svc.yaml
+++ b/charts/unifi/templates/syslog-svc.yaml
@@ -1,0 +1,54 @@
+{{ if not .Values.syslogService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "unifi.fullname" . }}-syslog
+  labels:
+    app.kubernetes.io/name: {{ include "unifi.name" . }}
+    helm.sh/chart: {{ include "unifi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.syslogService.labels }}
+{{ toYaml .Values.syslogService.labels | indent 4 }}
+{{- end }}
+{{- with .Values.syslogService.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.syslogService.type "ClusterIP") (empty .Values.syslogService.type)) }}
+  type: ClusterIP
+  {{- if .Values.syslogService.clusterIP }}
+  clusterIP: {{ .Values.syslogService.clusterIP }}
+  {{end}}
+{{- else if eq .Values.syslogService.type "LoadBalancer" }}
+  type: {{ .Values.syslogService.type }}
+  {{- if .Values.syslogService.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.syslogService.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.syslogService.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.syslogService.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.syslogService.type }}
+{{- end }}
+{{- if .Values.syslogService.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.syslogService.externalIPs | indent 4 }}
+{{- end }}
+  {{- if .Values.syslogService.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.syslogService.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.syslogService.port }}
+      targetPort: syslog
+      protocol: UDP
+      name: syslog
+{{ if (and (eq .Values.syslogService.type "NodePort") (not (empty .Values.syslogService.nodePort))) }}
+      nodePort: {{.Values.syslogService.nodePort}}
+{{ end }}
+  selector:
+    app.kubernetes.io/name: {{ include "unifi.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}

--- a/charts/unifi/templates/unified-svc.yaml
+++ b/charts/unifi/templates/unified-svc.yaml
@@ -62,6 +62,13 @@ spec:
 {{ if (and (eq .Values.unifiedService.type "NodePort") (not (empty .Values.stunService.nodePort))) }}
       nodePort: {{.Values.stunService.nodePort}}
 {{ end }}
+    - port: {{ .Values.syslogService.port }}
+      targetPort: syslog
+      protocol: UDP
+      name: syslog
+{{ if (and (eq .Values.unifiedService.type "NodePort") (not (empty .Values.syslogService.nodePort))) }}
+      nodePort: {{.Values.syslogService.nodePort}}
+{{ end }}
     - name: https-gui
       port: {{ .Values.guiService.port }}
       protocol: TCP

--- a/charts/unifi/values.yaml
+++ b/charts/unifi/values.yaml
@@ -10,10 +10,10 @@ image:
   tag: 5.12.35
   pullPolicy: IfNotPresent
 
-# If enabled, the controller, discovery, GUI, and STUN services will not be
+# If enabled, the controller, discovery, GUI, STUN and syslog services will not be
 # created.
 # Instead, one service will be created with the port and nodePort settings from
-# controllerService, discoveryService, guiService, and stunService.
+# controllerService, discoveryService, guiService, stunService and syslogService.
 # This is useful if, for example, the ClusterIP network is routable and being
 # accessed directly by access points, and the APs don't have a way to discern
 # different services on different IPs.
@@ -151,6 +151,27 @@ stunService:
 discoveryService:
   type: NodePort
   port: 10001  # udp
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+  labels: {}
+  ## Use loadBalancerIP to request a specific static IP,
+  ## otherwise leave blank
+  ##
+  loadBalancerIP:
+  # loadBalancerSourceRanges: []
+  ## Set the externalTrafficPolicy in the Service to either Cluster or Local
+  # externalTrafficPolicy: Cluster
+
+syslogService:
+  type: NodePort
+  port: 5514  # udp
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##

--- a/charts/unifi/values.yaml
+++ b/charts/unifi/values.yaml
@@ -221,6 +221,17 @@ customCert:
   # you can pass the name of that secret using certSecret variable
   # certSecret: unifi-tls
 
+# Logging configuration
+logging:
+  promtail:
+    enabled: false
+    image:
+      repository: grafana/promtail
+      tag: 1.6.0
+      pullPolicy: IfNotPresent
+    loki:
+      url: http://loki.logs.svc.cluster.local:3100/loki/api/v1/push
+
 # define an external mongoDB instead of using the built-in mongodb
 mongodb:
   enabled: false


### PR DESCRIPTION
#### Special notes for your reviewer:
This adds two features:
- `syslogService` to capture syslog from Unifi devices (needs to be enabled in site configuration). Logs from Unifi devices will end up in `/unifi/logs/remote`.
- optional Promtail sidecar for controller logs and remote device logs if available

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
