### PR TITLE
[mosquitto] add Prometheus Exporter as Sidecar Container

### DIFF
--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6.12"
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 0.4.0
+version: 0.5.0
 keywords:
   - message queue
   - MQTT

--- a/charts/mosquitto/ci/sidecar-values.yaml
+++ b/charts/mosquitto/ci/sidecar-values.yaml
@@ -1,0 +1,3 @@
+monitoring:
+  sidecar:
+    enabled: true

--- a/charts/mosquitto/templates/podmonitor.yaml
+++ b/charts/mosquitto/templates/podmonitor.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.monitoring.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+{{ include "mosquitto.labels" . | indent 4 }}
+    {{- if .Values.monitoring.podMonitor.labels }}
+    {{ toYaml .Values.monitoring.podMonitor.labels }}
+    {{- end }}
+  name: {{ template "mosquitto.fullname" . }}-prometheus-exporter
+{{- if .Values.monitoring.podMonitor.namespace }}
+  namespace: {{ .Values.monitoring.podMonitor.namespace }}
+{{- end }}
+spec:
+  podMetricsEndpoints:
+  - port: prometheus
+    path: /metrics
+{{- if .Values.monitoring.podMonitor.interval }}
+    interval: {{ .Values.monitoring.podMonitor.interval }}
+{{- end }}
+{{- if .Values.monitoring.podMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ .Values.monitoring.podMonitor.bearerTokenFile }}
+{{- end }}
+{{- if .Values.monitoring.podMonitor.bearerTokenSecret }}
+    bearerTokenSecret:
+      name: {{ .Values.monitoring.podMonitor.bearerTokenSecret.name }}
+      key: {{ .Values.monitoring.podMonitor.bearerTokenSecret.key }}
+      {{- if .Values.monitoring.podMonitor.bearerTokenSecret.optional }}
+      optional: {{ .Values.monitoring.podMonitor.bearerTokenSecret.optional }}
+      {{- end }}
+{{- end }}
+  jobLabel: {{ template "mosquitto.fullname" . }}-prometheus-exporter
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "mosquitto.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/mosquitto/templates/service.yaml
+++ b/charts/mosquitto/templates/service.yaml
@@ -25,6 +25,12 @@ spec:
       targetPort: websocket
       protocol: TCP
       name: websocket
+    {{- if .Values.monitoring.sidecar.enabled }}
+    - port: {{ .Values.monitoring.sidecar.port }}
+      targetPort: prometheus
+      protocol: TCP
+      name: prometheus
+    {{- end }}      
   selector:
     app.kubernetes.io/name: {{ include "mosquitto.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/mosquitto/templates/statefullset.yaml
+++ b/charts/mosquitto/templates/statefullset.yaml
@@ -25,6 +25,23 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        {{- if .Values.monitoring.sidecar.enabled }}
+        - name: exporter
+          image: "{{ .Values.monitoring.sidecar.image.repository }}:{{ .Values.monitoring.sidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.sidecar.image.pullPolicy }}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          args: 
+{{ toYaml .Values.monitoring.sidecar.args | indent 12 }}
+          env:
+{{ toYaml .Values.monitoring.sidecar.envs | indent 12 }}
+          resources:
+{{ toYaml .Values.monitoring.sidecar.resources | indent 12 }}
+          ports:
+            - containerPort: {{ .Values.monitoring.sidecar.port }}
+              name: prometheus
+              protocol: TCP
+        {{- end }}      
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -86,3 +86,30 @@ extraVolumes: []
 extraVolumeMounts: []
 #   - name: example-name
 #     mountPath: /path/in/container
+
+monitoring:
+  podMonitor:
+    enabled: false
+  sidecar:
+    enabled: false
+    port: 9234
+    args:
+      - "--use-splitted-config"
+    envs:
+      - name: MQTT_CLIENT_ID
+        value: exporter
+      - name: BROKER_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+    image:
+      repository: nolte/mosquitto-exporter
+      tag: v0.6.3
+      pullPolicy: IfNotPresent
+    resources:
+      limits:
+        cpu: 300m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 64Mi


### PR DESCRIPTION
Signed-off-by: nolte <nolte07@googlemail.com>

#### Special notes for your reviewer:

[#100](https://github.com/k8s-at-home/charts/pull/100) as optional Sidecar implementation and, support for create a PodMonitor.

#### Checklist
- [x] Chart Version bumped
~- [ ] Variables are documented in the README.md~
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
