### PR TITLE
[common] Use k8s-at-home wireguard image

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 1.1.0
+version: 1.2.0
 keywords:
   - k8s-at-home
   - common

--- a/charts/common/templates/addons/vpn/openvpn/_container.tpl
+++ b/charts/common/templates/addons/vpn/openvpn/_container.tpl
@@ -5,15 +5,15 @@ The OpenVPN container(s) to be inserted
 name: openvpn
 image: "{{ .Values.addons.vpn.openvpn.image.repository }}:{{ .Values.addons.vpn.openvpn.image.tag }}"
 imagePullPolicy: {{ .Values.addons.vpn.imagePullPolicy }}
+{{- with .Values.addons.vpn.securityContext }}
 securityContext:
-  capabilities:
-    add: 
-      - NET_ADMIN
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with .Values.addons.vpn.env }}
 env:
 {{- range $k, $v := . }}
   - name: {{ $k }}
-    value: {{ $v }}
+    value: {{ $v | quote }}
 {{- end }}
 {{- end }}  
 {{- if or .Values.addons.vpn.openvpn.auth .Values.addons.vpn.openvpn.authSecret }}
@@ -52,10 +52,10 @@ volumeMounts:
 {{- end }}
 {{- with .Values.addons.vpn.livenessProbe }}
 livenessProbe:
-  {{- toYaml . | nindent 4 }}
+  {{- toYaml . | nindent 2 }}
 {{- end -}}
 {{- with .Values.addons.vpn.resources }}
 resources:
-  {{- toYaml . | nindent 4 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end -}}

--- a/charts/common/templates/addons/vpn/wireguard/_addon.tpl
+++ b/charts/common/templates/addons/vpn/wireguard/_addon.tpl
@@ -3,7 +3,7 @@ Template to render Wireguard addon
 */}}
 {{- define "common.addon.wireguard" -}}
   {{/* Append the Wireguard container to the additionalContainers */}}
-  {{- $container := include "common.addon.wireguard.container" . | fromYaml -}}
+  {{- $container := fromYaml (include "common.addon.wireguard.container" .) -}}
   {{- if $container -}}
     {{- $additionalContainers := append .Values.additionalContainers $container -}}
     {{- $_ := set .Values "additionalContainers" $additionalContainers -}}

--- a/charts/common/templates/addons/vpn/wireguard/_container.tpl
+++ b/charts/common/templates/addons/vpn/wireguard/_container.tpl
@@ -5,24 +5,22 @@ The Wireguard container(s) to be inserted
 name: wireguard
 image: "{{ .Values.addons.vpn.wireguard.image.repository }}:{{ .Values.addons.vpn.wireguard.image.tag }}"
 imagePullPolicy: {{ .Values.addons.vpn.imagePullPolicy }}
+{{- with .Values.addons.vpn.securityContext }}
 securityContext:
-  privileged: true
-  capabilities:
-    add: 
-      - NET_ADMIN
-      - SYS_MODULE
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with .Values.addons.vpn.env }}
 env:
 {{- range $k, $v := . }}
   - name: {{ $k }}
-    value: {{ $v }}
+    value: {{ $v | quote }}
 {{- end }}
 {{- end }}
 {{- if or .Values.addons.vpn.configFile .Values.addons.vpn.scripts.up .Values.addons.vpn.scripts.down .Values.addons.vpn.additionalVolumeMounts .Values.persistence.shared.enabled }}
 volumeMounts:
 {{- if .Values.addons.vpn.configFile }}
   - name: vpnconfig
-    mountPath: /config/wg0.conf
+    mountPath: /etc/wireguard/wg0.conf
     subPath: vpnConfigfile
 {{- end }}
 {{- if .Values.addons.vpn.scripts.up }}
@@ -45,10 +43,10 @@ volumeMounts:
 {{- end }}
 {{- with .Values.addons.vpn.livenessProbe }}
 livenessProbe:
-  {{- toYaml . | nindent 4 }}
+  {{- toYaml . | nindent 2 }}
 {{- end -}}
 {{- with .Values.addons.vpn.resources }}
 resources:
-  {{- toYaml . | nindent 4 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end -}}

--- a/charts/common/templates/lib/controller/_volumes.tpl
+++ b/charts/common/templates/lib/controller/_volumes.tpl
@@ -6,15 +6,15 @@ volumes included by the controller
 {{- if $persistence.enabled }}
 - name: {{ $index }}
 {{- if $persistence.existingClaim }}
-{{/* Always prefer an existingClaim if that is set */}}
+{{- /* Always prefer an existingClaim if that is set */}}
   persistentVolumeClaim:
     claimName: {{ $persistence.existingClaim }}
 {{- else -}}
   {{- if $persistence.emptyDir -}}
-  {{/* Always prefer an emptyDir next if that is set */}}
+  {{- /* Always prefer an emptyDir next if that is set */}}
   emptyDir: {}
   {{- else -}}
-  {{/* Otherwise refer to the PVC name */}}
+  {{- /* Otherwise refer to the PVC name */}}
   persistentVolumeClaim:
     {{- if $persistence.nameSuffix }}
     claimName: {{ printf "%s-%s" (include "common.names.fullname" $) $persistence.nameSuffix }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -154,13 +154,20 @@ addons:
       # under the VPN_AUTH key
       authSecret:  # my-vpn-secret
 
-    # OpenVPN specific configuration
+    # WireGuard specific configuration
     wireguard:
       image:
-        repository: linuxserver/wireguard
-        tag: version-v1.0.20200827
+        repository: k8sathome/wireguard
+        tag: 1.0.20200827
 
     imagePullPolicy: IfNotPresent
+
+    # Set the VPN container securityContext
+    securityContext:
+      capabilities:
+        add: 
+          - NET_ADMIN
+          - SYS_MODULE
 
     # All variables specified here will be added to the vpn sidecar container
     # See the documentation of the VPN image for all config values


### PR DESCRIPTION
#### Special notes for your reviewer:
- Use the k8s-at-home wireguard image
- Make VPN container securityContext configurable
- Clean up some small indenting/quotation issues

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
