### PR TITLE
[common] Read and the service ports correctly

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 1.5.0
+version: 1.5.1
 keywords:
   - k8s-at-home
   - common

--- a/charts/common/templates/classes/_service.tpl
+++ b/charts/common/templates/classes/_service.tpl
@@ -1,3 +1,6 @@
+{{/*
+service class: all services should adhere to this
+*/}}
 {{- define "common.classes.service" -}}
 {{- $values := .Values.service -}}
 {{- if hasKey . "ObjectValues" -}}
@@ -9,7 +12,7 @@
 {{- if hasKey $values "nameSuffix" -}}
   {{- $serviceName = printf "%v-%v" $serviceName $values.nameSuffix -}}
 {{ end -}}
-{{- $svcType := $values.type -}}
+{{- $svcType := $values.type | default "" -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -58,17 +61,31 @@ spec:
   {{- if $values.publishNotReadyAddresses }}
   publishNotReadyAddresses: {{ $values.publishNotReadyAddresses }}
   {{- end }}
-  ports:
-    - port: {{ $values.port.port }}
-      targetPort: {{ $values.port.targetPort }}
-      protocol: {{ $values.port.protocol }}
-      name: {{ $values.port.name }}
-      {{- if (and (eq $svcType "NodePort") (not (empty $values.port.nodePort))) }}
-      nodePort: {{ $values.port.nodePort }}
-      {{ end }}
-    {{- with $values.additionalPorts }}
-    {{ toYaml . | nindent 4 }}
-    {{- end }}
+  {{- include "common.classes.service.ports" (dict "svcType" $svcType "values" $values ) | trim | nindent 2 }}
   selector:
     {{- include "common.labels.selectorLabels" . | nindent 4 }}
+{{- end }}
+
+{{/*
+logic that lists the ports and additionalPorts for a service
+*/}}
+{{- define "common.classes.service.ports" -}}
+  {{- $ports := list -}}
+  {{- $values := .values -}}
+  {{- $ports = mustAppend $ports $values.port -}}
+  {{- range $_ := $values.additionalPorts -}}
+    {{- $ports = mustAppend $ports . -}}
+  {{- end }}
+  {{- if $ports -}}
+  ports:
+  {{- range $_ := $ports }}
+  - port: {{ .port }}
+    targetPort: {{ .targetPort | default .name }}
+    protocol: {{ .protocol | default "TCP" }}
+    name: {{ .name }}
+    {{- if (and (eq $.svcType "NodePort") (not (empty .nodePort))) }}
+    nodePort: {{ .nodePort }}
+    {{ end }}
+  {{- end -}}
+  {{- end -}}
 {{- end }}

--- a/charts/common/templates/classes/_service.tpl
+++ b/charts/common/templates/classes/_service.tpl
@@ -65,27 +65,3 @@ spec:
   selector:
     {{- include "common.labels.selectorLabels" . | nindent 4 }}
 {{- end }}
-
-{{/*
-logic that lists the ports and additionalPorts for a service
-*/}}
-{{- define "common.classes.service.ports" -}}
-  {{- $ports := list -}}
-  {{- $values := .values -}}
-  {{- $ports = mustAppend $ports $values.port -}}
-  {{- range $_ := $values.additionalPorts -}}
-    {{- $ports = mustAppend $ports . -}}
-  {{- end }}
-  {{- if $ports -}}
-  ports:
-  {{- range $_ := $ports }}
-  - port: {{ .port }}
-    targetPort: {{ .targetPort | default .name }}
-    protocol: {{ .protocol | default "TCP" }}
-    name: {{ .name }}
-    {{- if (and (eq $.svcType "NodePort") (not (empty .nodePort))) }}
-    nodePort: {{ .nodePort }}
-    {{ end }}
-  {{- end -}}
-  {{- end -}}
-{{- end }}

--- a/charts/common/templates/classes/_service_ports.tpl
+++ b/charts/common/templates/classes/_service_ports.tpl
@@ -1,0 +1,23 @@
+{{/*
+logic that lists the ports and additionalPorts for a service
+*/}}
+{{- define "common.classes.service.ports" -}}
+  {{- $ports := list -}}
+  {{- $values := .values -}}
+  {{- $ports = mustAppend $ports $values.port -}}
+  {{- range $_ := $values.additionalPorts -}}
+    {{- $ports = mustAppend $ports . -}}
+  {{- end }}
+  {{- if $ports -}}
+  ports:
+  {{- range $_ := $ports }}
+  - port: {{ .port }}
+    targetPort: {{ .targetPort | default .name }}
+    protocol: {{ .protocol | default "TCP" }}
+    name: {{ .name }}
+    {{- if (and (eq $.svcType "NodePort") (not (empty .nodePort))) }}
+    nodePort: {{ .nodePort }}
+    {{ end }}
+  {{- end -}}
+  {{- end -}}
+{{- end }}

--- a/charts/common/templates/lib/controller/_container.tpl
+++ b/charts/common/templates/lib/controller/_container.tpl
@@ -1,4 +1,6 @@
-{{- /* The main containter that will be included in the controller */ -}}
+{{- /*
+The main containter that will be included in the controller 
+*/ -}}
 {{- define "common.controller.mainContainer" -}}
 - name: {{ template "common.names.fullname" . }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -14,15 +16,7 @@
     value: {{ $value | quote }}
   {{- end }}
   {{- end }}
-  ports:
-  - name: {{ .Values.service.port.name }}
-    containerPort: {{ .Values.service.port.port }}
-    protocol: {{ .Values.service.port.protocol }}
-  {{- range $port := .Values.service.additionalPorts }}
-  - name: {{ $port.name }}
-    containerPort: {{ $port.port }}
-    protocol: {{ $port.protocol }}
-  {{- end }}
+  {{- include "common.controller.ports" . | trim | nindent 2 }}
   volumeMounts:
   {{- range $index, $PVC := .Values.persistence }}
   {{- if $PVC.enabled }}

--- a/charts/common/templates/lib/controller/_ports.tpl
+++ b/charts/common/templates/lib/controller/_ports.tpl
@@ -1,0 +1,36 @@
+{{/*
+ports included by the controller
+*/}}
+{{- define "common.controller.ports" -}}
+  {{- $ports := list -}}
+  {{- with .Values.service -}}
+    {{- $serviceValues := deepCopy . -}}
+    {{/* append the ports for the main service */}}
+    {{- if .enabled -}}
+      {{- $ports = mustAppend $ports .port -}}
+      {{- range $_ := .additionalPorts -}}
+        {{/* append the additonalPorts for the main service */}}
+        {{- $ports = mustAppend $ports . -}}
+      {{- end }}
+    {{- end }}
+    {{/* append the ports for each additional service */}}
+    {{- range $_ := .additionalServices }}
+      {{- if .enabled -}}
+        {{- $ports = mustAppend $ports .port -}}
+        {{- range $_ := .additionalPorts -}}
+          {{/* append the additonalPorts for each additional service */}}
+          {{- $ports = mustAppend $ports . -}}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{/* export/render the list of ports */}}
+  {{- if $ports -}}
+  ports:
+  {{- range $_ := $ports }}
+  - name: {{ required "Missing port.name" .name }}
+    containerPort: {{ required "Missing port.port" .port }}
+    protocol: {{ .protocol | default "TCP" }}
+  {{- end -}}
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
#### Special notes for your reviewer:
Should fix #169

One edge case remains but I don't think we should build for it: if multiple ports would have the same name, the container spec will contain duplicate port names, which is not allowed.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
