### PR TITLE
[unifi] Add jvmInitHeapSize and jvmMaxHeapSize configuration

### DIFF
--- a/charts/unifi/Chart.yaml
+++ b/charts/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 5.14.23
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 1.2.0
+version: 1.3.0
 keywords:
   - ubiquiti
   - unifi

--- a/charts/unifi/README.md
+++ b/charts/unifi/README.md
@@ -141,6 +141,8 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `persistence.accessModes`                       | `[]`                         | Persistence access modes                                                                                               |
 | `extraConfigFiles`                              | `{}`                         | Dictionary containing files mounted to `/configmap` inside the pod (See [values.yaml](values.yaml) for examples)       |
 | `extraJvmOpts`                                  | `[]`                         | List of additional JVM options, e.g. `["-Dlog4j.configurationFile=file:/configmap/log4j2.xml"]`                        |
+| `jvmInitHeapSize`                               | ``                           | Java Virtual Machine (JVM) initial, and minimum, heap size.                                                            |
+| `jvmMaxHeapSize`                                | `1024M`                      | Java Virtual Machine (JVM) maximum heap size.                                                                          |
 | `resources`                                     | `{}`                         | CPU/Memory resource requests/limits                                                                                    |
 | `livenessProbe.enabled`                         | `true`                       | Turn on and off liveness probe                                                                                         |
 | `livenessProbe.initialDelaySeconds`             | `30`                         | Delay before liveness probe is initiated                                                                               |

--- a/charts/unifi/templates/deployment.yaml
+++ b/charts/unifi/templates/deployment.yaml
@@ -126,6 +126,14 @@ spec:
             - name: JVM_EXTRA_OPTS
               value: "{{- join " " .Values.extraJvmOpts }}"
             {{- end }}
+            {{- if .Values.jvmInitHeapSize }}
+            - name: JVM_INIT_HEAP_SIZE
+              value: "{{ .Values.jvmInitHeapSize }}"
+            {{- end }}
+            {{- if .Values.jvmMaxHeapSize }}
+            - name: JVM_MAX_HEAP_SIZE
+              value: "{{ .Values.jvmMaxHeapSize }}"
+            {{- end }}
             {{- if .Values.mongodb.enabled }}
             - name: DB_URI
               value: "{{ .Values.mongodb.dbUri }}"

--- a/charts/unifi/values.yaml
+++ b/charts/unifi/values.yaml
@@ -300,6 +300,15 @@ extraJvmOpts: []
   # - "-Dlog4j.configurationFile=file:/configmap/log4j2.xml"
   # - "-Dsystem_ip=1.2.3.4"
 
+## Java Virtual Machine (JVM) initial, and minimum, heap size
+## Unset value means there is no lower limit
+jvmInitHeapSize:
+
+## Java Virtual Machine (JVM) maximum heap size
+## For larger installations a larger value is recommended.
+## For memory constrained system this value can be lowered.
+jvmMaxHeapSize: 1024M
+
 extraConfigFiles: {}
   ## Specify additional config files which are mounted to /configmap
   ## Here is an example for a custom log4j config:


### PR DESCRIPTION
* Add jvmInitHeapSize and jvmMaxHeapSize which are passed on
  to the container as env vars

* Bump version, no change in default behaviour

* Update README.md with new configuration parameters

Signed-off-by: Thomas Ingvarsson <ingvarsson.thomas@gmail.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
