### PR TITLE
[unifi] Fix speedtest container port

### DIFF
--- a/charts/unifi/Chart.yaml
+++ b/charts/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 5.14.23
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 1.3.0
+version: 1.3.1
 keywords:
   - ubiquiti
   - unifi

--- a/charts/unifi/templates/deployment.yaml
+++ b/charts/unifi/templates/deployment.yaml
@@ -68,17 +68,17 @@ spec:
             - name: syslog
               containerPort: 5514
               protocol: UDP
-              {{ if .Values.captivePortalService.enabled }}
+            {{- if .Values.captivePortalService.enabled }}
             - name: captive-http
               containerPort: 8880
               protocol: TCP
             - name: captive-https
               containerPort: 8843
               protocol: TCP
+            {{- end }}
             - name: speedtest
               containerPort: 6789
               protocol: TCP
-              {{ end }}
           {{- if not .Values.runAsRoot }}
           securityContext:
             capabilities:


### PR DESCRIPTION
#### Special notes for your reviewer:
The recently introduced speedtest service in PR #148 specified the container port inside the conditional for `captivePortalService`. This changes fixes this.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[radarr]`)
