### PR TITLE
[multi-chart] bump charts to latest common library version

### DIFF
--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.9.0.5
 description: Bazarr is a companion application to Sonarr and Radarr. It manages and downloads subtitles based on your requirements
 name: bazarr
-version: 4.4.0
+version: 4.6.0
 keywords:
   - bazarr
   - radarr
@@ -21,4 +21,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/bazarr/OWNERS
+++ b/charts/bazarr/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/bazarr/README.md
+++ b/charts/bazarr/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [Bazarr](https://github.com/morpheus65535/bazarr).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -35,7 +37,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install bazarr \
-  --set env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/bazarr
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/couchpotato/Chart.yaml
+++ b/charts/couchpotato/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: latest
 description: CouchPotato (CP) is an automatic NZB and torrent downloader.
 name: couchpotato
-version: 3.0.0
+version: 3.1.0
 keywords:
   - couchpotato
   - usenet
@@ -18,4 +18,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/couchpotato/OWNERS
+++ b/charts/couchpotato/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/couchpotato/README.md
+++ b/charts/couchpotato/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [couchpotato](https://github.com/CouchPotato/CouchPotatoServer).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell

--- a/charts/ddclient/Chart.yaml
+++ b/charts/ddclient/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3.9.1
 description: Perl client used to update dynamic DNS entries for accounts on Dynamic DNS Network Service Providers
 name: ddclient
-version: 1.0.0
+version: 1.1.0
 keywords:
   - ddclient
   - dns
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.1
+    version: ^1.6.1

--- a/charts/ddclient/OWNERS
+++ b/charts/ddclient/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/ddclient/README.md
+++ b/charts/ddclient/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [ddclient](https://github.com/ddclient/ddclient).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell

--- a/charts/flood/Chart.yaml
+++ b/charts/flood/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.1.1
 description: Flood is a monitoring service for various torrent clients
 name: flood
-version: 1.0.1
+version: 1.1.0
 keywords:
   - flood
   - rtorrent
@@ -19,4 +19,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.1
+    version: ^1.6.1

--- a/charts/flood/OWNERS
+++ b/charts/flood/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/flood/README.md
+++ b/charts/flood/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [flood](https://github.com/jesec/flood).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 10.6.4
 description: Jellyfin is a Free Software Media System
 name: jellyfin
-version: 3.0.0
+version: 3.1.0
 keywords:
   - jellyfin
   - plex
@@ -18,4 +18,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/jellyfin/OWNERS
+++ b/charts/jellyfin/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [Jellyfin](https://github.com/jellyfin/jellyfin).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.8.0.1886
 description: Looks and smells like Sonarr but made for music
 name: lidarr
-version: 5.4.0
+version: 5.5.0
 keywords:
   - lidarr
   - torrent
@@ -18,4 +18,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/lidarr/OWNERS
+++ b/charts/lidarr/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/lidarr/README.md
+++ b/charts/lidarr/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [Lidarr](https://github.com/lidarr/Lidarr).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -35,7 +37,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install lidarr \
-  --set lidarr.env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/lidarr
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/node-red/Chart.yaml
+++ b/charts/node-red/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.5
 description: Node-RED is low-code programming for event-driven applications
 name: node-red
-version: 4.0.0
+version: 4.1.0
 keywords:
   - nodered
   - node-red
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.1
+    version: ^1.6.1

--- a/charts/node-red/OWNERS
+++ b/charts/node-red/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/node-red/README.md
+++ b/charts/node-red/README.md
@@ -2,7 +2,7 @@
 
 This is a helm chart for [Node-Red](https://nodered.org/).
 
-**This chart is not maintained by the Node-RED project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new)**
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
 
 ## TL;DR;
 

--- a/charts/nzbget/Chart.yaml
+++ b/charts/nzbget/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v21.0
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 6.4.0
+version: 6.5.0
 keywords:
   - nzbget
   - usenet
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/nzbget/OWNERS
+++ b/charts/nzbget/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/nzbget/README.md
+++ b/charts/nzbget/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [NZBGet](https://nzbget.net/).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -40,7 +42,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install nzbget \
-  --set env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/nzbget
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/nzbhydra2/Chart.yaml
+++ b/charts/nzbhydra2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v3.4.3
 description: Usenet meta search
 name: nzbhydra2
-version: 4.4.0
+version: 4.5.0
 keywords:
   - nzbhydra2
   - usenet
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/nzbhydra2/OWNERS
+++ b/charts/nzbhydra2/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/nzbhydra2/README.md
+++ b/charts/nzbhydra2/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [Nzbhydra2](https://github.com/theotherp/nzbhydra2).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -35,7 +37,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install nzbhydra2 \
-  --set env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/nzbhydra2
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/organizr/Chart.yaml
+++ b/charts/organizr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: latest
 description: HTPC/Homelab Services Organizer
 name: organizr
-version: 2.4.0
+version: 2.5.0
 keywords:
   - organizr
 home: https://github.com/k8s-at-home/charts/tree/master/charts/organizr
@@ -16,4 +16,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/organizr/OWNERS
+++ b/charts/organizr/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/organizr/README.md
+++ b/charts/organizr/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [Organizr](https://github.com/causefx/Organizr).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -35,7 +37,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install organizr \
-  --set env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/organizr
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/piaware/Chart.yaml
+++ b/charts/piaware/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v4.0
 description: Program for forwarding ADS-B data to FlightAware
 name: piaware
-version: 3.0.0
+version: 3.1.0
 keywords:
   - piaware
   - flight-aware
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/piaware/OWNERS
+++ b/charts/piaware/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/piaware/README.md
+++ b/charts/piaware/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [piaware](https://github.com/flightaware/piaware).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell

--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.20.4.3517-ab5e1197c
 description: Plex Media Server
 name: plex-media-server
-version: 0.0.1
+version: 0.0.2
 keywords:
   - plex
   - plex-media-server
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.1
+    version: ^1.6.1

--- a/charts/plex-media-server/OWNERS
+++ b/charts/plex-media-server/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -3,3 +3,5 @@
 **Do not use this chart, this is currently for testing bringing in the common library and using the k8s-at-home container image**
 
 Be sure to use the [plex](https://github.com/k8s-at-home/charts/tree/master/charts/plex) chart instead.
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**

--- a/charts/qbittorrent/Chart.yaml
+++ b/charts/qbittorrent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.3.0
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 name: qbittorrent
-version: 6.4.0
+version: 6.5.0
 keywords:
   - qbittorrent
   - torrrent
@@ -16,4 +16,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/qbittorrent/OWNERS
+++ b/charts/qbittorrent/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/qbittorrent/README.md
+++ b/charts/qbittorrent/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [qbittorrent](https://qbittorrent.org/).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -39,7 +41,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install my-release \
-  --set env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/qbittorrent
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3.0.0.3989
 description: A fork of Sonarr to work with movies à la Couchpotato
 name: radarr
-version: 7.4.0
+version: 7.5.0
 keywords:
   - radarr
   - torrent
@@ -18,4 +18,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/radarr/OWNERS
+++ b/charts/radarr/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/radarr/README.md
+++ b/charts/radarr/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [Radarr](https://github.com/Radarr/Radarr).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -35,7 +37,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install radarr \
-  --set radarr.env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/radarr
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3.1.0
 description: Free and easy binary newsreader
 name: sabnzbd
-version: 3.4.0
+version: 3.5.0
 keywords:
   - sabnzbd
   - usenet
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/sabnzbd/OWNERS
+++ b/charts/sabnzbd/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/sabnzbd/README.md
+++ b/charts/sabnzbd/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [Sabnzbd](https://github.com/sabnzbd/sabnzbd).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -35,7 +37,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install sabnzbd \
-  --set env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/sabnzbd
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3.0.4.993
 description: Smart PVR for newsgroup and bittorrent users
 name: sonarr
-version: 7.4.0
+version: 7.5.0
 keywords:
   - sonarr
   - torrent
@@ -18,4 +18,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/sonarr/OWNERS
+++ b/charts/sonarr/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/sonarr/README.md
+++ b/charts/sonarr/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [Sonarr](https://github.com/Sonarr/Sonarr).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -35,7 +37,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install sonarr \
-  --set sonarr.env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/sonarr
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/tautulli/Chart.yaml
+++ b/charts/tautulli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.6.1
 description: A Python based monitoring and tracking tool for Plex Media Server
 name: tautulli
-version: 5.4.0
+version: 5.5.0
 keywords:
   - tautulli
   - plex
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/tautulli/OWNERS
+++ b/charts/tautulli/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/tautulli/README.md
+++ b/charts/tautulli/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [Tautulli](https://github.com/Tautulli/Tautulli).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -35,7 +37,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install tautulli \
-  --set env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/tautulli
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/unifi-poller/Chart.yaml
+++ b/charts/unifi-poller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.1
 description: Collect ALL UniFi Controller, Site, Device & Client Data - Export to InfluxDB or Prometheus
 name: unifi-poller
-version: 3.0.0
+version: 3.1.0
 keywords:
   - unifi
   - unifi-poller
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/unifi-poller/OWNERS
+++ b/charts/unifi-poller/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/unifi-poller/README.md
+++ b/charts/unifi-poller/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [unifi-poller](https://github.com/unifi-poller/unifi-poller).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell

--- a/charts/xteve/Chart.yaml
+++ b/charts/xteve/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.1.2.0120
 description: M3U Proxy for Plex DVR and Emby Live TV.
 name: xteve
-version: 3.0.0
+version: 3.1.0
 keywords:
   - xteve
   - iptv
@@ -19,4 +19,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/xteve/OWNERS
+++ b/charts/xteve/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/xteve/README.md
+++ b/charts/xteve/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [xTeVe](https://github.com/xteve-project/xTeVe).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell
@@ -35,7 +37,7 @@ Additionally you can take a look at the common library [values.yaml](https://git
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 ```console
 helm install xteve \
-  --set env.TZ="America/New York" \
+  --set env.TZ="America/New_York" \
     k8s-at-home/xteve
 ```
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/charts/zigbee2mqtt/Chart.yaml
+++ b/charts/zigbee2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.16.1
 description: Bridges events and allows you to control your Zigbee devices via MQTT
 name: zigbee2mqtt
-version: 3.0.1
+version: 3.1.0
 keywords:
   - zigbee
   - mqtt
@@ -19,4 +19,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.1
+    version: ^1.6.1

--- a/charts/zigbee2mqtt/OWNERS
+++ b/charts/zigbee2mqtt/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/zigbee2mqtt/README.md
+++ b/charts/zigbee2mqtt/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [zigbee2mqtt](https://www.zigbee2mqtt.io).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell

--- a/charts/zwave2mqtt/Chart.yaml
+++ b/charts/zwave2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.6
 description: Fully configurable Zwave to MQTT gateway and Control Panel using NodeJS and Vue
 name: zwave2mqtt
-version: 5.1.0
+version: 5.2.0
 keywords:
   - zwave
   - mqtt
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: ^1.5.0
+    version: ^1.6.1

--- a/charts/zwave2mqtt/OWNERS
+++ b/charts/zwave2mqtt/OWNERS
@@ -1,4 +1,8 @@
 approvers:
 - billimek
+- onedr0p
+- bjw-s
 reviewers:
 - billimek
+- onedr0p
+- bjw-s

--- a/charts/zwave2mqtt/README.md
+++ b/charts/zwave2mqtt/README.md
@@ -2,6 +2,8 @@
 
 This is a helm chart for [zwave2mqtt](https://zwave2mqtt.org/).
 
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
 ## TL;DR;
 
 ```shell


### PR DESCRIPTION
#### Special notes for your reviewer:

- bumped common library to 1.6.1
- bumped all charts by minor version
- zigbee2mqtt will expectedly fail due to the "USB device not found" issue
- Disclaimer added to the charts about upstream projects
- updated OWNERS file to include bjw-s and myself
- left out jackett and ombi, these 2 were covered in other PRs

For real closes https://github.com/k8s-at-home/charts/issues/183

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
