### PR TITLE
[workflow] update linting and release workflows

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,8 +1,10 @@
+remote: origin
+target-branch: master
 helm-extra-args: --timeout 600s
 chart-dirs:
   - charts
+excluded-charts:
+  - common
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
   - k8s-at-home=https://k8s-at-home.com/charts
-excluded-charts:
-  - common

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -30,9 +30,11 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
+
       - name: Run chart-testing (lint)
         id: lint
         run: ct lint --config .github/ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.1.0
@@ -40,3 +42,4 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --config .github/ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,28 +1,42 @@
 name: Lint and Test Charts
+
 on: pull_request
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Fetch history
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
         run: |
-          git fetch --prune --unshallow;
-          echo "commitmsg=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
+          changed=$(ct list-changed --config .github/ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v1.0.0
-        if: "! contains(env.commitmsg, '[skip lint]')"
-        with:
-          command: lint
-          config: ct.yaml
+        run: ct lint --config .github/ct.yaml
+
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
-        if: "steps.lint.outputs.changed == 'true' && ! contains(env.commitmsg, '[skip install]')"
+        uses: helm/kind-action@v1.1.0
+        if: steps.list-changed.outputs.changed == 'true'
+
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0
-        if: "steps.lint.outputs.changed == 'true' && ! contains(env.commitmsg, '[skip install]')"
-        with:
-          command: install
-          config: ct.yaml
+        run: ct install --config .github/ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
@@ -53,12 +54,17 @@ jobs:
           ref: "gh-pages"
           fetch-depth: 0
 
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Commit and push timestamp updates
         run: |
-          git config --global user.email "$GITHUB_ACTOR"
-          git config --global user.name "$GITHUB_ACTOR@users.noreply.github.com"
-          export generated_date=$(date --utc +%FT%T.%9NZ)
-          sed -i -e "s/^generated:.*/generated: \"$generated_date\"/" index.yaml
-          git add index.yaml
-          git commit -sm "Update generated timestamp [ci-skip]" || exit 0
-          git push
+          if [[ -f index.yaml ]]; then
+            export generated_date=$(date --utc +%FT%T.%9NZ)
+            sed -i -e "s/^generated:.*/generated: \"$generated_date\"/" index.yaml
+            git add index.yaml
+            git commit -sm "Update generated timestamp [ci-skip]" || exit 0
+            git push
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,11 @@
-
 name: Release Charts
 
 on:
   push:
     branches:
       - master
+    paths:
+      - "charts/**"
 
 jobs:
   release:
@@ -13,33 +14,51 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Turnstyle
         uses: softprops/turnstyle@v1
         with:
           continue-after-seconds: 180
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}
 
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      # See https://github.com/helm/chart-releaser-action/issues/6
       - name: Install Helm
-        run: |
-          curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-          chmod 700 get_helm.sh
-          ./get_helm.sh
-      - name: Add dependency chart repos
-        run: |
-          helm repo add stable https://charts.helm.sh/stable
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0
+        uses: helm/chart-releaser-action@v1.1.0
         with:
           charts_repo_url: https://k8s-at-home.com/charts/
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+  
+  # Update the generated timestamp in the index.yaml
+  # needed until https://github.com/helm/chart-releaser/issues/90
+  # or helm/chart-releaser-action supports this
+  post-release:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: "gh-pages"
+          fetch-depth: 0
+
+      - name: Commit and push timestamp updates
+        run: |
+          git config --global user.email "$GITHUB_ACTOR"
+          git config --global user.name "$GITHUB_ACTOR@users.noreply.github.com"
+          export generated_date=$(date --utc +%FT%T.%9NZ)
+          sed -i -e "s/^generated:.*/generated: \"$generated_date\"/" index.yaml
+          git add index.yaml
+          git commit -sm "Update generated timestamp [ci-skip]" || exit 0
+          git push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           continue-after-seconds: 180
         env:
-          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -38,7 +38,7 @@ jobs:
         with:
           charts_repo_url: https://k8s-at-home.com/charts/
         env:
-          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   
   # Update the generated timestamp in the index.yaml
   # needed until https://github.com/helm/chart-releaser/issues/90


### PR DESCRIPTION
#### Special notes for your reviewer:

- moved `ct.yaml` to `.github` directory
- updated linting workflow and bumped `helm/chart-testing-action` to `v2.0.1`
- updated release workflow and bumped `helm/chart-releaser-action` to `v1.1.0`
- added job after release job to update `generated` timestamp in `index.yaml` in the `gh-pages` branch

Minor issue with `helm/chart-releaser-action` is this issue https://github.com/helm/chart-releaser-action/issues/61 however I didn't see this behavior in our tests