### PR TITLE
[traefik-forward-auth] Add cookie secret to values

### DIFF
--- a/charts/traefik-forward-auth/Chart.yaml
+++ b/charts/traefik-forward-auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik-forward-auth
 description: A minimal forward authentication service that provides OAuth/SSO login and authentication for the traefik reverse proxy/load balancer
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: 2.2.0
 keywords:
   - traefik

--- a/charts/traefik-forward-auth/README.md
+++ b/charts/traefik-forward-auth/README.md
@@ -61,6 +61,7 @@ helm install traefik-forward-auth k8s-at-home/traefik-forward-auth --values valu
 | cookie.domain | string | `""` | Domain(s) to set auth cookie on. (Comma delimited) |
 | cookie.insecure | string | `""` | Use insecure cookies |
 | cookie.name | string | `""` | Cookie Name (default: _forward_auth) |
+| cookie.secret | string| `""` | Cookie Secret - useful when running multiple instances |
 | default.action | string | `""` | [auth|allow] Default action (default: auth) |
 | default.provider | string | `""` | [google|oidc|generic-oauth] Default provider (default: google) |
 | env | list | `[]` |  |

--- a/charts/traefik-forward-auth/templates/deployment.yaml
+++ b/charts/traefik-forward-auth/templates/deployment.yaml
@@ -95,6 +95,13 @@ spec:
             - name: URL_PATH
               value: {{ .Values.urlPath | quote }}
             {{- end }}
+            {{- if .Values.cookie.secret }}
+            - name: COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $fullName }}
+                  key: cookie-secret
+            {{- end }}
             {{- if ne .Values.secret "-" }}
             - name: SECRET
               {{- if .Values.secret }}

--- a/charts/traefik-forward-auth/templates/secret.yaml
+++ b/charts/traefik-forward-auth/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (ne .Values.secret "-") (not .Values.secret) }}
+{{- if or (and (ne .Values.secret "-") (not .Values.secret)) .Values.cookie.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,5 +7,10 @@ metadata:
   {{- include "traefik-forward-auth.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if not .Values.secret }}
   secret: {{ randAlphaNum 16 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.cookie.secret }}
+  cookie-secret: {{ .Values.cookie.secret | b64enc | quote }}
+  {{- end }}
   {{- end }}

--- a/charts/traefik-forward-auth/values.yaml
+++ b/charts/traefik-forward-auth/values.yaml
@@ -35,6 +35,8 @@ cookie:
   name: ""
   # cookie.csrfName -- CSRF Cookie Name (default: _forward_auth_csrf)
   csrfName: ""
+  # cookie.secret -- Cookie Secret used for authentication across multiple instances / clusters (default: randomly generated)
+  secret: ""
 default:
   # default.action -- [auth|allow] Default action (default: auth)
   action: ""


### PR DESCRIPTION
#### Special notes for your reviewer:

Cookie-secret is normally automatically generated by traefik-forward-auth. But if specified via env-vars, it would allow you to run multiple instances of forward-auth on the same cookie domain, enabling authentication between them without logging in multiple times. 

If this isn't set, and you try and use the same cookie domain; you'd be presented with a "Not Authorized" message as the cookie-secret doesn't match that instance's value, and you'd need to do a `/_oauth/logout` and re-authenticate to set the cookie with the new cookie-secret.

My changes will, if necessary add the env-var to the pod, and create a secret if necessary.  

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[radarr]`)
