### PR TITLE
[renovate] remove gitAuthor from renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,5 @@
 {
   "enabled": true,
-  "gitAuthor": "Renovate Bot <renovate@whitesourcesoftware.com>",
   "commitMessagePrefix": "[{{{parentDir}}}]",
   "branchTopic": "{{{parentDir}}}-{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}",
   "assigneesFromCodeOwners": true,


### PR DESCRIPTION
#### Special notes for your reviewer:

This is the default anyways