### PR TITLE
[bitwardenrs] Fix HPA target

### DIFF
--- a/charts/bitwardenrs/Chart.yaml
+++ b/charts/bitwardenrs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bitwardenrs
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.16.3
 keywords:
   - bitwarden

--- a/charts/bitwardenrs/templates/hpa.yaml
+++ b/charts/bitwardenrs/templates/hpa.yaml
@@ -8,7 +8,11 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
+    {{- if eq .Values.persistence.type "statefulset" }}
+    kind: StatefulSet
+    {{- else }}
     kind: Deployment
+    {{- end }}
     name: {{ include "bitwardenrs.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}


### PR DESCRIPTION
#### Special notes for your reviewer:
Fixes #286 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)

Confirmed that this change fixes the issue, as I am now seeing the HPA correctly scraping pod metrics.
![image](https://user-images.githubusercontent.com/4422163/100579672-33cf8800-32aa-11eb-8ff2-7006e0f60486.png)
