### PR TITLE
[homeassistant] deploy ha as statefulset instead of deployment

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.118.3
+appVersion: 0.118.5
 description: Home Assistant
 name: home-assistant
-version: 3.4.0
+version: 3.4.1
 keywords:
 - home-assistant
 - hass

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $args := include "home-assistant.vscode.args" . -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "home-assistant.fullname" . }}
   labels:
@@ -10,8 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
-  strategy:
-    type: {{ .Values.strategyType }}
+  serviceName: {{ .Release.Name }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "home-assistant.name" . }}


### PR DESCRIPTION
This change might be useful for some ha integrations which register a token based on `socket.gethostname()` method like [freebox integration](https://github.com/home-assistant/core/blob/dev/homeassistant/components/freebox/const.py#L16).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
