### PR TITLE
[appdaemon] remove mountPath

### DIFF
--- a/charts/appdaemon/Chart.yaml
+++ b/charts/appdaemon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.5
 description: AppDaemon is a loosely coupled, multi-threaded, sandboxed python execution environment for writing automation apps for various types of Home Automation Software including Home Assistant and MQTT.
 name: appdaemon
-version: 1.0.1
+version: 1.0.2
 keywords:
   - appdaemon
   - home-automation

--- a/charts/appdaemon/values.yaml
+++ b/charts/appdaemon/values.yaml
@@ -79,7 +79,6 @@ persistence:
   config:
     enabled: false
     emptyDir: false
-    mountPath: /conf
     ## Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
#### Special notes for your reviewer:

Mistake on the mountPath, it is defaulted to `/config` in our image.

https://github.com/k8s-at-home/container-images/blob/main/appdaemon/entrypoint.sh#L7

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
