### PR TITLE
[navidrome][lychee] Bump to re-trigger repo upload

### DIFF
--- a/charts/lychee/Chart.yaml
+++ b/charts/lychee/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.8
 description: Lychee is a free photo-management tool, which runs on your server or web-space
 name: lychee
-version: 1.0.0
+version: 1.0.1
 keywords:
   - lychee
   - photo

--- a/charts/navidrome/Chart.yaml
+++ b/charts/navidrome/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.39.0
 description: Navidrome is an open source web-based music collection server and streamer
 name: navidrome
-version: 1.0.0
+version: 1.0.1
 keywords:
   - navidrome
   - music


### PR DESCRIPTION
#### Special notes for your reviewer:
Both charts in v1.0.0 were not uploaded to the repository. As https://github.com/k8s-at-home/charts/pull/295, this PR aims to activate the upload.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[radarr]`)
