### PR TITLE
[blocky] Update to 0.11 and add query log pvc

### DIFF
--- a/charts/blocky/Chart.yaml
+++ b/charts/blocky/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.10
+appVersion: v0.11
 description: DNS proxy as ad-blocker for local network
 name: blocky
-version: 4.0.1
+version: 4.1.0
 keywords:
   - blocky
   - dbs

--- a/charts/blocky/templates/deployment.yaml
+++ b/charts/blocky/templates/deployment.yaml
@@ -45,6 +45,13 @@ spec:
               subPath: {{ $name }}
               readOnly: true
             {{- end }}
+            {{- if .Values.config.queryLog }}
+            - name: data
+              mountPath: {{ .Values.config.queryLog.dir }}
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
+            {{- end }}
           ports:
             - name: api
               containerPort: 4000
@@ -89,6 +96,15 @@ spec:
                     - key: {{ $name }}
                       path: {{ $name }}
                   {{- end }}
+        {{- if .Values.config.queryLog }}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "blocky.fullname" . }}{{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/blocky/templates/persistentvolumeclaim.yaml
+++ b/charts/blocky/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "blocky.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "blocky.name" . }}
+    helm.sh/chart: {{ include "blocky.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.persistence.finalizers }}
+  finalizers:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- with .Values.persistence.selectorLabels }}
+  selector:
+    matchLabels:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+{{- end -}}

--- a/charts/blocky/values.yaml
+++ b/charts/blocky/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: spx01/blocky
-  tag: v0.10
+  tag: v0.11
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/charts/blocky/values.yaml
+++ b/charts/blocky/values.yaml
@@ -106,11 +106,33 @@ config:
     # url path, optional (default '/metrics')
     path: /metrics
 
+  # optional: write query information (question, answer, client, duration etc) to daily csv file
+  # queryLog:
+  #     # directory (will be mounted as volume in the pod)
+  #     dir: /logs
+  #     # if true, write one file per client. Writes all queries to single file otherwise
+  #     perClient: true
+  #     # if > 0, deletes log files which are older than ... days
+  #     logRetentionDays: 7
+
   # optional: HTTP listener port, default 0 = no http listener. If > 0, will be used for prometheus metrics, pprof, ...
   httpPort: 4000
   # optional: Log level (one from debug, info, warn, error). Default: info
   logLevel: info
 
+## Add persistence for query logs (if enabled)
+persistence:
+  enabled: false
+  # storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  # annotations: {}
+  finalizers:
+    - kubernetes.io/pvc-protection
+  # selectorLabels: {}
+  # subPath: ""
+  # existingClaim:
 
 # Probes configuration
 probes:


### PR DESCRIPTION
**Description of the change**

Adds a volume to the blocky deployment for query logs. Can either be an `emptyDir` if persistence is disabled, an existing PVC referenced by `persistence.existingClaim`, or new PVC.

**Benefits**

Allows the use of query logs without filling the pod's ephemeral storage. Persistence is opt-in and will only be used if query logs are enabled.

**Possible drawbacks**

Only supports a deployment with a referenced PVC for now, using a StatefulSet is not supported. This means that only 1 replica can be used if the access mode is `ReadWriteOnce`. Additionally the PVC will be deleted if the chart is uninstalled.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
