### PR TITLE
[plex] Quote values for extraEnv

### DIFF
--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.20.2.3402
 description: Plex Media Server
 name: plex
-version: 2.1.0
+version: 2.1.1
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -175,7 +175,7 @@ spec:
 # Extra ENV Values supplied by user
 {{- range $key, $value := .Values.extraEnv }}
           - name: {{ $key }}
-            value: {{ $value }}
+            value: "{{ $value }}"
 {{- end }}
 # This is part of pkcsMangler
 {{- if .Values.certificate.pkcsMangler.enabled }}
@@ -310,7 +310,7 @@ spec:
       - name: {{ .name }}
         persistentVolumeClaim:
           claimName: {{ .claimName }}
-  {{- end }}        
+  {{- end }}
 {{- end }}
       - name: shared
         emptyDir: {}


### PR DESCRIPTION
**Description of the change**

Ensure we always use a string and prevent accidental usage of incorrect type
(such as using true or false as values)

**Benefits**

Incorrect value type would lead to templating errors and would require additional escaped quotes. This bypasses those issues and should make it less error-prone to users. 

**Possible drawbacks**

N/A

**Applicable issues**

- Mentioned in to #137

**Additional information**

Pretty simple change

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [x] (optional) Variables are documented in the README.md
