### PR TITLE
[common] allow code-server to run with additional args

### DIFF
--- a/charts/common/CHANGELOG.md
+++ b/charts/common/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+### Added
+
+- Allow for additional arguments to be added to code-server runtime vis `addons.codeserver.args`
+
 ## [2.0.4]
 
 ### Fixed

--- a/charts/common/CHANGELOG.md
+++ b/charts/common/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Allow for additional arguments to be added to code-server runtime vis `addons.codeserver.args`
+- Allow for additional arguments to be added to code-server runtime via `addons.codeserver.args`
 
 ## [2.0.4]
 

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.0.4
+version: 2.1.0
 keywords:
   - k8s-at-home
   - common

--- a/charts/common/templates/addons/code-server/_container.tpl
+++ b/charts/common/templates/addons/code-server/_container.tpl
@@ -30,7 +30,6 @@ args:
 - "--port"
 - "{{ .Values.addons.codeserver.service.port.port }}"
 - {{ .Values.addons.codeserver.workingDir | default (first .Values.addons.codeserver.volumeMounts).mountPath }}
-- {{ .Values.addons.codeserver.workingDir | default (first .Values.addons.codeserver.volumeMounts).mountPath }}
 {{- with .Values.addons.codeserver.volumeMounts }}
 volumeMounts:
   {{- toYaml . | nindent 2 }}

--- a/charts/common/templates/addons/code-server/_container.tpl
+++ b/charts/common/templates/addons/code-server/_container.tpl
@@ -24,13 +24,12 @@ ports:
   containerPort: {{ .Values.addons.codeserver.service.port.port }}
   protocol: TCP
 args:
+{{- range .Values.addons.codeserver.args }}
+- {{ . | quote }}
+{{- end }}
 - "--port"
 - "{{ .Values.addons.codeserver.service.port.port }}"
-- "--auth"
-- "none"
-{{- with .Values.addons.codeserver.args }}
-{{ . }}
-{{- end }}
+- {{ .Values.addons.codeserver.workingDir | default (first .Values.addons.codeserver.volumeMounts).mountPath }}
 - {{ .Values.addons.codeserver.workingDir | default (first .Values.addons.codeserver.volumeMounts).mountPath }}
 {{- with .Values.addons.codeserver.volumeMounts }}
 volumeMounts:

--- a/charts/common/templates/addons/code-server/_container.tpl
+++ b/charts/common/templates/addons/code-server/_container.tpl
@@ -28,6 +28,9 @@ args:
 - "{{ .Values.addons.codeserver.service.port.port }}"
 - "--auth"
 - "none"
+{{- with .Values.addons.codeserver.args }}
+{{ . }}
+{{- end }}
 - {{ .Values.addons.codeserver.workingDir | default (first .Values.addons.codeserver.volumeMounts).mountPath }}
 {{- with .Values.addons.codeserver.volumeMounts }}
 volumeMounts:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -314,6 +314,9 @@ addons:
       pullPolicy: IfNotPresent
       tag: 3.7.4
 
+    # Add additional args
+    args: []
+
     # Specify a list of volumes that get mounted in the code-server container.
     # At least 1 volumeMount is required!
     volumeMounts: []

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -314,8 +314,10 @@ addons:
       pullPolicy: IfNotPresent
       tag: 3.7.4
 
-    # Add additional args
-    args: []
+    # Set codeserver command line arguments
+    args:
+      - --auth
+      - none
 
     # Specify a list of volumes that get mounted in the code-server container.
     # At least 1 volumeMount is required!

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -315,9 +315,12 @@ addons:
       tag: 3.7.4
 
     # Set codeserver command line arguments
+    # consider setting --user-data-dir to a persistent location to preserve code-server setting changes
     args:
       - --auth
       - none
+      # - --user-data-dir
+      # - "/config/.vscode"
 
     # Specify a list of volumes that get mounted in the code-server container.
     # At least 1 volumeMount is required!


### PR DESCRIPTION
**Description of the change**

Enable code-server addon to run with additional configured runtime arguments

**Benefits**

Enables additional runtime features, such as: 

```
      --user-data-dir        Path to the user data directory.
      --extensions-dir       Path to the extensions directory.
      --list-extensions      List installed VS Code extensions.
      --force                Avoid prompts when installing VS Code extensions.
      --install-extension    Install or update a VS Code extension by id or vsix. The identifier of an extension is `${publisher}.${name}`.
                             To install a specific version provide `@${version}`. For example: 'vscode.csharp@1.2.3'.
      --enable-proposed-api  Enable proposed API features for extensions. Can receive one or more extension IDs to enable individually.
```

As configured currently, the code-server addon will never retain state for code-server extensions, settings, etc as these are all persisted in `~/.local`.  This can be overridden with the `--user-data-dir` argument to reference a persisted location (e.g. `/config/.vscode`)

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md
