### PR TITLE
[home-assistant] bump home-assistant to use common chart 2.1.0

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2020.12.1
 description: Home Assistant
 name: home-assistant
-version: 5.0.0
+version: 5.1.0
 keywords:
 - home-assistant
 - hass
@@ -19,7 +19,7 @@ maintainers:
 dependencies:
 - name: common
   repository: https://k8s-at-home.com/charts/
-  version: 2.0.4
+  version: 2.1.0
 - name: postgresql
   version: 10.2.0
   repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
**Description of the change**

Bump common chart library dependency to 2.1.0

**Benefits**

This should help solve issue with code-server & settings persistence


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md
