### PR TITLE
[node-feature-discovery] New image repository and version bump to v0.7.0

### DIFF
--- a/charts/node-feature-discovery/Chart.yaml
+++ b/charts/node-feature-discovery/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: node-feature-discovery
-version: 2.0.0
-appVersion: 0.6.0
+version: 2.1.0
+appVersion: 0.7.0
 description: Detect hardware features available on each node in a Kubernetes cluster, and advertises those features using node labels
 keywords:
   - kubernetes

--- a/charts/node-feature-discovery/values.yaml
+++ b/charts/node-feature-discovery/values.yaml
@@ -3,10 +3,10 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: quay.io/kubernetes_incubator/node-feature-discovery
+  repository: gcr.io/k8s-staging-nfd/node-feature-discovery
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.6.0"
+  tag: "v0.7.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
**Description of the change**

According to the new release of node-feature-discovery https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v0.7.0 the registry moved from `quay.io` to `gcr.io`. I bumped to the new version too. Keep in mind, that there is a PR open in kubernetes-sigs/node-feature-discovery/pull/423 for a hosted chart in its repo.

**Benefits**

Automation will find new images for the deployment.

**Possible drawbacks**

None.

**Applicable issues**

No related issues.

**Additional information**

None.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [x] (optional) Variables are documented in the README.md