### PR TITLE
[resilio-sync]: new chart

### DIFF
--- a/charts/resilio-sync/.helmignore
+++ b/charts/resilio-sync/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/resilio-sync/.helmignore
+++ b/charts/resilio-sync/.helmignore
@@ -19,5 +19,6 @@
 .project
 .idea/
 *.tmproj
+.vscode/
 # OWNERS file for Kubernetes
 OWNERS

--- a/charts/resilio-sync/Chart.yaml
+++ b/charts/resilio-sync/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+appVersion: 2.7.2
+description: Resilio Sync is a fast, reliable, and simple file sync and share solution, powered by P2P technology
+name: resilio-sync
+version: 1.0.0
+keywords:
+  - resilio
+  - sync
+  - btsync
+  - bittorrent
+home: https://github.com/k8s-at-home/charts/tree/master/charts/resio-sync
+icon: https://blog.resilio.com/wp-content/uploads/2016/06/SyncSymbol-260x260px.png
+sources:
+  - https://github.com/orgs/linuxserver/packages/container/package/resilio-sync
+maintainers:
+  - name: salekseev
+    email: 100800+salekseev@users.noreply.github.com
+dependencies:
+  - name: common
+    repository: https://k8s-at-home.com/charts/
+    version: 2.1.1

--- a/charts/resilio-sync/OWNERS
+++ b/charts/resilio-sync/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- salekseev
+- onedr0p
+- bjw-s
+reviewers:
+- salekseev
+- onedr0p
+- bjw-s

--- a/charts/resilio-sync/README.md
+++ b/charts/resilio-sync/README.md
@@ -1,0 +1,68 @@
+# Resilio Sync
+
+This is a helm chart for [resilio-sync](https://resilio-sync.org/).
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
+## TL;DR;
+
+```shell
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/resilio-sync
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release k8s-at-home/resilio-sync
+```
+
+The default login details (change ASAP) are:
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+Read through the charts [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/resilio-sync/values.yaml)
+file. It has several commented out suggested values.
+Additionally you can take a look at the common library [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/common/values.yaml) for more (advanced) configuration options.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+```console
+helm install my-release \
+  --set env.TZ="America/New_York" \
+    k8s-at-home/resilio-sync
+```
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the
+chart. For example,
+```console
+helm install my-release k8s-at-home/resilio-sync --values values.yaml 
+```
+
+```yaml
+image:
+  tag: ...
+```
+
+---
+**NOTE**
+
+If you get
+```console
+Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...`
+```
+it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like 4.0.1 -> 5.0.0) indicates that there is an incompatible breaking change potentially needing manual actions.

--- a/charts/resilio-sync/templates/NOTES.txt
+++ b/charts/resilio-sync/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/resilio-sync/templates/common.yaml
+++ b/charts/resilio-sync/templates/common.yaml
@@ -1,0 +1,1 @@
+{{ include "common.all" . }}

--- a/charts/resilio-sync/values.yaml
+++ b/charts/resilio-sync/values.yaml
@@ -1,0 +1,94 @@
+# Default values for resilio-sync.
+
+image:
+  repository: ghcr.io/linuxserver/resilio-sync
+  pullPolicy: IfNotPresent
+  tag: 2.7.2.1375-ls75
+
+strategy:
+  type: Recreate
+
+env: {}
+  # TZ: UTC
+  # PUID: 1001
+  # PGID: 1001
+  # UMASK: 022
+
+service:
+  port:
+    port: 8888
+
+  additionalServices:
+  - enabled: true
+    nameSuffix: bt
+    type: ClusterIP
+    port:
+      port: 55555
+      name: bt
+      protocol: TCP
+      targetPort: 55555
+  - enabled: true
+    nameSuffix: utp
+    type: ClusterIP
+    port:
+      port: 55555
+      name: utp
+      protocol: UDP
+      targetPort: 55555
+
+persistence:
+  config:
+    enabled: false
+    emptyDir: false
+    mountPath: /config
+
+  media:
+    enabled: false
+    emptyDir: false
+    mountPath: /media
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    # storageClass: "-"
+    # accessMode: ReadWriteOnce
+    # size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    # skipuninstall: false
+    # existingClaim: ""
+
+  downloads:
+    enabled: false
+    emptyDir: false
+    mountPath: /downloads
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    # storageClass: "-"
+    # accessMode: ReadWriteOnce
+    # size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    # skipuninstall: false
+    # existingClaim: ""
+
+  sync:
+    enabled: false
+    emptyDir: false
+    mountPath: /sync
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    # storageClass: "-"
+    # accessMode: ReadWriteOnce
+    # size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    # skipuninstall: false
+    # existingClaim: ""

--- a/charts/resilio-sync/values.yaml
+++ b/charts/resilio-sync/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/linuxserver/resilio-sync
   pullPolicy: IfNotPresent
-  tag: 2.7.2.1375-ls75
+  tag: version-2.7.2.1375
 
 strategy:
   type: Recreate


### PR DESCRIPTION
**Description of the change**

Adding a chart for resilio-sync based on [linuxserver image](https://github.com/orgs/linuxserver/packages/container/package/resilio-sync).

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [X] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
