### PR TITLE
[dsmr-reader] New chart

### DIFF
--- a/charts/dsmr-reader/.helmignore
+++ b/charts/dsmr-reader/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/dsmr-reader/.helmignore
+++ b/charts/dsmr-reader/.helmignore
@@ -19,5 +19,6 @@
 .project
 .idea/
 *.tmproj
+.vscode/
 # OWNERS file for Kubernetes
 OWNERS

--- a/charts/dsmr-reader/Chart.yaml
+++ b/charts/dsmr-reader/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+appVersion: v4.9.0
+description: DSMR-protocol reader, telegram data storage and energy consumption visualizer.
+name: dsmr-reader
+version: 1.0.0
+keywords:
+- dsmr-reader
+- energy
+home: https://github.com/k8s-at-home/charts/tree/master/charts/dsmr-reader
+icon: https://avatars2.githubusercontent.com/u/57727360?s=400&v=4
+sources:
+- https://github.com/dsmrreader/dsmr-reader
+- https://github.com/xirixiz/dsmr-reader-docker
+maintainers:
+- name: billimek
+  email: jeff@billimek.com
+dependencies:
+- name: common
+  repository: https://k8s-at-home.com/charts/
+  version: 2.1.1
+- name: postgresql
+  version: 10.2.0
+  repository: https://charts.bitnami.com/bitnami
+  condition: postgresql.enabled

--- a/charts/dsmr-reader/OWNERS
+++ b/charts/dsmr-reader/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- billimek
+- onedr0p
+- bjw-s
+reviewers:
+- billimek
+- onedr0p
+- bjw-s

--- a/charts/dsmr-reader/README.md
+++ b/charts/dsmr-reader/README.md
@@ -1,0 +1,67 @@
+# DSMR-reader
+
+This is a helm chart for [DSMR-reader](https://github.com/dsmrreader/dsmr-reader).
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
+## TL;DR;
+
+```shell
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/dsmr-reader
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release k8s-at-home/dsmr-reader
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+Read through the charts [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/dsmr-reader/values.yaml)
+file. It has several commented out suggested values.
+Additionally you can take a look at the common library [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/common/values.yaml) for more (advanced) configuration options.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+```console
+helm install dsmr-reader \
+  --set env.TZ="America/New_York" \
+    k8s-at-home/dsmr-reader
+```
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the
+chart. For example,
+```console
+helm install dsmr-reader k8s-at-home/dsmr-reader --values values.yaml 
+```
+
+```yaml
+image:
+  tag: ...
+```
+
+---
+**NOTE**
+
+If you get
+```console
+Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...`
+```
+it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like 4.0.1 -> 5.0.0) indicates that there is an incompatible breaking change potentially needing manual actions.

--- a/charts/dsmr-reader/ci/ct-values.yaml
+++ b/charts/dsmr-reader/ci/ct-values.yaml
@@ -1,0 +1,9 @@
+fullnameOverride: dsmr-reader
+
+env:
+  DATALOGGER_MODE: receiver
+  DJANGO_DATABASE_HOST: dsmr-reader-db
+
+postgresql:
+  enabled: true
+  fullnameOverride: dsmr-reader-db

--- a/charts/dsmr-reader/templates/NOTES.txt
+++ b/charts/dsmr-reader/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/dsmr-reader/templates/common.yaml
+++ b/charts/dsmr-reader/templates/common.yaml
@@ -1,0 +1,1 @@
+{{ include "common.all" . }}

--- a/charts/dsmr-reader/values.yaml
+++ b/charts/dsmr-reader/values.yaml
@@ -1,0 +1,47 @@
+# Default values for dsmr-reader.
+
+image:
+  repository: xirixiz/dsmr-reader-docker
+  pullPolicy: IfNotPresent
+  tag: latest-v4.9.0-amd64
+
+securityContext:
+  privileged: true
+
+strategy:
+  type: Recreate
+
+service:
+  port:
+    port: 80
+
+# For all options see https://github.com/xirixiz/dsmr-reader-docker#dsmr-reader---environment-variables
+env:
+  # TZ: UTC
+  # DJANGO_TIME_ZONE: UTC
+  DJANGO_DATABASE_USER: dsmr-reader
+  DJANGO_DATABASE_PASSWORD: dsmr-reader-pass
+  DJANGO_DATABASE_PORT: 5432
+  DJANGO_DATABASE_NAME: dsmr-reader
+
+# Path to your p1 reader device in the container
+# additionalVolumeMounts:
+# - name: p1reader
+#   mountPath: /dev/ttyUSB0
+
+# Path to your p1 reader device on the host
+# additionalVolumes:
+# - name: p1reader
+#   hostPath:
+#     path: /dev/ttyUSB0
+
+# Enable postgres
+# ... for more options see https://github.com/bitnami/charts/tree/master/bitnami/postgresql
+postgresql:
+  enabled: false
+  postgresqlUsername: dsmr-reader
+  postgresqlPassword: dsmr-reader-pass
+  postgresqlDatabase: dsmr-reader
+  persistence:
+    enabled: false
+    # storageClass: ""


### PR DESCRIPTION
**Description of the change**

Adds a chart for [dsmr-reader](https://github.com/dsmrreader/dsmr-reader), a DSMR-protocol reader, telegram data storage and energy consumption visualizer. Can be used for reading the smart meter DSMR (Dutch Smart Meter Requirements) P1 port.

**Benefits**

More charts! 😄 

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md
