### PR TITLE
[home-assistant] allow setting a base64-encoded SSH private key

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2020.12.1
 description: Home Assistant
 name: home-assistant
-version: 5.1.1
+version: 5.2.0
 keywords:
 - home-assistant
 - hass

--- a/charts/home-assistant/templates/secret.yaml
+++ b/charts/home-assistant/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.git.deployKey }}
+{{- if or .Values.git.deployKey .Values.git.deployKeyBase64 }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,5 +7,9 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if .Values.git.deployKey }}
   id_rsa: {{ .Values.git.deployKey | b64enc | quote }}
+  {{- else }}
+  id_rsa: {{ .Values.git.deployKeyBase64 | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -18,12 +18,19 @@ service:
 # # Enable devices to be discoverable
 # hostNetwork: true
 
+# # When hostNetwork is true set dnsPolicy to ClusterFirstWithHostNet
+# dnsPolicy: ClusterFirstWithHostNet
+
 # # Enable passing thru a USB device to Home Assistant
 # securityContext:
 #   privileged: true
 
-git:
-  deployKey: ""
+# Allow access a Git repository by passing in a private SSH key
+# git:
+#   # Raw SSH private key
+#   deployKey: ""
+#   # Base64-encoded SSH private key
+#   deployKeyBase64: ""
 
 # Enable a prometheus-operator servicemonitor
 prometheus:

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -29,7 +29,7 @@ service:
 # git:
 #   # Raw SSH private key
 #   deployKey: ""
-#   # Base64-encoded SSH private key
+#   # Base64-encoded SSH private key. When both variables are set, the raw SSH key takes precedence.
 #   deployKeyBase64: ""
 
 # Enable a prometheus-operator servicemonitor

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -26,11 +26,11 @@ service:
 #   privileged: true
 
 # Allow access a Git repository by passing in a private SSH key
-# git:
-#   # Raw SSH private key
-#   deployKey: ""
-#   # Base64-encoded SSH private key. When both variables are set, the raw SSH key takes precedence.
-#   deployKeyBase64: ""
+git:
+  # Raw SSH private key
+  deployKey: ""
+  # Base64-encoded SSH private key. When both variables are set, the raw SSH key takes precedence.
+  deployKeyBase64: ""
 
 # Enable a prometheus-operator servicemonitor
 prometheus:


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Allows setting a Base64-encoded SSH private key

**Benefits**

<!-- What benefits will be realized by the code change? -->

Using sealed-secrets and `.env` I need to pass this var in as a single line, SSH private keys are multiline

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
