### PR TITLE
[Blocky] Change probes to /

### DIFF
--- a/charts/blocky/Chart.yaml
+++ b/charts/blocky/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.11
 description: DNS proxy as ad-blocker for local network
 name: blocky
-version: 4.1.0
+version: 4.1.1
 keywords:
   - blocky
   - dbs

--- a/charts/blocky/templates/deployment.yaml
+++ b/charts/blocky/templates/deployment.yaml
@@ -63,19 +63,19 @@ spec:
               protocol: UDP
           livenessProbe:
             httpGet:
-              path: /metrics
+              path: /
               port: api
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /metrics
+              path: /
               port: api
             failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
           startupProbe:
             httpGet:
-              path: /metrics
+              path: /
               port: api
             initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}

--- a/charts/blocky/values.yaml
+++ b/charts/blocky/values.yaml
@@ -1,5 +1,3 @@
-replicaCount: 1
-
 image:
   repository: spx01/blocky
   tag: v0.11


### PR DESCRIPTION
**Description of the change**

Make sure blocky also runs without having /metrics
And removed some values that didn't do anything

**Benefits**
Without running prometheus still a succesfull deployment

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [x] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
