### PR TITLE
[Readarr] New Readarr chart

### DIFF
--- a/charts/readarr/.helmignore
+++ b/charts/readarr/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/readarr/.helmignore
+++ b/charts/readarr/.helmignore
@@ -21,3 +21,4 @@
 *.tmproj
 # OWNERS file for Kubernetes
 OWNERS
+.vscode/

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.1.0.351
 description: A fork of Radarr to work with Books & AudioBooks
 name: readarr
-version: 0.0.1
+version: 1.0.0
 keywords:
   - readarr
   - torrent

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+appVersion: 0.1.0.351
+description: A fork of Radarr to work with Books & AudioBooks
+name: readarr
+version: 0.0.1
+keywords:
+  - readarr
+  - torrent
+  - usenet
+  - AudioBooks
+  - ebooks
+home: https://github.com/k8s-at-home/charts/tree/master/charts/readarr
+icon: https://readarr.com/img/logo.png
+sources:
+  - https://github.com/Readarr/Readarr
+  - https://readarr.com
+maintainers:
+  - name: mcmarkj
+    email: mark@markmcw.uk
+dependencies:
+  - name: common
+    repository: https://k8s-at-home.com/charts/
+    version: 2.1.1

--- a/charts/readarr/README.md
+++ b/charts/readarr/README.md
@@ -1,0 +1,55 @@
+# Readarr
+
+This is a helm chart for [Readarr](https://github.com/Readarr/Readarr).
+
+**Readarr is still in early development, and this chart will install a nightly build of Readarr.
+[See the project readme for more information](https://github.com/Readarr/Readarr#readarr-is-in-early-stages-of-development-alphabeta-binary-builds-are-not-yet-available-use-of-any-test-builds-isnt-recommend-and-may-have-detrimental-effects-on-your-library)**
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
+## TL;DR;
+
+```shell
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/readarr
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release k8s-at-home/readarr
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+Read through the charts [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/readarr/values.yaml)
+file. It has several commented out suggested values.
+Additionally you can take a look at the common library [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/common/values.yaml) for more (advanced) configuration options.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+```console
+helm install readarr \
+  --set env.TZ="America/New_York" \
+    k8s-at-home/readarr
+```
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the
+chart. For example,
+```console
+helm install readarr k8s-at-home/readarr --values values.yaml
+```
+
+```yaml
+image:
+  tag: ...
+```

--- a/charts/readarr/README.md
+++ b/charts/readarr/README.md
@@ -3,7 +3,7 @@
 This is a helm chart for [Readarr](https://github.com/Readarr/Readarr).
 
 **Readarr is still in early development, and this chart will install a nightly build of Readarr.
-[See the project readme for more information](https://github.com/Readarr/Readarr#readarr-is-in-early-stages-of-development-alphabeta-binary-builds-are-not-yet-available-use-of-any-test-builds-isnt-recommend-and-may-have-detrimental-effects-on-your-library)**
+[See the project readme for more information](https://github.com/Readarr/Readarr#readarr-is-in-early-stages-of-development-alphabeta-binary-builds-are-not-yet-available-use-of-any-test-builds-isnt-recommend-and-may-have-detrimental-effects-on-your-library). Take back-up's if you decide to use this on an existing library as the project is considered unstable**
 
 **This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
 

--- a/charts/readarr/templates/NOTES.txt
+++ b/charts/readarr/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/readarr/templates/common.yaml
+++ b/charts/readarr/templates/common.yaml
@@ -1,0 +1,1 @@
+{{ include "common.all" . }}

--- a/charts/readarr/values.yaml
+++ b/charts/readarr/values.yaml
@@ -1,0 +1,40 @@
+# Default values for Radarr.
+
+image:
+  repository: hotio/readarr
+  pullPolicy: IfNotPresent
+  tag: nightly
+
+strategy:
+  type: Recreate
+
+service:
+  port:
+    port: 8787
+
+env: {}
+  # TZ: UTC
+  # PUID: 1001
+  # PGID: 1001
+
+persistence:
+  config:
+    enabled: false
+    emptyDir: false
+
+  media:
+    enabled: false
+    emptyDir: false
+    mountPath: /media
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    # storageClass: "-"
+    # accessMode: ReadWriteOnce
+    # size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    # skipuninstall: false
+    # existingClaim: ""


### PR DESCRIPTION
**Description of the change**

Readarr is a radarr fork for Books, AudioBooks etc. It's still in early development but is lined up to be a replacement for LazyLibrarian. This PR adds the new chart. 
 
**Benefits**

Whole new charts. 

**Possible drawbacks**

It's currently only nightly builds as the project is quite new. 


**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
