### PR TITLE
[octoprint] Use built-in haproxy

### DIFF
--- a/charts/octoprint/Chart.yaml
+++ b/charts/octoprint/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.4.2
 description: OctoPrint is the snappy web interface for your 3D printer
 name: octoprint
-version: 2.2.1
+version: 2.2.2
 keywords:
   - octoprint
   - 3d

--- a/charts/octoprint/values.yaml
+++ b/charts/octoprint/values.yaml
@@ -13,11 +13,15 @@ securityContext:
 
 service:
   port:
-    port: 5000
+    port: 80
 
 env:
-  OCTOPRINT_PORT: "5000"
   # TZ: UTC
+
+  ## uncomment the environment variables below to ensure camera streaming is enabled when
+  ## you add a video device
+  # ENABLE_MJPG_STREAMER: "true"
+  # MJPG_STREAMER_INPUT: "-y -n -r 640x480"
   # CAMERA_DEV: /dev/video0
 
 persistence:


### PR DESCRIPTION
**Description of the change**

Use the built-in haproxy for octoprint, since otherwise the webcam support won't work.

**Benefits**

If not implemented, webcam support will not work by default.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md
