### PR TITLE
[oauth2-proxy] Add support for initContainers

### DIFF
--- a/charts/oauth2-proxy/Chart.yaml
+++ b/charts/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 4.0.1
+version: 4.1.0
 apiVersion: v1
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/charts/oauth2-proxy/README.md
+++ b/charts/oauth2-proxy/README.md
@@ -92,6 +92,7 @@ Parameter | Description | Default
 `ingress.annotations` | Ingress annotations | `nil`
 `ingress.hosts` | Ingress accepted hostnames | `nil`
 `ingress.tls` | Ingress TLS configuration | `nil`
+`initContainers` | pod init containers | `[]`
 `livenessProbe.enabled`  | enable Kubernetes livenessProbe. Disable to use oauth2-proxy with Istio mTLS. See [Istio FAQ](https://istio.io/help/faq/security/#k8s-health-checks) | `true`
 `livenessProbe.initialDelaySeconds` | number of seconds | 0
 `livenessProbe.timeoutSeconds` | number of seconds | 1

--- a/charts/oauth2-proxy/templates/deployment.yaml
+++ b/charts/oauth2-proxy/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "oauth2-proxy.serviceAccountName" . }}
+{{- if ne (len .Values.initContainers) 0 }}
+      initContainers:
+{{ toYaml .Values.initContainers | indent 6 }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -169,6 +169,10 @@ podDisruptionBudget:
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 podSecurityContext: {}
 
+# Configure init containers for pod
+# REF: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+initContainers: []
+
 # whether to use http or https
 httpScheme: http
 


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This change adds possibility to specify initContainers for oauth-proxy2 pod.

**Benefits**

Example use case is fetching secrets from external source, e.g. with vault-agent fetch secrets from Hashicorp Vault.

**Possible drawbacks**

None, by default no initContainers are added.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
