### PR TITLE
[Deluge] V1 of Deluge Chart

### DIFF
--- a/charts/deluge/.helmignore
+++ b/charts/deluge/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS
+.vscode/

--- a/charts/deluge/Chart.yaml
+++ b/charts/deluge/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+appVersion: v2.0.3-2201906121747
+description: Deluge is a torrent download client
+name: deluge
+version: 1.0.0
+keywords:
+  - deluge
+  - torrent
+home: https://github.com/k8s-at-home/charts/tree/master/charts/deluge
+icon: https://avatars2.githubusercontent.com/u/6733935?v=3&s=200
+sources:
+  - https://hub.docker.com/r/linuxserver/deluge/
+  - https://deluge-torrent.org/
+maintainers:
+  - name: mcmarkj
+    email: mark@markmcw.uk
+dependencies:
+  - name: common
+    repository: https://k8s-at-home.com/charts/
+    version: 2.1.1

--- a/charts/deluge/OWNERS
+++ b/charts/deluge/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- billimek
+- onedr0p
+- bjw-s
+reviewers:
+- billimek
+- onedr0p
+- bjw-s

--- a/charts/deluge/README.md
+++ b/charts/deluge/README.md
@@ -1,0 +1,57 @@
+# Deluge
+
+This is a helm chart for [Deluge](https://deluge-torrent.org/).
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
+## TL;DR;
+
+```shell
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/deluge
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release k8s-at-home/deluge
+```
+
+The default login details (change ASAP) are:
+
+* password:deluge
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+Read through the charts [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/deluge/values.yaml)
+file. It has several commented out suggested values.
+Additionally you can take a look at the common library [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/common/values.yaml) for more (advanced) configuration options.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+```console
+helm install deluge \
+  --set env.TZ="America/New_York" \
+    k8s-at-home/deluge
+```
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the
+chart. For example,
+```console
+helm install deluge k8s-at-home/deluge --values values.yaml
+```
+
+These values will be nested as it is a dependency, for example
+```yaml
+image:
+  tag: ...
+```

--- a/charts/deluge/templates/NOTES.txt
+++ b/charts/deluge/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/deluge/templates/common.yaml
+++ b/charts/deluge/templates/common.yaml
@@ -1,0 +1,1 @@
+{{ include "common.all" . }}

--- a/charts/deluge/values.yaml
+++ b/charts/deluge/values.yaml
@@ -38,8 +38,8 @@ persistence:
 env: {}
   ## Optional ENV Vars that can be set.
   ## All values below are the current default values.
-  #PUID: "1000"
-  #PGID: "1000"
-  #TZ: "Europe/London"
-  #UMASK_SET: "022"
-  #DELUGE_LOGLEVEL: "error"
+  # PUID: "1000"
+  # PGID: "1000"
+  # TZ: "Europe/London"
+  # UMASK_SET: "022"
+  # DELUGE_LOGLEVEL: "error"

--- a/charts/deluge/values.yaml
+++ b/charts/deluge/values.yaml
@@ -1,0 +1,45 @@
+# Default values for deluge.
+
+image:
+  repository: linuxserver/deluge
+  pullPolicy: IfNotPresent
+  tag: version-2.0.3-2201906121747ubuntu18.04.1
+
+strategy:
+  type: Recreate
+
+service:
+  port:
+    port: 8112
+
+persistence:
+  config:
+    enabled: false
+    emptyDir: false
+    mountPath: /config
+
+  downloads:
+    enabled: false
+    emptyDir: false
+    mountPath: /downloads
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    # storageClass: "-"
+    # accessMode: ReadWriteOnce
+    # size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    # skipuninstall: false
+    # existingClaim: ""
+
+env: {}
+  ## Optional ENV Vars that can be set.
+  ## All values below are the current default values.
+  #PUID: "1000"
+  #PGID: "1000"
+  #TZ: "Europe/London"
+  #UMASK_SET: "022"
+  #DELUGE_LOGLEVEL: "error"


### PR DESCRIPTION
**Description of the change**

New chart for the Deluge torrent downloader. 

**Benefits**

Deluge is straightforward, stable, easy use torrent client that can run headless in the cloud. It comes bundled quite often with LazyLibrarian, Sonarr, Radarr etc. A chart for this does not yet exist as far as I am aware. 

**Possible drawbacks**

None.

**Applicable issues**

None 


**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
