### PR TITLE
[nzbhydra2] Use HTTP probes & Bump Version

### DIFF
--- a/charts/nzbhydra2/Chart.yaml
+++ b/charts/nzbhydra2/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v3.4.3
+appVersion: v3.8.1
 description: Usenet meta search
 name: nzbhydra2
-version: 5.1.1
+version: 5.2.0
 keywords:
   - nzbhydra2
   - usenet

--- a/charts/nzbhydra2/Chart.yaml
+++ b/charts/nzbhydra2/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/nzbhydra2
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/hydra-icon.png
 sources:
-  - https://hub.docker.com/r/linuxserver/nzbhydra2/
+  - https://hub.docker.com/r/linuxserver/nzbhydra2
   - https://github.com/theotherp/nzbhydra2
 maintainers:
   - name: billimek

--- a/charts/nzbhydra2/values.yaml
+++ b/charts/nzbhydra2/values.yaml
@@ -53,7 +53,6 @@ probes:
       timeoutSeconds: 10
 
 
-
 persistence:
   config:
     enabled: false

--- a/charts/nzbhydra2/values.yaml
+++ b/charts/nzbhydra2/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: linuxserver/nzbhydra2
   pullPolicy: IfNotPresent
-  tag: version-v3.4.3
+  tag: version-v3.8.1
 
 strategy:
   type: Recreate
@@ -18,8 +18,42 @@ env: {}
   # PGID: 1001
 
 probes:
-  startup:
+  liveness:
     enabled: true
+    custom: true
+    spec:
+      initialDelaySeconds: 30
+      failureThreshold: 5
+      periodSeconds: 10
+      timeoutSeconds: 10
+      httpGet:
+        path: /actuator/health/livenessState
+        port: http
+
+  readiness:
+      enabled: true
+      custom: true
+      spec:
+        initialDelaySeconds: 30
+        failureThreshold: 5
+        periodSeconds: 10
+        timeoutSeconds: 10
+        httpGet:
+          path: /actuator/health/readinessState
+          port: http
+
+  startup:
+      enabled: true
+      custom: true
+      spec:
+        initialDelaySeconds: 30
+        failureThreshold: 5
+        periodSeconds: 10
+        timeoutSeconds: 10
+        httpGet:
+          path: /actuator/health/readinessState
+          port: http
+
 
 persistence:
   config:

--- a/charts/nzbhydra2/values.yaml
+++ b/charts/nzbhydra2/values.yaml
@@ -19,40 +19,39 @@ env: {}
 
 probes:
   liveness:
-    enabled: true
     custom: true
+    enabled: true
     spec:
-      initialDelaySeconds: 30
       failureThreshold: 5
-      periodSeconds: 10
-      timeoutSeconds: 10
       httpGet:
         path: /actuator/health/livenessState
         port: http
-
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 10
   readiness:
-      enabled: true
-      custom: true
-      spec:
-        initialDelaySeconds: 30
-        failureThreshold: 5
-        periodSeconds: 10
-        timeoutSeconds: 10
-        httpGet:
-          path: /actuator/health/readinessState
-          port: http
-
+    custom: true
+    enabled: true
+    spec:
+      failureThreshold: 5
+      httpGet:
+        path: /actuator/health/readinessState
+        port: http
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 10
   startup:
-      enabled: true
-      custom: true
-      spec:
-        initialDelaySeconds: 30
-        failureThreshold: 5
-        periodSeconds: 10
-        timeoutSeconds: 10
-        httpGet:
-          path: /actuator/health/readinessState
-          port: http
+    custom: true
+    enabled: true
+    spec:
+      failureThreshold: 5
+      httpGet:
+        path: /actuator/health/readinessState
+        port: http
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 10
+
 
 
 persistence:


### PR DESCRIPTION
**Description of the change**

Use the HTTP endpoints for readiness, liveness and startup instead of the port. So if anything goes wrong internally in the app these will stop returning 200 and the pod would be considered unhealthy. 

**Benefits**

Better liveness checks than a TCP port check. 

**Possible drawbacks**

Not aware of any

**Applicable issues**

- fixes #411

**Additional information**

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [X] (optional) Variables are documented in the README.md