### PR TITLE
[hyperion-ng] Initial Commit

### DIFF
--- a/charts/hyperion-ng/.helmignore
+++ b/charts/hyperion-ng/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/hyperion-ng/.helmignore
+++ b/charts/hyperion-ng/.helmignore
@@ -18,6 +18,7 @@
 # Various IDEs
 .project
 .idea/
+.vscode/
 *.tmproj
 # OWNERS file for Kubernetes
 OWNERS

--- a/charts/hyperion-ng/Chart.yaml
+++ b/charts/hyperion-ng/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: 2.0.0-alpha9
-description: Hyperion is an opensource Bias or Ambient Lighting implementation 
+description: Hyperion is an opensource Bias or Ambient Lighting implementation
 name: hyperion-ng
 version: 1.0.0
 keywords:

--- a/charts/hyperion-ng/Chart.yaml
+++ b/charts/hyperion-ng/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+appVersion: 2.0.0-alpha9
+description: Hyperion is an opensource Bias or Ambient Lighting implementation 
+name: hyperion-ng
+version: 1.0.0
+keywords:
+  - hyperion-ng
+  - hyperion
+home: https://github.com/k8s-at-home/charts/tree/master/charts/hyperion-ng
+icon: https://raw.githubusercontent.com/hyperion-project/hyperion.ng/master/assets/webconfig/img/hyperion/hyperionlogo.png?raw=true
+sources:
+  - https://github.com/hyperion-project/hyperion.ng
+  - https://hub.docker.com/r/sirfragalot/hyperion.ng
+maintainers:
+  - name: billimek
+    email: jeff@billimek.com
+dependencies:
+  - name: common
+    repository: https://k8s-at-home.com/charts/
+    version: 2.1.1

--- a/charts/hyperion-ng/OWNERS
+++ b/charts/hyperion-ng/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- billimek
+- onedr0p
+- bjw-s
+reviewers:
+- billimek
+- onedr0p
+- bjw-s

--- a/charts/hyperion-ng/README.md
+++ b/charts/hyperion-ng/README.md
@@ -1,0 +1,67 @@
+# Radarr
+
+This is a helm chart for [Hyperion.ng](https://github.com/hyperion-project/hyperion.ng).
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
+## TL;DR;
+
+```shell
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/hyperion-ng
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release k8s-at-home/hyperion-ng
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+Read through the charts [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/hyperion-ng/values.yaml)
+file. It has several commented out suggested values.
+Additionally you can take a look at the common library [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/common/values.yaml) for more (advanced) configuration options.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+```console
+helm install hyperion-ng \
+  --set env.TZ="America/New_York" \
+    k8s-at-home/hyperion-ng
+```
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the
+chart. For example,
+```console
+helm install hyperion-ng k8s-at-home/hyperion-ng --values values.yaml 
+```
+
+```yaml
+image:
+  tag: ...
+```
+
+---
+**NOTE**
+
+If you get
+```console
+Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...`
+```
+it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like 4.0.1 -> 5.0.0) indicates that there is an incompatible breaking change potentially needing manual actions.

--- a/charts/hyperion-ng/templates/NOTES.txt
+++ b/charts/hyperion-ng/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/hyperion-ng/templates/common.yaml
+++ b/charts/hyperion-ng/templates/common.yaml
@@ -1,0 +1,1 @@
+{{ include "common.all" . }}

--- a/charts/hyperion-ng/values.yaml
+++ b/charts/hyperion-ng/values.yaml
@@ -1,4 +1,4 @@
-# Default values for Radarr.
+# Default values for hyperion-ng.
 
 image:
   repository: sirfragalot/hyperion.ng

--- a/charts/hyperion-ng/values.yaml
+++ b/charts/hyperion-ng/values.yaml
@@ -1,0 +1,37 @@
+# Default values for Radarr.
+
+image:
+  repository: sirfragalot/hyperion.ng
+  pullPolicy: IfNotPresent
+  tag: 2.0.0-alpha.9-x86_64
+
+strategy:
+  type: Recreate
+
+service:
+  port:
+    port: 8090
+  additionalPorts:
+  - port: 19444
+    name: jsonservice
+    protocol: TCP
+    targetPort: 19444
+  - port: 19445
+    name: protobufservice
+    protocol: TCP
+    targetPort: 19445
+  - port: 19333
+    name: boblightservice
+    protocol: TCP
+    targetPort: 19333
+
+env: {}
+  # TZ: UTC
+  # PUID: 1001
+  # PGID: 1001
+
+persistence:
+  config:
+    enabled: false
+    emptyDir: false
+    mountPath: /root/.hyperion


### PR DESCRIPTION
**Description of the change**

New chart!

**Benefits**

This service, along with WLED driver for LED lights and a Hyperion Android app, allows for the sync of TV backlighting to whatever is being played on Android TV

**Possible drawbacks**

You cover the whole wall with LEDs

**Applicable issues**

None

**Additional information**

I have been running this, piggy backing off of the Radarr chart with no issues.

The only things I am not sure about are
- How to name the config data since the path for Hyperion's config is odd. This could be changed by forking the docker build, I suppose
- The docker tag, there are other archs but the images aren't multi-arch. 
 
**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md
