### PR TITLE
[Mosquitto] Update Mosquitto to support configurable ports

### DIFF
--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6.12"
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 0.5.0
+version: 0.6.0
 keywords:
   - message queue
   - MQTT

--- a/charts/mosquitto/templates/NOTES.txt
+++ b/charts/mosquitto/templates/NOTES.txt
@@ -1,6 +1,6 @@
 ** Please be patient while the chart is being deployed **
 
-Mosquitto can be accessed within the cluster on port 1883 at {{ template "mosquitto.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+Mosquitto can be accessed within the cluster on port {{ .Values.service.port }} at {{ template "mosquitto.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 To access for outside the cluster, perform the following steps:
 
@@ -26,13 +26,13 @@ NOTE: It may take a few minutes for the LoadBalancer IP to be available.
 
 To Access the Moquitto port:
 
-    echo "URL : mqtt://$SERVICE_IP:1883/"
+    echo "URL : mqtt://$SERVICE_IP:{{ .Values.service.port }}/"
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
 To Access the Mosquitto MQTT port:
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "mosquitto.fullname" . }} 1883:1883
-    echo "URL : mqtt://127.0.0.1:1883/"
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "mosquitto.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+    echo "URL : mqtt://127.0.0.1:{{ .Values.service.port }}/"
 
 {{- end }}

--- a/charts/mosquitto/templates/service.yaml
+++ b/charts/mosquitto/templates/service.yaml
@@ -17,11 +17,11 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - port: 1883
+    - port: {{ .Values.service.port }}
       targetPort: default
       protocol: TCP
       name: default
-    - port: 9001
+    - port: {{ .Values.service.websocketPort }}
       targetPort: websocket
       protocol: TCP
       name: websocket

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -34,6 +34,8 @@ securityContext: {}
 service:
   annotations: {}
   type: ClusterIP
+  port: 1883
+  websocketPort: 9001
   # externalTrafficPolicy:
   # loadBalancerIP:
 


### PR DESCRIPTION
**Description of the change**

Updated the service to have configurable ports for users that wish to run on non-standard. 

**Benefits**

Users can configure the ports that they want the service to expose

**Possible drawbacks**

**Applicable issues**

**Additional information**
Tested on microk8s 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)