### PR TITLE
[samba] New chart

### DIFF
--- a/charts/samba/.helmignore
+++ b/charts/samba/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/samba/Chart.yaml
+++ b/charts/samba/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+appVersion: latest
+description: A simple in-cluster Samba server
+name: samba
+version: 1.0.0
+keywords:
+  - samba
+home: https://github.com/k8s-at-home/charts/tree/master/charts/samba
+icon: https://upload.wikimedia.org/wikipedia/commons/thumb/d/db/Samba_logo_2010.svg/500px-Samba_logo_2010.svg.png
+sources:
+  - https://github.com/dperson/samba
+maintainers:
+  - name: billimek
+    email: jeff@billimek.com
+dependencies:
+  - name: common
+    repository: https://k8s-at-home.com/charts/
+    version: 2.2.0

--- a/charts/samba/OWNERS
+++ b/charts/samba/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- billimek
+- onedr0p
+- bjw-s
+reviewers:
+- billimek
+- onedr0p
+- bjw-s

--- a/charts/samba/README.md
+++ b/charts/samba/README.md
@@ -1,0 +1,67 @@
+# samba
+
+This is a helm chart for a [samba](https://github.com/dperson/samba) server.
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
+## TL;DR;
+
+```shell
+$ helm repo add k8s-at-home https://k8s-at-home.com/charts/
+$ helm install k8s-at-home/samba
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release k8s-at-home/samba
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+Read through the charts [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/samba/values.yaml)
+file. It has several commented out suggested values.
+Additionally you can take a look at the common library [values.yaml](https://github.com/k8s-at-home/charts/blob/master/charts/common/values.yaml) for more (advanced) configuration options.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+```console
+helm install samba \
+  --set env.TZ="America/New_York" \
+    k8s-at-home/samba
+```
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the
+chart. For example,
+```console
+helm install samba k8s-at-home/samba --values values.yaml 
+```
+
+```yaml
+image:
+  tag: ...
+```
+
+---
+**NOTE**
+
+If you get
+```console
+Error: rendered manifests contain a resource that already exists. Unable to continue with install: existing resource conflict: ...`
+```
+it may be because you uninstalled the chart with `skipuninstall` enabled, you need to manually delete the pvc or use `existingClaim`.
+
+---
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like 4.0.1 -> 5.0.0) indicates that there is an incompatible breaking change potentially needing manual actions.

--- a/charts/samba/templates/NOTES.txt
+++ b/charts/samba/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/samba/templates/common.yaml
+++ b/charts/samba/templates/common.yaml
@@ -1,0 +1,1 @@
+{{ include "common.all" . }}

--- a/charts/samba/values.yaml
+++ b/charts/samba/values.yaml
@@ -1,0 +1,43 @@
+# Default values for samba.
+
+image:
+  repository: dperson/samba
+  tag: latest
+  pullPolicy: Always
+
+strategy:
+  type: Recreate
+
+probes:
+  liveness:
+    enabled: false
+  readiness:
+    enabled: false
+
+service:
+  port:
+    name: tcp
+    port: 445
+  additionalPorts:
+    - name: netbios
+      port: 139
+
+## For all available environment variables and configuration options, please see:
+## https://github.com/dperson/samba/blob/master/README.md
+env: {}
+  # TZ: UTC
+  # SHARE1: share1;/share/samba/share1
+  # SHARE2: share2;/share/samba/share2
+
+## Configure the volume mounts for your shared folders here.
+additionalVolumeMounts: []
+# - name: my-hostpath-data
+#   mountPath: /share/samba/share1
+# - name: my-pvc-data
+#   mountPath: /share/samba/share2
+
+## Configure the volumes for your shared folders here.
+additionalVolumes: []
+# - name: my-pvc-data
+#   persistentVolumeClaim:
+#     claimName: my-pvc-name


### PR DESCRIPTION
**Description of the change**

New chart for a simple in-cluster samba server.

**Benefits**

Allows running a simple Samba server in the cluster. This can be useful for example when running a Synology / Sonos combination, where Sonos does not support newer Samba versions and Synology does not allow older versions.

**Possible drawbacks**

N/A

**Applicable issues**

- #437 

**Additional information**

This is a simple server chart for now, based completely on the image provided by https://github.com/dperson/samba (because it supports the desired functionality out of the box and can be configured using environment variables.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
