### PR TITLE
[zwave2mqtt] Custom probes

### DIFF
--- a/charts/zwave2mqtt/Chart.yaml
+++ b/charts/zwave2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.6
 description: Fully configurable Zwave to MQTT gateway and Control Panel using NodeJS and Vue
 name: zwave2mqtt
-version: 6.2.1
+version: 6.3.0
 keywords:
   - zwave
   - mqtt

--- a/charts/zwave2mqtt/values.yaml
+++ b/charts/zwave2mqtt/values.yaml
@@ -13,47 +13,47 @@ env:
 
 probes:
   liveness:
-    custom: true
     enabled: true
-    spec:
-      failureThreshold: 5
-      httpGet:
-        path: /health
-        port: http
-        httpHeaders:
-          - name: Accept
-            value: text/plain
-      initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 10
+    # custom: true
+    # spec:
+    #   failureThreshold: 5
+    #   httpGet:
+    #     path: /health
+    #     port: http
+    #     httpHeaders:
+    #       - name: Accept
+    #         value: text/plain
+    #   initialDelaySeconds: 30
+    #   periodSeconds: 10
+    #   timeoutSeconds: 10
   readiness:
-    custom: true
     enabled: true
-    spec:
-      failureThreshold: 5
-      httpGet:
-        path: /health
-        port: http
-        httpHeaders:
-          - name: Accept
-            value: text/plain
-      initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 10
+    # custom: true
+    # spec:
+    #   failureThreshold: 5
+    #   httpGet:
+    #     path: /health
+    #     port: http
+    #     httpHeaders:
+    #       - name: Accept
+    #         value: text/plain
+    #   initialDelaySeconds: 30
+    #   periodSeconds: 10
+    #   timeoutSeconds: 10
   startup:
-    custom: true
     enabled: false
-    spec:
-      failureThreshold: 5
-      httpGet:
-        path: /health
-        port: http
-        httpHeaders:
-          - name: Accept
-            value: text/plain
-      initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 10
+    # custom: true
+    # spec:
+    #   failureThreshold: 5
+    #   httpGet:
+    #     path: /health
+    #     port: http
+    #     httpHeaders:
+    #       - name: Accept
+    #         value: text/plain
+    #   initialDelaySeconds: 30
+    #   periodSeconds: 10
+    #   timeoutSeconds: 10
 
 service:
   port:

--- a/charts/zwave2mqtt/values.yaml
+++ b/charts/zwave2mqtt/values.yaml
@@ -11,6 +11,50 @@ strategy:
 env:
   OZW_AUTO_UPDATE_CONFIG: true
 
+probes:
+  liveness:
+    custom: true
+    enabled: true
+    spec:
+      failureThreshold: 5
+      httpGet:
+        path: /health
+        port: http
+        httpHeaders:
+          - name: Accept
+            value: text/plain
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 10
+  readiness:
+    custom: true
+    enabled: true
+    spec:
+      failureThreshold: 5
+      httpGet:
+        path: /health
+        port: http
+        httpHeaders:
+          - name: Accept
+            value: text/plain
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 10
+  startup:
+    custom: true
+    enabled: false
+    spec:
+      failureThreshold: 5
+      httpGet:
+        path: /health
+        port: http
+        httpHeaders:
+          - name: Accept
+            value: text/plain
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 10
+
 service:
   port:
     port: 8091


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Add custom probe examples to the zwave2mqtt chart, based on https://github.com/OpenZWave/Zwave2Mqtt#health-check-endpoints

**Benefits**

Get better feedback from the liveness of the application

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #91 

**Additional information**

Disabled the probes by default, since the application needs to be configured before the probes would actually work.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
