### PR TITLE
[bitwardenrs] Add option to change web port

### DIFF
--- a/charts/bitwardenrs/Chart.yaml
+++ b/charts/bitwardenrs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bitwardenrs
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 1.0.1
+version: 1.1.0
 appVersion: 1.16.3
 keywords:
   - bitwarden

--- a/charts/bitwardenrs/templates/deployment.yaml
+++ b/charts/bitwardenrs/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.bitwardenrs.gui.port }}
               protocol: TCP
             {{- if .Values.bitwardenrs.websockets.enabled }}
             - name: websocket

--- a/charts/bitwardenrs/templates/statefulset.yaml
+++ b/charts/bitwardenrs/templates/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.bitwardenrs.gui.port }}
               protocol: TCP
             {{- if .Values.bitwardenrs.websockets.enabled }}
             - name: websocket

--- a/charts/bitwardenrs/values.yaml
+++ b/charts/bitwardenrs/values.yaml
@@ -14,6 +14,9 @@ fullnameOverride: ""
 bitwardenrs:
   domain: ""
   signupsAllowed: false
+  gui:
+    # If you set a different port here, you must also provide it under env
+    port: 80
   websockets:
     enabled: true
     port: 3012
@@ -49,6 +52,9 @@ bitwardenrs:
       passwordKey: ""
 
 env: {}
+# If you plan to run the WebUI on a port other than port 80, specify that here:
+# For example, if running the container as a non-root user.
+#  ROCKET_PORT: "80"
 
 persistence:
   type: statefulset


### PR DESCRIPTION
Signed-off-by: TJ Wesolowski <wojoinc@pm.me>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Adds an option to the values.yaml:
```yaml
bitwardenrs:
  gui:
    # If you set a different port here, you must also provide it under env
    port: 80
```

**Benefits**

When combined with the following:
```yaml
env:
  ROCKET_PORT: "<port>"
```
this allows the user to specify a different port for bitwarden to bind to for the WebUI.
This has other benefits, but the most significant is that it allows the user to specify a web port above 1024 when running the container as a non-root user. For example, with the following SecurityContext:
```yaml
securityContext:
  capabilities:
    drop:
      - ALL
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  runAsUser: 65534
```

**Possible drawbacks**

None that I can see so far.
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #491
- Related: dani-garcia/bitwarden_rs#776

**Additional information**

Bumped the minor version, as this should be a backwards-compatible change. Tested an in-place upgrade on my deployment without issues. The default port for the webui has not changed, so existing users should be able to safely upgrade the chart.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
