### PR TITLE
[zwavejs2mqtt] Safer default values.yaml

### DIFF
--- a/charts/zwavejs2mqtt/Chart.yaml
+++ b/charts/zwavejs2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0-alpha.2
 description: Fully configurable Zwave to MQTT Gateway and Control Panel
 name: zwavejs2mqtt
-version: 1.0.1
+version: 1.1.0
 keywords:
   - zwave
   - mqtt

--- a/charts/zwavejs2mqtt/Chart.yaml
+++ b/charts/zwavejs2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0-alpha.2
 description: Fully configurable Zwave to MQTT Gateway and Control Panel
 name: zwavejs2mqtt
-version: 1.0.0
+version: 1.0.1
 keywords:
   - zwave
   - mqtt

--- a/charts/zwavejs2mqtt/values.yaml
+++ b/charts/zwavejs2mqtt/values.yaml
@@ -12,6 +12,12 @@ strategy:
 # https://zwave-js.github.io/zwavejs2mqtt/#/guide/env-vars
 env: {}
   # OZW_NETWORK_KEY:
+  # TZ: Europe/Helsinki
+
+# Get environment from a secret:
+#envFrom:
+#  - secretRef:
+#      name: zwavejs2mqtt-network-key
 
 probes:
   liveness:
@@ -60,9 +66,26 @@ probes:
 service:
   port:
     port: 8091
+    
+ingress:
+  enabled: false
+#  annotations:
+#    kubernetes.io/ingress.class: nginx
+#    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+#    cert-manager.io/cluster-issuer: some-smart-ca-issuer
+#  tls:
+#    - hosts:
+#        - zwave.home.some
+#      secretName: elveli-zwavejs2mqtt
+#  hosts:
+#    - host: zwave.home.some
+#      paths:
+#        - path: /
+#          pathType: Prefix
 
-securityContext:
-  privileged: true
+# Privileged may be required if USB controller is accessed directly through the host machine
+# securityContext:
+#  privileged: true
 
 persistence:
   config:
@@ -83,15 +106,15 @@ persistence:
     # existingClaim: ""
 
 # Path to your zwave device in the container
-additionalVolumeMounts:
-  - name: usb
-    mountPath: /dev/serial/by-id/usb-0658_0200-if00
+additionalVolumeMounts: []
+#  - name: usb
+#    mountPath: /dev/serial/by-id/usb-0658_0200-if00
 
 # Path to your zwave device on the host
-additionalVolumes:
-  - name: usb
-    hostPath:
-      path: /dev/serial/by-id/usb-0658_0200-if00
+additionalVolumes: []
+#  - name: usb
+#    hostPath:
+#      path: /dev/serial/by-id/usb-0658_0200-if00
 
 # affinity:
 #   nodeAffinity:

--- a/charts/zwavejs2mqtt/values.yaml
+++ b/charts/zwavejs2mqtt/values.yaml
@@ -1,7 +1,7 @@
 # Default values for zwavejs2mqtt.
 #
 # Please also consider possible values for the `common` library chart.
-# 
+#
 image:
   repository: zwavejs/zwavejs2mqtt
   pullPolicy: IfNotPresent

--- a/charts/zwavejs2mqtt/values.yaml
+++ b/charts/zwavejs2mqtt/values.yaml
@@ -1,5 +1,7 @@
 # Default values for zwavejs2mqtt.
-
+#
+# Please also consider possible values for the `common` library chart.
+# 
 image:
   repository: zwavejs/zwavejs2mqtt
   pullPolicy: IfNotPresent
@@ -12,12 +14,6 @@ strategy:
 # https://zwave-js.github.io/zwavejs2mqtt/#/guide/env-vars
 env: {}
   # OZW_NETWORK_KEY:
-  # TZ: Europe/Helsinki
-
-# Get environment from a secret:
-# envFrom:
-#   - secretRef:
-#       name: zwavejs2mqtt-network-key
 
 probes:
   liveness:
@@ -66,22 +62,6 @@ probes:
 service:
   port:
     port: 8091
-
-ingress:
-  enabled: false
-#  annotations:
-#    kubernetes.io/ingress.class: nginx
-#    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-#    cert-manager.io/cluster-issuer: some-smart-ca-issuer
-#  tls:
-#    - hosts:
-#        - zwave.home.some
-#      secretName: elveli-zwavejs2mqtt
-#  hosts:
-#    - host: zwave.home.some
-#      paths:
-#        - path: /
-#          pathType: Prefix
 
 # Privileged may be required if USB controller is accessed directly through the host machine
 # securityContext:

--- a/charts/zwavejs2mqtt/values.yaml
+++ b/charts/zwavejs2mqtt/values.yaml
@@ -66,7 +66,7 @@ probes:
 service:
   port:
     port: 8091
-    
+
 ingress:
   enabled: false
 #  annotations:
@@ -85,7 +85,7 @@ ingress:
 
 # Privileged may be required if USB controller is accessed directly through the host machine
 # securityContext:
-#  privileged: true
+#   privileged: true
 
 persistence:
   config:

--- a/charts/zwavejs2mqtt/values.yaml
+++ b/charts/zwavejs2mqtt/values.yaml
@@ -15,9 +15,9 @@ env: {}
   # TZ: Europe/Helsinki
 
 # Get environment from a secret:
-#envFrom:
-#  - secretRef:
-#      name: zwavejs2mqtt-network-key
+# envFrom:
+#   - secretRef:
+#       name: zwavejs2mqtt-network-key
 
 probes:
   liveness:

--- a/charts/zwavejs2mqtt/values.yaml
+++ b/charts/zwavejs2mqtt/values.yaml
@@ -1,7 +1,7 @@
 # Default values for zwavejs2mqtt.
 # This chart inherits from our common library chart. You can check the default values/options here:
 # https://github.com/k8s-at-home/charts/tree/master/charts/common
-# 
+#
 image:
   repository: zwavejs/zwavejs2mqtt
   pullPolicy: IfNotPresent

--- a/charts/zwavejs2mqtt/values.yaml
+++ b/charts/zwavejs2mqtt/values.yaml
@@ -1,7 +1,7 @@
 # Default values for zwavejs2mqtt.
 # This chart inherits from our common library chart. You can check the default values/options here:
 # https://github.com/k8s-at-home/charts/tree/master/charts/common
-#
+
 image:
   repository: zwavejs/zwavejs2mqtt
   pullPolicy: IfNotPresent

--- a/charts/zwavejs2mqtt/values.yaml
+++ b/charts/zwavejs2mqtt/values.yaml
@@ -1,7 +1,7 @@
 # Default values for zwavejs2mqtt.
-#
-# Please also consider possible values for the `common` library chart.
-#
+# This chart inherits from our common library chart. You can check the default values/options here:
+# https://github.com/k8s-at-home/charts/tree/master/charts/common
+# 
 image:
   repository: zwavejs/zwavejs2mqtt
   pullPolicy: IfNotPresent


### PR DESCRIPTION
- Default to non-privileged
- No default device mounts
- `envFrom` example
- Ingress example