### PR TITLE
[zigbee2mqtt] Safer default values, improved configuration

### DIFF
--- a/charts/zigbee2mqtt/Chart.yaml
+++ b/charts/zigbee2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.17.0
 description: Bridges events and allows you to control your Zigbee devices via MQTT
 name: zigbee2mqtt
-version: 4.2.1
+version: 4.3.0
 keywords:
   - zigbee
   - mqtt

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -120,7 +120,7 @@ config:
     homeassistant_status_topic: 'homeassistant/status'
 
     # Optional: Enables report feature (see information -> report for more details) (default: false)
-    report: true
+    # report: true
 
     # Optional: Add an elapsed attribute to MQTT messages, contains milliseconds since the previous msg (default: false)
     elapsed: true

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -103,6 +103,7 @@ config:
     log_level: info
 
     # Optional: ZigBee channel, changing requires re-pairing of all devices. (Note: use a ZLL channel: 11, 15, 20, or 25 to avoid Problems)
+    # default: 11
     channel: 11
 
     # Optional: Baudrate for serial port (default: 115200 for Z-Stack, 38400 for Deconz)

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -1,7 +1,6 @@
 # Default values for zigbee2mqtt.
 # This chart inherits from our common library chart. You can check the default values/options here:
 # https://github.com/k8s-at-home/charts/tree/master/charts/common
-#
 image:
   repository: koenkk/zigbee2mqtt
   pullPolicy: IfNotPresent

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -1,5 +1,7 @@
 # Default values for zigbee2mqtt.
-
+# This chart inherits from our common library chart. You can check the default values/options here:
+# https://github.com/k8s-at-home/charts/tree/master/charts/common
+#
 image:
   repository: koenkk/zigbee2mqtt
   pullPolicy: IfNotPresent
@@ -15,8 +17,9 @@ service:
   port:
     port: 8080
 
-securityContext:
-  privileged: true
+# Privileged may be required if USB controller is accessed directly through the host machine
+# securityContext:
+#   privileged: true
 
 persistence:
   data:
@@ -37,15 +40,15 @@ persistence:
     # existingClaim: ""
 
 # Path to your zigbee device in the container
-additionalVolumeMounts:
-  - name: usb
-    mountPath: /dev/ttyACM0
+additionalVolumeMounts: []
+#  - name: usb
+#    mountPath: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2400981-if00
 
 # Path to your zigbee device on the host
-additionalVolumes:
-  - name: usb
-    hostPath:
-      path: /dev/ttyACM0
+additionalVolumes: []
+#  - name: usb
+#    hostPath:
+#      path: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2400981-if00
 
 # affinity:
 #   nodeAffinity:

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -104,7 +104,7 @@ config:
 
     # Optional: ZigBee channel, changing requires re-pairing of all devices. (Note: use a ZLL channel: 11, 15, 20, or 25 to avoid Problems)
     # default: 11
-    channel: 11
+    # channel: 11
 
     # Optional: Baudrate for serial port (default: 115200 for Z-Stack, 38400 for Deconz)
     # baudrate: 38400

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -1,6 +1,7 @@
 # Default values for zigbee2mqtt.
 # This chart inherits from our common library chart. You can check the default values/options here:
 # https://github.com/k8s-at-home/charts/tree/master/charts/common
+
 image:
   repository: koenkk/zigbee2mqtt
   pullPolicy: IfNotPresent
@@ -90,7 +91,6 @@ config:
   # USB / Serial settings
   serial:
     # Location of your zigbee device
-    port: /dev/ttyACM0
     # port: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2400981-if00
 
     # Optional: adapter type, not needed unless you are experiencing problems (options: zstack, deconz)

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -91,7 +91,8 @@ config:
   # USB / Serial settings
   serial:
     # Location of your zigbee device
-    port: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2400981-if00
+    port: /dev/ttyACM0
+    # port: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2400981-if00
 
     # Optional: adapter type, not needed unless you are experiencing problems (options: zstack, deconz)
     # adapter: deconz

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -123,7 +123,7 @@ config:
     # report: true
 
     # Optional: Add an elapsed attribute to MQTT messages, contains milliseconds since the previous msg (default: false)
-    elapsed: true
+    # elapsed: true
 
   # Both of these need to be enabled for the webui
   frontend:

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -68,6 +68,8 @@ config:
   homeassistant: false
 
   # allow new devices to join
+  # WARNING: Disable this after all devices have been paired! (default: false)
+  # Note: this will be controllable in the UI
   permit_join: true
 
   # MQTT settings
@@ -79,16 +81,48 @@ config:
     # MQTT server authentication, uncomment if required:
     # user: my_user
     # password: my_password
+    # client_id: my_id
+    # Alternatively, credentials may be put into a separate file, managed through a secret:
+    # password: '!secret password'
+
+    # Optional: Include device information to mqtt messages (default: false)
+    include_device_information: true
 
   # USB / Serial settings
   serial:
     # Location of your zigbee device
-    port: /dev/ttyACM0
+    port: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2400981-if00
+
+    # Optional: adapter type, not needed unless you are experiencing problems (options: zstack, deconz)
+    # adapter: deconz
 
   advanced:
     network_key: GENERATE
     log_output:
       - console
+    log_level: info
+
+    # Optional: ZigBee channel, changing requires re-pairing of all devices. (Note: use a ZLL channel: 11, 15, 20, or 25 to avoid Problems)
+    channel: 11
+
+    # Optional: Baudrate for serial port (default: 115200 for Z-Stack, 38400 for Deconz)
+    # baudrate: 38400
+
+    # Optional: RTS / CTS Hardware Flow Control for serial port (default: false)
+    # rtscts: true
+
+    # Optional: Add a last_seen attribute to MQTT messages, contains date/time of last Zigbee message
+    # possible values are: disable (default), ISO_8601, ISO_8601_local, epoch (default: disable)
+    last_seen: 'ISO_8601'
+
+    homeassistant_discovery_topic: 'homeassistant'
+    homeassistant_status_topic: 'homeassistant/status'
+
+    # Optional: Enables report feature (see information -> report for more details) (default: false)
+    report: true
+
+    # Optional: Add an elapsed attribute to MQTT messages, contains milliseconds since the previous msg (default: false)
+    elapsed: true
 
   # Both of these need to be enabled for the webui
   frontend:


### PR DESCRIPTION
Much safer defaults (similar to #493):
- Disabled privileged by default.
- Disabled mounting devices by default. 
- Updated exampled device name to match a more useful case (specific device, not to encourage generic device names)
- Added a comment to check `common` chart.

Additionally:
- Some more options to default configuration, especially useful for Conbee II and/or Home Assistant.