### PR TITLE
[oauth2-proxy] change image to new home and bump image version

### DIFF
--- a/charts/oauth2-proxy/Chart.yaml
+++ b/charts/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 4.2.0
+version: 4.3.0
 apiVersion: v1
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -29,8 +29,8 @@ config:
   # existingConfig: config
 
 image:
-  repository: "quay.io/pusher/oauth2_proxy"
-  tag: "v5.1.0"
+  repository: "quay.io/oauth2-proxy/oauth2-proxy"
+  tag: "v6.1.1"
   pullPolicy: "IfNotPresent"
 
 # Optionally specify an array of imagePullSecrets.

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -9,7 +9,7 @@ config:
   # Use an existing secret for OAuth2 credentials (see secret.yaml for required fields)
   # Example:
   # existingSecret: secret
-  cookieSecret: "XXXXXXXXXX"
+  cookieSecret: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
   google: {}
     # adminEmail: xxxx
     # serviceAccountJson: xxxx


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This updates the image repo to https://quay.io/repository/oauth2-proxy/oauth2-proxy and bumps the version to v6.1.1

**Benefits**

<!-- What benefits will be realized by the code change? -->

I do not see any issues bumping this to v6.1.1, the chart has been working _fine_ for a long time.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

Could be an edge case where upgrading to v6.x might break some feature in the chart, but we will cross that road when we get to it :)

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [x] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
