### PR TITLE
[powerdns] Webserver container port, and startup script fixes

### DIFF
--- a/charts/powerdns/Chart.yaml
+++ b/charts/powerdns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v4.3.1
 description: PowerDNS is a DNS server, written in C++ and licensed under the GPL. It runs on most Unix derivatives. PowerDNS features a large number of different backends ranging from simple BIND style zonefiles to relational databases and load balancing/failover algorithms. A DNS recursor is provided as a separate program.
 name: powerdns
-version: 3.0.1
+version: 3.0.2
 home: https://www.powerdns.com/
 sources:
   - http://www.github.com/PowerDNS/

--- a/charts/powerdns/templates/deployment.yaml
+++ b/charts/powerdns/templates/deployment.yaml
@@ -94,6 +94,9 @@ spec:
             - name: dns-udp
               containerPort: 53
               protocol: UDP
+            - name: dns-webserver
+              containerPort: 8081
+              protocol: TCP
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             tcpSocket:

--- a/charts/powerdns/templates/deployment.yaml
+++ b/charts/powerdns/templates/deployment.yaml
@@ -124,13 +124,13 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/sh", "-c", "let a=0; while [ $a -lt 200 ]; do sleep 5; let a=a+1; echo 'Attempt: '$a; if nc -vz {{ printf "%s-%s" .Release.Name "mariadb"}} 3306; then (! pdnsutil list-zone {{ .Values.powerdns.domain }} 2>/dev/null) && pdnsutil create-zone {{ .Values.powerdns.domain }} && break; fi; echo 'End attempt'; done"]
+                command: ["/bin/sh", "-c", "let a=0; while [ $a -lt 200 ]; do sleep 5; let a=a+1; echo 'Attempt: '$a; if nc -vz {{ printf "%s-%s" .Release.Name "mariadb"}} 3306; then pdnsutil list-zone {{ .Values.powerdns.domain }} 2>/dev/null && break; pdnsutil create-zone {{ .Values.powerdns.domain }}; fi; done"]
 {{ end }}
 {{- if .Values.postgresql.enabled }}
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/sh", "-c", "let a=0; while [ $a -lt 200 ]; do sleep 5; let a=a+1; echo 'Attempt: '$a; if nc -vz {{ printf "%s-%s" .Release.Name "postgresql"}} 5432; then (! pdnsutil list-zone {{ .Values.powerdns.domain }} 2>/dev/null) && pdnsutil create-zone {{ .Values.powerdns.domain }} && break; fi; echo 'End attempt'; done"]
+                command: ["/bin/sh", "-c", "let a=0; while [ $a -lt 200 ]; do sleep 5; let a=a+1; echo 'Attempt: '$a; if nc -vz {{ printf "%s-%s" .Release.Name "postgresql"}} 5432; then pdnsutil list-zone {{ .Values.powerdns.domain }} 2>/dev/null && break; pdnsutil create-zone {{ .Values.powerdns.domain }}; fi; done"]
 {{ end }}
           resources:
 {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/powerdns/templates/deployment.yaml
+++ b/charts/powerdns/templates/deployment.yaml
@@ -124,13 +124,13 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/sh", "-c", "a=0;while [ $a -lt 200 ];do sleep 5;a=$[a+1];echo 'stage: '$a;if nc -vz {{- printf "%s-%s" .Release.Name "mariadb"}} 3306;then (! pdnsutil list-zone {{ .Values.powerdns.domain }} 2>/dev/null) && pdnsutil create-zone {{ .Values.powerdns.domain }};echo 'End Stage';a=200;fi;done"]
+                command: ["/bin/sh", "-c", "let a=0; while [ $a -lt 200 ]; do sleep 5; let a=a+1; echo 'Attempt: '$a; if nc -vz {{ printf "%s-%s" .Release.Name "mariadb"}} 3306; then (! pdnsutil list-zone {{ .Values.powerdns.domain }} 2>/dev/null) && pdnsutil create-zone {{ .Values.powerdns.domain }} && break; fi; echo 'End attempt'; done"]
 {{ end }}
 {{- if .Values.postgresql.enabled }}
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/sh", "-c", "a=0;while [ $a -lt 200 ];do sleep 5;a=$[a+1];echo 'stage: '$a;if nc -vz {{- printf "%s-%s" .Release.Name "postgresql"}} 5432;then (! pdnsutil list-zone {{ .Values.powerdns.domain }} 2>/dev/null) && pdnsutil create-zone {{ .Values.powerdns.domain }};echo 'End Stage';a=200;fi;done"]
+                command: ["/bin/sh", "-c", "let a=0; while [ $a -lt 200 ]; do sleep 5; let a=a+1; echo 'Attempt: '$a; if nc -vz {{ printf "%s-%s" .Release.Name "postgresql"}} 5432; then (! pdnsutil list-zone {{ .Values.powerdns.domain }} 2>/dev/null) && pdnsutil create-zone {{ .Values.powerdns.domain }} && break; fi; echo 'End attempt'; done"]
 {{ end }}
           resources:
 {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
**Description of the change**

* Re-add the webserver container port that was removed in a recent change
* Fix post-start script
    - don't trim whitespace between `OPTIONS` and `HOST` arguments to `nc` command
    - retry loop would always terminate after first attempt; re-formatted and re-structured script for clarity

**Benefits**

* Brings back the webserver port, restoring functionality that had worked in older versions (e.g. v2.2.0)
* Fixes the post-start script, saves users from needing create their zone manually

**Possible drawbacks**

* Existing users not overriding `powerdns.domain` will now get a `mydomain.local` zone (re-)created for them on upgrade, and all future restarts
    - should we make the post-start hook conditional on `powerdns.domain` being set, and change the default to empty string?

**Additional information**

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)