### PR TITLE
[common] Allow to override container command

### DIFF
--- a/charts/common/CHANGELOG.md
+++ b/charts/common/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2]
+
+### Added
+
+- Allow overriding the main container command.
+
 ## [2.2.1]
 
 ### Fixed

--- a/charts/common/CHANGELOG.md
+++ b/charts/common/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.2]
+## [2.3.0]
 
 ### Added
 

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.2.2
+version: 2.3.0
 keywords:
   - k8s-at-home
   - common

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.2.1
+version: 2.2.2
 keywords:
   - k8s-at-home
   - common

--- a/charts/common/templates/lib/controller/_container.tpl
+++ b/charts/common/templates/lib/controller/_container.tpl
@@ -5,6 +5,9 @@ The main container included in the controller.
 - name: {{ include "common.names.fullname" . }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
   imagePullPolicy: {{ .Values.image.pullPolicy }}
+  {{- with .Values.command }}
+  command: {{ . }}
+  {{- end }}
   {{- with .Values.args }}
   args: {{ . }}
   {{- end }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -12,6 +12,8 @@ strategy:
   ## DaemonSets ignore this
   type: RollingUpdate
 
+# Override the default command
+command: []
 # Override the default args
 args: []
 


### PR DESCRIPTION
Once we start messing with arguments, it is often convenient to also override the command (which is the container entrypoint). I just hit a use case where that would have been helpful. 

Normal people would never need this, but it is not harmful either. 

Signed-off-by: Ingvarr Zhmakin
