### PR TITLE
[traefik-forward-auth] Fix artifact hub links in README.md

### DIFF
--- a/charts/README.templates.md.gotmpl
+++ b/charts/README.templates.md.gotmpl
@@ -14,7 +14,7 @@
     {{ template "repository.organization" . }}/{{ template "chart.name" . }}
 {{- end -}}
 {{- define "badge.artifactHub" -}}
-  [![ArtifactHub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/{{ template "chart.name" . }})](https://artifacthub.io/packages/helm/{{ template "chart.name" . }})
+  [![ArtifactHub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/{{ template "chart.name" . }})](https://artifacthub.io/packages/helm/k8s-at-home/{{ template "chart.name" . }})
 {{- end -}}
 {{- define "description.multiarch" -}}
 The default values and container images used in this chart will allow for running in a multi-arch cluster (amd64, arm, arm64)

--- a/charts/traefik-forward-auth/Chart.yaml
+++ b/charts/traefik-forward-auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik-forward-auth
 description: A minimal forward authentication service that provides OAuth/SSO login and authentication for the traefik reverse proxy/load balancer
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: 2.2.0
 keywords:
   - traefik

--- a/charts/traefik-forward-auth/README.md
+++ b/charts/traefik-forward-auth/README.md
@@ -1,6 +1,6 @@
 # traefik-forward-auth
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square) [![ArtifactHub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/traefik-forward-auth)](https://artifacthub.io/packages/helm/k8s-at-home/traefik-forward-auth)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square) [![ArtifactHub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/traefik-forward-auth)](https://artifacthub.io/packages/helm/k8s-at-home/traefik-forward-auth)
 
 A minimal forward authentication service that provides OAuth/SSO login and authentication for the traefik reverse proxy/load balancer
 

--- a/charts/traefik-forward-auth/README.md
+++ b/charts/traefik-forward-auth/README.md
@@ -1,6 +1,6 @@
 # traefik-forward-auth
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square) [![ArtifactHub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/traefik-forward-auth)](https://artifacthub.io/packages/helm/traefik-forward-auth)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square) [![ArtifactHub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/traefik-forward-auth)](https://artifacthub.io/packages/helm/k8s-at-home/traefik-forward-auth)
 
 A minimal forward authentication service that provides OAuth/SSO login and authentication for the traefik reverse proxy/load balancer
 
@@ -61,11 +61,11 @@ helm install traefik-forward-auth k8s-at-home/traefik-forward-auth --values valu
 | cookie.domain | string | `""` | Domain(s) to set auth cookie on. (Comma delimited) |
 | cookie.insecure | string | `""` | Use insecure cookies |
 | cookie.name | string | `""` | Cookie Name (default: _forward_auth) |
-| cookie.secret | string| `""` | Cookie Secret - useful when running multiple instances |
+| cookie.secret | string | `""` | Cookie Secret used for authentication across multiple instances / clusters (default: randomly generated) |
 | default.action | string | `""` | [auth|allow] Default action (default: auth) |
 | default.provider | string | `""` | [google|oidc|generic-oauth] Default provider (default: google) |
 | env | list | `[]` |  |
-| envFrom | list | `[]` | Load environment variables from secrets or configmaps |
+| envFrom | string | `nil` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"thomseddon/traefik-forward-auth"` |  |


### PR DESCRIPTION
**Description of the change**

Fix artifacthub links in the helm-docs template, and regenerate traefik-forward-auth/README.md

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)