### PR TITLE
[plex] Add ability to define volume in extraMounts

### DIFF
--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.20.2.3402
 description: Plex Media Server
 name: plex
-version: 2.1.1
+version: 2.2.0
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/plex/templates/deployment.yaml
+++ b/charts/plex/templates/deployment.yaml
@@ -310,6 +310,9 @@ spec:
       - name: {{ .name }}
         persistentVolumeClaim:
           claimName: {{ .claimName }}
+  {{- else if .volume }}
+      - name: {{ .name }}
+        {{- toYaml .volume | nindent 8 }}
   {{- end }}
 {{- end }}
       - name: shared

--- a/charts/plex/values.yaml
+++ b/charts/plex/values.yaml
@@ -223,6 +223,16 @@ persistence:
   #   claimName: optional-claim
   #   mountPath: /mnt/path/in/pod
   #   subPath: optional/sub/path
+  #
+  ## Example using an existing NFS filer directly. Below the 'volume' key all volume types are allowed (eg. nfs, iscsi, hostPath).
+  ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core for further information
+  # - name: example2
+  #   mountPath: mnt/example2
+  #   volume:
+  #     nfs:
+  #       server: <nfs server fqdn or ip>
+  #       path: <nfs export path>
+  #       readOnly: true
 
   config:
     # Optionally specify claimName to manually override the PVC to be used for


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
This change adds the ability to freely use existing network storage (or hostPath storage) not defined as a PV inside the cluster. Eg. I have 2 Synology NFS filer containing various media files. Without this change, I need to define a PV and PVC to use this. Especially defining PVs need cluster admin access, which can be avoided using this ability.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Freely use existing external storage without defining PVs and PVCs.

**Possible drawbacks**

`-`

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
`-`

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
`-`

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
