### PR TITLE
[Frigate] adding data pvc and rtmp port to support upcoming 0.8.0 rel…

### DIFF
--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.6.0"
 description: Realtime object detection on RTSP cameras with the Google Coral
 name: frigate
-version: 4.0.1
+version: 4.0.2
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/templates/data-pvc.yaml
+++ b/charts/frigate/templates/data-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "frigate.fullname" . }}-data
+  {{- if .Values.persistence.data.skipuninstall }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "frigate.name" . }}
+    helm.sh/chart: {{ include "frigate.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size | quote }}
+{{- if .Values.persistence.data.storageClass }}
+{{- if (eq "-" .Values.persistence.data.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.data.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
             - mountPath: /config
               name: config
               readOnly: false
+            - mountPath: /media
+              name: media
+              readOnly: false
           command: ['sh', '-c']
           args:
             - cp /frigate-config/* /config;
@@ -59,6 +62,9 @@ spec:
           ports:
             - name: http
               containerPort: 5000
+              protocol: TCP
+            - name: rtmp
+              containerPort: 1935
               protocol: TCP
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
@@ -108,8 +114,10 @@ spec:
             {{- end }}
             - mountPath: /config
               name: config
-            - name: dshm
-              mountPath: /dev/shm
+            - mountPath: /data
+              name: data
+            - mountPath: /dev/shm
+              name: dshm
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -130,6 +138,13 @@ spec:
         - name: usb
           hostPath:
             path: {{ .Values.coral.hostPath }}
+        {{- end }}
+        - name: data
+        {{- if .Values.persistence.data.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.data.existingClaim }}{{ .Values.persistence.data.existingClaim }}{{- else }}{{ template "frigate.fullname" . }}-data{{- end }}
+        {{- else }}
+          emptyDir: {}
         {{- end }}
         - name: dshm
           emptyDir:

--- a/charts/frigate/templates/service.yaml
+++ b/charts/frigate/templates/service.yaml
@@ -44,6 +44,13 @@ spec:
 {{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{.Values.service.nodePort}}
 {{ end }}
+    - name: rtmp
+      port: 1935
+      protocol: TCP
+      targetPort: rtmp
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{ end }}
   selector:
     app.kubernetes.io/name: {{ include "frigate.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -249,3 +249,24 @@ tolerations: []
 affinity: {}
 
 podAnnotations: {}
+
+persistence:
+  data:
+    enabled: true
+    ## frigate configuration data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    ##
+    ## If you want to reuse an existing claim, you can pass the name of the PVC using
+    ## the existingClaim variable
+    # existingClaim: your-claim
+    # subPath: some-subpath
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    ## Do not delete the pvc upon helm uninstall
+    skipuninstall: false


### PR DESCRIPTION
…ease

Signed-off-by: brujoand <anders@brujordet.no>

**Description of the change**

This adds a service for the rtmp port which is needed for live streaming and sets up a pvc for /data which is where Frigate will store clips and snapshots. 

**Benefits**

This chart will now work with the Home Assistant integration without modification

**Possible drawbacks**

Well, I might have messed something up


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

This chart will probably be moved to the Frigate authors repo some time in the future, so I did not attempt to use the common library.