### PR TITLE
Fix indent for additionalVolumeMounts

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.2.1
+version: 2.2.2
 keywords:
   - k8s-at-home
   - common

--- a/charts/common/templates/lib/controller/_container.tpl
+++ b/charts/common/templates/lib/controller/_container.tpl
@@ -35,7 +35,7 @@ The main container included in the controller.
   {{- end }}
   {{- end }}
   {{- if .Values.additionalVolumeMounts }}
-    {{- toYaml .Values.additionalVolumeMounts | nindent 2 }}
+    {{- toYaml .Values.additionalVolumeMounts | nindent 4 }}
   {{- end }}
   {{- include "common.controller.probes" . | nindent 2 }}
   {{- with .Values.resources }}

--- a/charts/node-red/Chart.yaml
+++ b/charts/node-red/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
 dependencies:
   - name: common
     repository: https://k8s-at-home.com/charts/
-    version: 2.2.1
+    version: 2.2.2


### PR DESCRIPTION
Without this I get the output:

```
volumeMounts:
nfs: 
  [...]
```

When I expected to see the values indented under the `volumeMounts` section.