### PR TITLE
[common] Add support for volumeClaimTemplates in statefulset

### DIFF
--- a/charts/common-test/Chart.yaml
+++ b/charts/common-test/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common-test
 description: Helper chart to test different use cases of the common library
-version: 1.0.2
+version: 1.0.3
 keywords:
   - k8s-at-home
   - common

--- a/charts/common-test/ci/statefulset-values.yaml
+++ b/charts/common-test/ci/statefulset-values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: b4bz/homer
+  tag: latest
+  pullPolicy: IfNotPresent
+
+controllerType: statefulset
+
+volumeClaimTemplates:
+  - name: data
+    mountPath: /data
+    accessMode: "ReadWriteOnce"
+    size: 1Gi
+  - name: backup
+    mountPath: /backup
+    subPath: theSubPath
+    accessMode: "ReadWriteOnce"
+    size: 2Gi
+#    storageClass: cheap-storage-class

--- a/charts/common-test/ci/statefulset-values.yaml
+++ b/charts/common-test/ci/statefulset-values.yaml
@@ -15,4 +15,3 @@ volumeClaimTemplates:
     subPath: theSubPath
     accessMode: "ReadWriteOnce"
     size: 2Gi
-#    storageClass: cheap-storage-class

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.3.0
+version: 2.3.1
 keywords:
   - k8s-at-home
   - common

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.3.1
+version: 2.3.0
 keywords:
   - k8s-at-home
   - common

--- a/charts/common/templates/_statefulset.tpl
+++ b/charts/common/templates/_statefulset.tpl
@@ -36,4 +36,18 @@ spec:
       {{- include "common.labels.selectorLabels" . | nindent 8 }}
     spec:
       {{- include "common.controller.pod" . | nindent 6 }}
+  volumeClaimTemplates:
+  {{- range $index, $vct := .Values.volumeClaimTemplates }}
+  - metadata:
+      name: {{ $vct.name }}
+    spec:
+      accessModes: 
+        - {{ required (printf "accessMode is required for vCT %v" $vct.name) $vct.accessMode  | quote }}
+      resources:
+        requests:
+          storage: {{ required (printf "size is required for PVC %v" $vct.name) $vct.size | quote }}
+      {{- if $vct.storageClass }}
+      storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else }}{{ $vct.storageClass | quote }}{{- end }}
+      {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/common/templates/lib/controller/_container.tpl
+++ b/charts/common/templates/lib/controller/_container.tpl
@@ -40,6 +40,15 @@ The main container included in the controller.
   {{- if .Values.additionalVolumeMounts }}
     {{- toYaml .Values.additionalVolumeMounts | nindent 2 }}
   {{- end }}
+  {{- if eq .Values.controllerType "statefulset"  }}
+  {{- range $index, $vct := .Values.volumeClaimTemplates }}
+  - mountPath: {{ $vct.mountPath }}
+    name: {{ $vct.name }}
+  {{- if $vct.subPath }}
+    subPath: {{ $vct.subPath }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
   {{- include "common.controller.probes" . | nindent 2 }}
   {{- with .Values.resources }}
   resources:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -209,7 +209,7 @@ additionalVolumes: []
 
 additionalVolumeMounts: []
 
-volumeClaimTemplates: #[]
+volumeClaimTemplates: []
 # Used in statefulset to create individual disks for each instance
 # - name: data
 #   mountPath: /data

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -220,7 +220,7 @@ volumeClaimTemplates: []
 #   subPath: theSubPath
 #   accessMode: "ReadWriteOnce"
 #   size: 2Gi
-#  storageClass: cheap-storage-class
+#   storageClass: cheap-storage-class
 
 nodeSelector: {}
 

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -209,6 +209,19 @@ additionalVolumes: []
 
 additionalVolumeMounts: []
 
+volumeClaimTemplates: #[]
+# Used in statefulset to create individual disks for each instance
+# - name: data
+#   mountPath: /data
+#   accessMode: "ReadWriteOnce"
+#   size: 1Gi
+# - name: backup
+#   mountPath: /backup
+#   subPath: theSubPath
+#   accessMode: "ReadWriteOnce"
+#   size: 2Gi
+#  storageClass: cheap-storage-class
+
 nodeSelector: {}
 
 affinity: {}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Adding support for volumeClaimTemplates in statefulset in the common chart

**Benefits**

<!-- What benefits will be realized by the code change? -->
With this change is possible to use the full power of the statefulset in the common chart, ie it's possible to have unique storage for each instance of a statefulset, and make it possible to scale a statefulset to more than one member.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
After removing a helm deployment using this functionality the pvc/pv will be kept.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
More information about Statefulset can be found at:
https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-storage

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ x ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ x ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

The common and common-test chart version is bumped.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
