### PR TITLE
[common-next] some additional pod properties

### DIFF
--- a/charts/common/templates/lib/controller/_pod.tpl
+++ b/charts/common/templates/lib/controller/_pod.tpl
@@ -11,8 +11,17 @@ serviceAccountName: {{ include "common.names.serviceAccountName" . }}
 securityContext:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.priorityClassName }}
+priorityClassName: {{ . }}
+{{- end }}
+{{- with .Values.schedulerName }}
+schedulerName: {{ . }}
+{{- end }}
 {{- with .Values.hostNetwork }}
 hostNetwork: {{ . }}
+{{- end }}
+{{- with .Values.hostname }}
+hostname: {{ . }}
 {{- end }}
 {{- with .Values.dnsPolicy }}
 dnsPolicy: {{ . }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -52,7 +52,7 @@ envFrom: []
 # schedulerName: awkward-dangerous-scheduler
 
 # A rare use case when explicit hostname setting is necessary
-# hostname: 
+# hostname:
 
 # When using hostNetwork make sure you set dnsPolicy to ClusterFirstWithHostNet
 hostNetwork: false

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -48,10 +48,10 @@ envFrom: []
 # Custom priority class for different treatment by the scheduler
 # priorityClassName: system-node-critical
 
-# ...and custom scheduler name
+# Allow specifying a custom scheduler name
 # schedulerName: awkward-dangerous-scheduler
 
-# A rare use case when explicit hostname setting is necessary
+# Allow specifying explicit hostname setting
 # hostname:
 
 # When using hostNetwork make sure you set dnsPolicy to ClusterFirstWithHostNet

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -45,6 +45,15 @@ envFrom: []
 # - secretRef:
 #     name: secret-name
 
+# Custom priority class for different treatment by the scheduler
+# priorityClassName: system-node-critical
+
+# ...and custom scheduler name
+# schedulerName: awkward-dangerous-scheduler
+
+# A rare use case when explicit hostname setting is necessary
+# hostname: 
+
 # When using hostNetwork make sure you set dnsPolicy to ClusterFirstWithHostNet
 hostNetwork: false
 


### PR DESCRIPTION
**Description of the change**

Just little stuff which happened to be useful in smarter-device-manager (#490).

**Benefits**

Not harming.

**Possible drawbacks**

Not rewarding?..

**Applicable issues**

N/A

**Additional information**

**Checklist**
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [-] (optional) Variables are documented in the README.md
