### PR TITLE
[unifi] Added conditional, if https svc for captive portal defined, default to https svc

### DIFF
--- a/charts/unifi/Chart.yaml
+++ b/charts/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 5.14.23
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 1.3.1
+version: 1.4.0
 keywords:
   - ubiquiti
   - unifi

--- a/charts/unifi/templates/captive-ingress.yaml
+++ b/charts/unifi/templates/captive-ingress.yaml
@@ -34,6 +34,10 @@ spec:
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}-captiveportalservice
+              {{- if .Values.captivePortalService.https }}
+              servicePort: captive-https
+              {{- else }}
               servicePort: captive-http
+              {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
Add conditional to ingress for captive portal to default to https, otherwise, use http

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->
Users will be able to use https ingress for captive portal

**Possible drawbacks**
Might create weird behavior for people with https service enabled for captive portal, but aren't actually using it.
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #539 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [X] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->

I didn't bump up the Chart version actually because I didn't change the chart, only the template.  Can someone test this fix? I currently have my unifi controller up on my one node K8S and my ingress uses the node IP, so I can't deploy it again.