### PR TITLE
[unifi] Fixed unifi chart breaking from range restriction value on captive ingress

### DIFF
--- a/charts/unifi/Chart.yaml
+++ b/charts/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 5.14.23
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 1.4.0
+version: 1.4.1
 keywords:
   - ubiquiti
   - unifi

--- a/charts/unifi/templates/captive-ingress.yaml
+++ b/charts/unifi/templates/captive-ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "unifi.fullname" . -}}
 {{- $ingressPath := .Values.captivePortalService.ingress.path -}}
 {{- $unifiedServiceEnabled := .Values.unifiedService.enabled -}}
+{{- $captivePortalHttps := .Values.captivePortalService.https -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -34,7 +35,7 @@ spec:
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}-captiveportalservice
-              {{- if .Values.captivePortalService.https }}
+              {{- if $captivePortalHttps }}
               servicePort: captive-https
               {{- else }}
               servicePort: captive-http


### PR DESCRIPTION

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

My last PR broke because range seems like it restricted what I could use for values for that section.  I've defined it as a variable at the top of the template and referenced it using that.

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Defined the following {{- $captivePortalHttps := .Values.captivePortalService.https -}} so I can use it in a conditional correctly.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Fixes the broken template

**Possible drawbacks**
None that weren't already introduced in the last PR #540 
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes  #539

**Additional information**
I was able to test using dry run so I can confirm it'll go through this time.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [X] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
