### PR TITLE
[unifi] Allow service port to define captive portal port in deployment like gui and controller service

### DIFF
--- a/charts/unifi/Chart.yaml
+++ b/charts/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 5.14.23
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 1.4.1
+version: 1.4.2
 keywords:
   - ubiquiti
   - unifi

--- a/charts/unifi/templates/deployment.yaml
+++ b/charts/unifi/templates/deployment.yaml
@@ -70,10 +70,10 @@ spec:
               protocol: UDP
             {{- if .Values.captivePortalService.enabled }}
             - name: captive-http
-              containerPort: 8880
+              containerPort: {{ .Values.captivePortalService.http }}
               protocol: TCP
             - name: captive-https
-              containerPort: 8843
+              containerPort: {{ .Values.captivePortalService.https }}
               protocol: TCP
             {{- end }}
             - name: speedtest


### PR DESCRIPTION


<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
Changed the values of the container ports for the captive portal to be dynamic in the deployment like gui and controller.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
It'll allow users using the captive portal in https mode to use standard https port instead of the default 8843.  I couldn't get around the captive portal appending :8843 to my ingress url, messing it up.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
None that aren't already exist with setting lit like gui and controller service.
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
