### PR TITLE
[unifi] fix typo in UNIFI_STDOUT placement

### DIFF
--- a/charts/unifi/Chart.yaml
+++ b/charts/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 5.14.23
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 1.5.0
+version: 1.5.1
 keywords:
   - ubiquiti
   - unifi

--- a/charts/unifi/templates/deployment.yaml
+++ b/charts/unifi/templates/deployment.yaml
@@ -122,6 +122,8 @@ spec:
               value: "{{ .Values.UID }}"
             - name: UNIFI_GID
               value: "{{ .Values.GID }}"
+            - name: UNIFI_STDOUT
+              value: "true"
             {{- if .Values.extraJvmOpts }}
             - name: JVM_EXTRA_OPTS
               value: "{{- join " " .Values.extraJvmOpts }}"
@@ -149,8 +151,6 @@ spec:
               value: "{{ .Values.customCert.certName }}"
             - name: CERT_PRIVATE_NAME
               value: "{{ .Values.customCert.keyName }}"
-            - name: UNIFI_STDOUT
-              value: "true"
             {{- end }}
           volumeMounts:
             - mountPath: /unifi/data


### PR DESCRIPTION
**Description of the change**

#547 incorrectly placed the new env variable wrapped inside a conditional that should not have been; this PR fixes that placement.

**Benefits**

Make stdout logging work

**Possible drawbacks**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md
