### PR TITLE
install go-replace before using it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b .bin
 
 # Create chart
 PATH=$PATH:$PWD/.bin
+task deps:install
 task chart:create CHART=chart_name
 # Don't forgot edit some chart informations in charts/char_name/Chart.yaml and charts/char_name/values.yaml
 


### PR DESCRIPTION
running `chart:create` fails due to missing go-replace; tried on a few different environments.

helm looks to be used later on in `chart:create`, so picked `deps:install` instead of `deps:go-replace`.