### PR TITLE
shouldn't bump template version

### DIFF
--- a/templates/chart/Chart.yaml
+++ b/templates/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: ${CHARTNAME} helm package
 name: ${CHARTNAME}
-version: 1.1.0
+version: 1.0.0
 keywords:
   - ${CHARTNAME}
 home: https://github.com/k8s-at-home/charts/tree/master/charts/${CHARTNAME}


### PR DESCRIPTION
CONTRIBUTING.md says charts should start at 1.0.0; so presumably the template should too.

Fresh charts generated with `task chart:create` start at 1.1.0 because of this line.