### PR TITLE
[common] v3.0.0

### DIFF
--- a/charts/common/CHANGELOG.md
+++ b/charts/common/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `probes.startupProbe` is now enabled by default. This will allow for quicker `Ready` states on Pods. It will precede the liveness and readiness Probes.
+- `probes.startupProbe` is now enabled by default. This will allow for quicker `Ready` states on Pods. It will precede the liveness and readiness Probes. *Note:* This requires that you are running [Kubernetes 1.16](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
 - Aligned our default values for liveness and readiness Probes with the Kubernetes defaults:
-  - `initialDelaySeconds` is now 0
-  - `timeoutSeconds` is now 1
-  - `failureThreshold` is now 3
+  - `initialDelaySeconds` is now `0`
+  - `timeoutSeconds` is now `1`
+  - `failureThreshold` is now `3`
 
 ## [2.5.1]
 

--- a/charts/common/CHANGELOG.md
+++ b/charts/common/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0]
+
+### Changed
+
+- `probes.startupProbe` is now enabled by default. This will allow for quicker `Ready` states on Pods. It will precede the liveness and readiness Probes.
+- Aligned our default values for liveness and readiness Probes with the Kubernetes defaults:
+  - `initialDelaySeconds` is now 0
+  - `timeoutSeconds` is now 1
+  - `failureThreshold` is now 3
+
 ## [2.5.1]
 
 ### Added
@@ -98,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.7.0]
 
 This is the last version before starting this changelog. All sorts of cool stuff was changed, but only `git log` remembers what that was :slightly_frowning_face:
+
+[3.0.0]: https://github.com/k8s-at-home/charts/tree/common-3.0.0/charts/common
 
 [2.5.1]: https://github.com/k8s-at-home/charts/tree/common-2.5.1/charts/common
 

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.5.1
+version: 3.0.0
 keywords:
   - k8s-at-home
   - common

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -3,6 +3,7 @@ name: common
 description: Function library for k8s-at-home charts
 type: library
 version: 3.0.0
+kubeVersion: ">=1.16.0"
 keywords:
   - k8s-at-home
   - common

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -98,10 +98,10 @@ probes:
     ## The spec field contains the values for the default livenessProbe.
     ## If you selected custom: true, this field holds the definition of the livenessProbe.
     spec:
-      initialDelaySeconds: 30
-      failureThreshold: 5
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
 
   readiness:
     enabled: true
@@ -110,22 +110,23 @@ probes:
     ## The spec field contains the values for the default readinessProbe.
     ## If you selected custom: true, this field holds the definition of the readinessProbe.
     spec:
-      initialDelaySeconds: 30
-      failureThreshold: 5
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
 
   startup:
-    enabled: false
+    enabled: true
     ## Set this to true if you wish to specify your own startupProbe
     custom: false
     ## The spec field contains the values for the default startupProbe.
     ## If you selected custom: true, this field holds the definition of the startupProbe.
     spec:
-      initialDelaySeconds: 5
+      initialDelaySeconds: 0
+      timeoutSeconds: 1
+      ## This means it has a maximum of 5*30=150 seconds to start up before it fails
+      periodSeconds: 5
       failureThreshold: 30
-      periodSeconds: 10
-      timeoutSeconds: 10
 
 service:
   enabled: true


### PR DESCRIPTION
**Description of the change**

- [x] Enable startupProbe by default
- [x] Match default values for Probes with Kubernetes defaults

**Benefits**

Services will be reported as Ready a lot sooner, minimising downtime.

**Possible drawbacks**

N/A

**Applicable issues**

- fixes #573 

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
