### PR TITLE
[sonarr] chore: fix chart home URL after it was missed

### DIFF
--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 appVersion: 3.0.4.993
 description: Smart PVR for newsgroup and bittorrent users
 name: sonarr
-version: 9.0.0
+version: 9.0.1
 kubeVersion: ">=1.16.0"
 keywords:
 - sonarr
 - torrent
 - usenet
-home: https://github.com/k8s-at-home/charts/tree/master/charts/media-common/sonarr
+home: https://github.com/k8s-at-home/charts/tree/master/charts/sonarr
 icon: https://github.com/Sonarr/Sonarr/blob/phantom-develop/Logo/512.png?raw=true
 sources:
 - https://github.com/Sonarr/Sonarr


### PR DESCRIPTION
**Description of the change**

It looks like in September, there was an effort to reorganize the charts. Unfortunately, commit b94814d3d708ce4cf46bb0aafde9178cb5976092 moved the entries for Sonarr but missed this one URL.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

For users working through graphical installers like Rancher, this value is really helpful to have right.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

None

<!-- Describe any known limitations with your change -->

**Applicable issues**

n/a

**Additional information**

n/a

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
