### PR TITLE
[actions] remove updating timestamps in index.yaml

### DIFF
--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -52,39 +52,3 @@ jobs:
           charts_repo_url: https://k8s-at-home.com/charts/
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-  
-  # Update the generated timestamp in the index.yaml
-  # needed until https://github.com/helm/chart-releaser/issues/90
-  # or helm/chart-releaser-action supports this
-  post-release:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Block concurrent jobs
-        uses: softprops/turnstyle@v1
-        with:
-          continue-after-seconds: 180
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: "gh-pages"
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Commit and push timestamp updates
-        run: |
-          if [[ -f index.yaml ]]; then
-            git pull
-            export generated_date=$(date --utc +%FT%T.%9NZ)
-            sed -i -e "s/^generated:.*/generated: \"$generated_date\"/" index.yaml
-            git add index.yaml
-            git commit -sm "Update generated timestamp [ci-skip]" || exit 0
-            git push
-          fi

--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -45,7 +45,9 @@ jobs:
         uses: azure/setup-helm@v1
         with:
           version: v3.4.0
-
+     
+      # Waiting on new version to be released that supports updating the genereated timestamp field
+      # https://github.com/helm/chart-releaser/issues/103 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
         with:


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

- Flux2 relies less on this field now
- Chart releaser has been updated to generate this timestamp on the next release https://github.com/helm/chart-releaser/issues/90

I think it's safe to remove now even though the new version of the chart releaser action isn't released yet. Renovatebot should notify us of an upgrade to the action.