### PR TITLE
[oauth2-proxy] add support for ingressClassName

### DIFF
--- a/charts/oauth2-proxy/Chart.yaml
+++ b/charts/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 4.3.0
+version: 4.4.0
 apiVersion: v1
 appVersion: 5.1.0
 home: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/charts/oauth2-proxy/README.md
+++ b/charts/oauth2-proxy/README.md
@@ -87,6 +87,7 @@ Parameter | Description | Default
 `image.tag` | Image tag | `v5.1.0`
 `imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
 `ingress.enabled` | Enable Ingress | `false`
+`ingress.ingressClassName` | Set ingressClassName | `nil`
 `ingress.path` | Ingress accepted path | `/`
 `ingress.extraPaths` | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions). | `[]`
 `ingress.annotations` | Ingress annotations | `nil`

--- a/charts/oauth2-proxy/templates/ingress.yaml
+++ b/charts/oauth2-proxy/templates/ingress.yaml
@@ -21,6 +21,11 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+  {{- if $values.ingressClassName }}
+  ingressClassName: {{ $values.ingressClassName }}
+  {{- end }}
+  {{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host | quote }}

--- a/charts/oauth2-proxy/templates/ingress.yaml
+++ b/charts/oauth2-proxy/templates/ingress.yaml
@@ -22,8 +22,8 @@ metadata:
 {{- end }}
 spec:
   {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
-  {{- if $values.ingressClassName }}
-  ingressClassName: {{ $values.ingressClassName }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   {{- end }}
   rules:

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -99,6 +99,8 @@ ingress:
     # - secretName: chart-example-tls
     #   hosts:
     #     - chart-example.local
+  # Define the ingressClassName
+  # ingressClassName: nginx
 
 resources: {}
   # limits:


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Add support for ingressClassName in oauth2-proxy

**Benefits**

Add support for ingressClassName in oauth2-proxy

**Possible drawbacks**

N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #449

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [x] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
