### PR TITLE
[home-assistant] don't restrict to rsa ssh key type

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2021.1.5
 description: Home Assistant
 name: home-assistant
-version: 6.0.1
+version: 6.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - home-assistant

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -123,6 +123,7 @@ The value derived is the name of the kubernetes service object for home-assistan
 | env | object | `{}` |  |
 | git.deployKey | string | `""` |  |
 | git.deployKeyBase64 | string | `""` |  |
+| git.keyType | string | `"rsa"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"homeassistant/home-assistant"` |  |
 | image.tag | string | `"2021.1.5"` |  |

--- a/charts/home-assistant/templates/secret.yaml
+++ b/charts/home-assistant/templates/secret.yaml
@@ -8,8 +8,8 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.git.deployKey }}
-  id_rsa: {{ .Values.git.deployKey | b64enc | quote }}
+  id_{{ .Values.git.keyType }}: {{ .Values.git.deployKey | b64enc | quote }}
   {{- else }}
-  id_rsa: {{ .Values.git.deployKeyBase64 | quote }}
+  id_{{ .Values.git.keyType }}: {{ .Values.git.deployKeyBase64 | quote }}
   {{- end }}
 {{- end }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -39,6 +39,8 @@ git:
   deployKey: ""
   # Base64-encoded SSH private key. When both variables are set, the raw SSH key takes precedence.
   deployKeyBase64: ""
+  # SSH key type (secret key will be named "id_${keyType}"
+  keyType: rsa
 
 # Enable a prometheus-operator servicemonitor
 prometheus:


### PR DESCRIPTION
**Description of the change**
Don't restrict to rsa ssh key type for home-assistant

**Benefits**
Not much.

**Possible drawbacks**
Not much either.

**Applicable issues**
I prefer ed25519.

**Additional information**
I could've used RSA for this TBH but I decided to make a PR since I have a big heart.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [x] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
