### PR TITLE
[pyload] Add /downloads PVC use to pyload chart

### DIFF
--- a/charts/pyload/Chart.yaml
+++ b/charts/pyload/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.4.20
 description: pyLoad is a Free and Open Source download manager written in Python and designed to be extremely lightweight, easily extensible and fully manageable via web.
 name: pyload
-version: 3.0.1
+version: 3.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - pyload

--- a/charts/pyload/values.yaml
+++ b/charts/pyload/values.yaml
@@ -29,3 +29,19 @@ persistence:
   config:
     enabled: false
     emptyDir: false
+  downloads:
+    enabled: false
+    emptyDir: false
+    mountPath: /downloads
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    # storageClass: "-"
+    # accessMode: ReadWriteOnce
+    # size: 1Gi
+    ## Do not delete the pvc upon helm uninstall
+    # skipuninstall: false
+    # existingClaim: ""


### PR DESCRIPTION
Simple addition of a sample for the /downloads mount path used by pyload.
Just thought it would be worth to be added to the values.yaml of the pycharm chart :)

**Description of the change**

See above

**Benefits**

Anyone deploying the chart may not wonder where downloads go ;)

**Possible drawbacks**

None

**Applicable issues**

-

**Additional information**
-

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

