### PR TITLE
[transmission] always use chart-defined config

### DIFF
--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3.0.0
 description: Transmission is a cross-platform BitTorrent client
 name: transmission
-version: 1.1.0
+version: 2.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - transmission

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3.0.0
 description: Transmission is a cross-platform BitTorrent client
 name: transmission
-version: 1.0.0
+version: 1.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - transmission

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 Transmission is a cross-platform BitTorrent client
 

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -186,7 +186,7 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [1.1.0]
+### [2.0.0]
 
 #### Changed
 

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,14 +1,14 @@
 # transmission
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
-transmission helm package
+Transmission is a cross-platform BitTorrent client
 
 **This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
 
 ## Source Code
 
-* <https://github.com/transmission/transmission-docker>
+* <https://hub.docker.com/r/linuxserver/transmission>
 * <https://github.com/k8s-at-home/charts/tree/master/charts/transmission>
 
 ## Requirements
@@ -78,11 +78,107 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"transmission/transmission"` |  |
-| image.tag | string | `"1.0.0"` |  |
+| image.repository | string | `"linuxserver/transmission"` |  |
+| image.tag | string | `"version-3.00-r2"` |  |
 | ingress.enabled | bool | `false` |  |
-| service.port.port | int | `1880` |  |
+| persistence.config.emptyDir | bool | `false` |  |
+| persistence.config.enabled | bool | `false` |  |
+| persistence.config.mountPath | string | `"/config"` |  |
+| persistence.downloads.emptyDir | bool | `false` |  |
+| persistence.downloads.enabled | bool | `false` |  |
+| persistence.downloads.mountPath | string | `"/downloads"` |  |
+| persistence.watch.emptyDir | bool | `false` |  |
+| persistence.watch.enabled | bool | `false` |  |
+| persistence.watch.mountPath | string | `"/watch"` |  |
+| probes.liveness.spec.timeoutSeconds | int | `30` |  |
+| probes.readiness.spec.timeoutSeconds | int | `30` |  |
+| service.additionalServices[0].annotations | object | `{}` |  |
+| service.additionalServices[0].enabled | bool | `true` |  |
+| service.additionalServices[0].nameSuffix | string | `"utptcp"` |  |
+| service.additionalServices[0].port.name | string | `"utptcp"` |  |
+| service.additionalServices[0].port.port | int | `51413` |  |
+| service.additionalServices[0].port.protocol | string | `"TCP"` |  |
+| service.additionalServices[0].port.targetport | int | `51413` |  |
+| service.additionalServices[0].type | string | `"ClusterIP"` |  |
+| service.additionalServices[1].annotations | object | `{}` |  |
+| service.additionalServices[1].enabled | bool | `true` |  |
+| service.additionalServices[1].nameSuffix | string | `"utpudp"` |  |
+| service.additionalServices[1].port.name | string | `"utpudp"` |  |
+| service.additionalServices[1].port.port | int | `51413` |  |
+| service.additionalServices[1].port.protocol | string | `"UDP"` |  |
+| service.additionalServices[1].port.targetport | int | `51413` |  |
+| service.additionalServices[1].type | string | `"ClusterIP"` |  |
+| service.port.name | string | `"http"` |  |
+| service.port.port | int | `9091` |  |
 | strategy.type | string | `"Recreate"` |  |
+| transmissionConfig.alt-speed-down | int | `50` |  |
+| transmissionConfig.alt-speed-enabled | bool | `false` |  |
+| transmissionConfig.alt-speed-time-begin | int | `540` |  |
+| transmissionConfig.alt-speed-time-day | int | `127` |  |
+| transmissionConfig.alt-speed-time-enabled | bool | `false` |  |
+| transmissionConfig.alt-speed-time-end | int | `1020` |  |
+| transmissionConfig.alt-speed-up | int | `50` |  |
+| transmissionConfig.bind-address-ipv4 | string | `"0.0.0.0"` |  |
+| transmissionConfig.bind-address-ipv6 | string | `"::\""` |  |
+| transmissionConfig.blocklist-enabled | bool | `true` |  |
+| transmissionConfig.blocklist-url | string | `"http://john.bitsurge.net/public/biglist.p2p.gz"` |  |
+| transmissionConfig.cache-size-mb | int | `4` |  |
+| transmissionConfig.dht-enabled | bool | `true` |  |
+| transmissionConfig.download-dir | string | `"/downloads/complete"` |  |
+| transmissionConfig.download-queue-enabled | bool | `true` |  |
+| transmissionConfig.download-queue-size | int | `5` |  |
+| transmissionConfig.encryption | int | `1` |  |
+| transmissionConfig.idle-seeding-limit | int | `30` |  |
+| transmissionConfig.idle-seeding-limit-enabled | bool | `false` |  |
+| transmissionConfig.incomplete-dir | string | `"/downloads/incomplete"` |  |
+| transmissionConfig.incomplete-dir-enabled | bool | `true` |  |
+| transmissionConfig.lpd-enabled | bool | `false` |  |
+| transmissionConfig.message-level | int | `2` |  |
+| transmissionConfig.peer-congestion-algorithm | string | `""` |  |
+| transmissionConfig.peer-id-ttl-hours | int | `6` |  |
+| transmissionConfig.peer-limit-global | int | `200` |  |
+| transmissionConfig.peer-limit-per-torrent | int | `50` |  |
+| transmissionConfig.peer-port | int | `51413` |  |
+| transmissionConfig.peer-port-random-high | int | `65535` |  |
+| transmissionConfig.peer-port-random-low | int | `49152` |  |
+| transmissionConfig.peer-port-random-on-start | bool | `false` |  |
+| transmissionConfig.peer-socket-tos | string | `"default"` |  |
+| transmissionConfig.pex-enabled | bool | `true` |  |
+| transmissionConfig.port-forwarding-enabled | bool | `false` |  |
+| transmissionConfig.preallocation | int | `1` |  |
+| transmissionConfig.prefetch-enabled | bool | `true` |  |
+| transmissionConfig.queue-stalled-enabled | bool | `true` |  |
+| transmissionConfig.queue-stalled-minutes | int | `30` |  |
+| transmissionConfig.ratio-limit | int | `2` |  |
+| transmissionConfig.ratio-limit-enabled | bool | `false` |  |
+| transmissionConfig.rename-partial-files | bool | `true` |  |
+| transmissionConfig.rpc-authentication-required | bool | `false` |  |
+| transmissionConfig.rpc-bind-address | string | `"0.0.0.0"` |  |
+| transmissionConfig.rpc-enabled | bool | `true` |  |
+| transmissionConfig.rpc-host-whitelist | string | `""` |  |
+| transmissionConfig.rpc-host-whitelist-enabled | bool | `false` |  |
+| transmissionConfig.rpc-password | string | `"CHANGEME"` |  |
+| transmissionConfig.rpc-port | int | `9091` |  |
+| transmissionConfig.rpc-url | string | `"/transmission/"` |  |
+| transmissionConfig.rpc-username | string | `""` |  |
+| transmissionConfig.rpc-whitelist | string | `""` |  |
+| transmissionConfig.rpc-whitelist-enabled | bool | `false` |  |
+| transmissionConfig.scrape-paused-torrents-enabled | bool | `true` |  |
+| transmissionConfig.script-torrent-done-enabled | bool | `false` |  |
+| transmissionConfig.script-torrent-done-filename | string | `""` |  |
+| transmissionConfig.seed-queue-enabled | bool | `false` |  |
+| transmissionConfig.seed-queue-size | int | `10` |  |
+| transmissionConfig.speed-limit-down | int | `100` |  |
+| transmissionConfig.speed-limit-down-enabled | bool | `false` |  |
+| transmissionConfig.speed-limit-up | int | `100` |  |
+| transmissionConfig.speed-limit-up-enabled | bool | `false` |  |
+| transmissionConfig.start-added-torrents | bool | `true` |  |
+| transmissionConfig.trash-original-torrent-files | bool | `false` |  |
+| transmissionConfig.umask | int | `2` |  |
+| transmissionConfig.upload-slots-per-torrent | int | `14` |  |
+| transmissionConfig.utp-enabled | bool | `true` |  |
+| transmissionConfig.watch-dir | string | `"/watch"` |  |
+| transmissionConfig.watch-dir-enabled | bool | `false` |  |
 
 ## Changelog
 
@@ -90,19 +186,17 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.1.0]
+
+#### Changed
+
+- customConfig became transmissionConfig and is always used
+
 ### [1.0.0]
 
 #### Added
 
-- N/A
-
-#### Changed
-
-- N/A
-
-#### Removed
-
-- N/A
+- Initial commit
 
 [1.0.0]: #1.0.0
 

--- a/charts/transmission/README_CHANGELOG.md.gotmpl
+++ b/charts/transmission/README_CHANGELOG.md.gotmpl
@@ -9,19 +9,17 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.1.0]
+
+#### Changed
+
+- customConfig became transmissionConfig and is always used
+
 ### [1.0.0]
 
 #### Added
 
-- N/A
-
-#### Changed
-
-- N/A
-
-#### Removed
-
-- N/A
+- Initial commit
 
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/transmission/README_CHANGELOG.md.gotmpl
+++ b/charts/transmission/README_CHANGELOG.md.gotmpl
@@ -9,7 +9,7 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [1.1.0]
+### [2.0.0]
 
 #### Changed
 

--- a/charts/transmission/templates/common.yaml
+++ b/charts/transmission/templates/common.yaml
@@ -1,1 +1,31 @@
+{{/* Make sure all variables are set properly */}}
+{{- include "common.values.setup" . }}
+
+{{/* Append the configMap to the additionalVolumes */}}
+{{- define "transmission.configmap.volume" -}}
+name: transmission-settings
+configMap:
+  name: {{ template "common.names.fullname" . }}-config
+{{- end -}}
+
+{{- $volume := include "transmission.configmap.volume" . | fromYaml -}}
+{{- if $volume -}}
+    {{- $additionalVolumes := append .Values.additionalVolumes $volume }}
+    {{- $_ := set .Values "additionalVolumes" (deepCopy $additionalVolumes) -}}
+{{- end -}}
+
+{{/* Append the configMap volume to the additionalVolumeMounts */}}
+{{- define "transmission.configmap.volumeMount" -}}
+name: transmission-settings
+mountPath: /config/settings.json
+subPath: settings.json
+{{- end -}}
+
+{{- $volumeMount := include "transmission.configmap.volumeMount" . | fromYaml -}}
+{{- if $volumeMount -}}
+    {{- $additionalVolumeMounts := append .Values.additionalVolumeMounts $volumeMount }}
+    {{- $_ := set .Values "additionalVolumeMounts" (deepCopy $additionalVolumeMounts) -}}
+{{- end -}}
+
+{{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/transmission/templates/configmap.yaml
+++ b/charts/transmission/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.customConfig.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +6,4 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 data:
   settings.json: |
-    {{- .Values.customconfig.config | mustToPrettyJson | nindent 4 }}
-{{- end }}
+    {{- .Values.transmissionConfig | mustToPrettyJson | nindent 4 }}

--- a/charts/transmission/values.yaml
+++ b/charts/transmission/values.yaml
@@ -99,86 +99,72 @@ persistence:
     emptyDir: false
     mountPath: /watch
 
-## Enable this if you want to specify your own config within the chart
-# additionalVolumes:
-#   - name: transmission-config
-#     configMap:
-#       # Replace RELEASE-NAME with your actual name
-#       name: RELEASE-NAME-transmission-config
-#
-# additionalVolumeMounts:
-#   - mountPath: /config/settings.json
-#     name: transmission-config
-#     subPath: settings.json
-
-customConfig:
-  enabled: false
-  config:
-    alt-speed-down: 50
-    alt-speed-enabled: false
-    alt-speed-time-begin: 540
-    alt-speed-time-day: 127
-    alt-speed-time-enabled: false
-    alt-speed-time-end: 1020
-    alt-speed-up: 50
-    bind-address-ipv4: "0.0.0.0"
-    bind-address-ipv6: ::"
-    blocklist-enabled: true
-    blocklist-url: "http://john.bitsurge.net/public/biglist.p2p.gz"
-    cache-size-mb: 4
-    dht-enabled: true
-    download-dir: "/downloads/complete"
-    download-queue-enabled: true
-    download-queue-size: 5
-    encryption: 1
-    idle-seeding-limit: 30
-    idle-seeding-limit-enabled: false
-    incomplete-dir: "/downloads/incomplete"
-    incomplete-dir-enabled: true
-    lpd-enabled: false
-    message-level: 2
-    peer-congestion-algorithm: ""
-    peer-id-ttl-hours: 6
-    peer-limit-global: 200
-    peer-limit-per-torrent: 50
-    peer-port: 51413
-    peer-port-random-high: 65535
-    peer-port-random-low: 49152
-    peer-port-random-on-start: false
-    peer-socket-tos: "default"
-    pex-enabled: true
-    port-forwarding-enabled: false
-    preallocation: 1
-    prefetch-enabled: true
-    queue-stalled-enabled: true
-    queue-stalled-minutes: 30
-    ratio-limit: 2
-    ratio-limit-enabled: false
-    rename-partial-files: true
-    rpc-authentication-required: false
-    rpc-bind-address: "0.0.0.0"
-    rpc-enabled: true
-    rpc-host-whitelist: ""
-    rpc-host-whitelist-enabled: false
-    rpc-password: "CHANGEME"
-    rpc-port: 9091
-    rpc-url: "/transmission/"
-    rpc-username: ""
-    rpc-whitelist: ""
-    rpc-whitelist-enabled: false
-    scrape-paused-torrents-enabled: true
-    script-torrent-done-enabled: false
-    script-torrent-done-filename: ""
-    seed-queue-enabled: false
-    seed-queue-size: 10
-    speed-limit-down: 100
-    speed-limit-down-enabled: false
-    speed-limit-up: 100
-    speed-limit-up-enabled: false
-    start-added-torrents: true
-    trash-original-torrent-files: false
-    umask: 2
-    upload-slots-per-torrent: 14
-    utp-enabled: true
-    watch-dir: "/watch"
-    watch-dir-enabled: false
+transmissionConfig:
+  alt-speed-down: 50
+  alt-speed-enabled: false
+  alt-speed-time-begin: 540
+  alt-speed-time-day: 127
+  alt-speed-time-enabled: false
+  alt-speed-time-end: 1020
+  alt-speed-up: 50
+  bind-address-ipv4: "0.0.0.0"
+  bind-address-ipv6: ::"
+  blocklist-enabled: true
+  blocklist-url: "http://john.bitsurge.net/public/biglist.p2p.gz"
+  cache-size-mb: 4
+  dht-enabled: true
+  download-dir: "/downloads/complete"
+  download-queue-enabled: true
+  download-queue-size: 5
+  encryption: 1
+  idle-seeding-limit: 30
+  idle-seeding-limit-enabled: false
+  incomplete-dir: "/downloads/incomplete"
+  incomplete-dir-enabled: true
+  lpd-enabled: false
+  message-level: 2
+  peer-congestion-algorithm: ""
+  peer-id-ttl-hours: 6
+  peer-limit-global: 200
+  peer-limit-per-torrent: 50
+  peer-port: 51413
+  peer-port-random-high: 65535
+  peer-port-random-low: 49152
+  peer-port-random-on-start: false
+  peer-socket-tos: "default"
+  pex-enabled: true
+  port-forwarding-enabled: false
+  preallocation: 1
+  prefetch-enabled: true
+  queue-stalled-enabled: true
+  queue-stalled-minutes: 30
+  ratio-limit: 2
+  ratio-limit-enabled: false
+  rename-partial-files: true
+  rpc-authentication-required: false
+  rpc-bind-address: "0.0.0.0"
+  rpc-enabled: true
+  rpc-host-whitelist: ""
+  rpc-host-whitelist-enabled: false
+  rpc-password: "CHANGEME"
+  rpc-port: 9091
+  rpc-url: "/transmission/"
+  rpc-username: ""
+  rpc-whitelist: ""
+  rpc-whitelist-enabled: false
+  scrape-paused-torrents-enabled: true
+  script-torrent-done-enabled: false
+  script-torrent-done-filename: ""
+  seed-queue-enabled: false
+  seed-queue-size: 10
+  speed-limit-down: 100
+  speed-limit-down-enabled: false
+  speed-limit-up: 100
+  speed-limit-up-enabled: false
+  start-added-torrents: true
+  trash-original-torrent-files: false
+  umask: 2
+  upload-slots-per-torrent: 14
+  utp-enabled: true
+  watch-dir: "/watch"
+  watch-dir-enabled: false


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
The chart now always uses the chart-defined transmission config
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
App config is now idempotent
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [X] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
