### PR TITLE
[workflows] create issue workflows [ci-skip]

### DIFF
--- a/.github/workflows/invalid-template.yaml
+++ b/.github/workflows/invalid-template.yaml
@@ -1,0 +1,21 @@
+---
+
+name: 'Invalid Template'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+
+jobs:
+  support:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: dessant/support-requests@v2
+      with:
+        github-token: ${{ github.token }}
+        support-label: 'invalid:template-incomplete'
+        issue-comment: >
+          :wave: @{issue-author}, please follow the template provided.
+        close-issue: true
+        lock-issue: true
+        issue-lock-reason: 'resolved'

--- a/.github/workflows/invalid-template.yaml
+++ b/.github/workflows/invalid-template.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: dessant/support-requests@v2
       with:
-        github-token: ${{ github.token }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         support-label: 'invalid:template-incomplete'
         issue-comment: >
           :wave: @{issue-author}, please follow the template provided.

--- a/.github/workflows/support.yaml
+++ b/.github/workflows/support.yaml
@@ -10,17 +10,17 @@ jobs:
   support:
     runs-on: ubuntu-20.04
     steps:
-      - uses: dessant/support-requests@v2
-        with:
-          github-token: ${{ github.token }}
-          support-label: 'support'
-          issue-comment: >
-            :wave: @{issue-author}, we use the issue tracker exclusively
-            for bug reports and feature requests. However, this issue appears
-            to be a support request. Please use our support channels
-            to get help with our Helm charts.
-            - [Discord](https://discord.gg/sTMX7Vh)
-            - [GitHub Discussions](https://github.com/k8s-at-home/charts/discussions)
-          close-issue: true
-          lock-issue: false
-          issue-lock-reason: 'off-topic'
+    - uses: dessant/support-requests@v2
+      with:
+        github-token: ${{ github.token }}
+        support-label: 'support'
+        issue-comment: >
+          :wave: @{issue-author}, we use the issue tracker exclusively
+          for bug reports and feature requests. However, this issue appears
+          to be a support request. Please use our support channels
+          to get help with our Helm charts.
+          - [Discord](https://discord.gg/sTMX7Vh)
+          - [GitHub Discussions](https://github.com/k8s-at-home/charts/discussions)
+        close-issue: true
+        lock-issue: false
+        issue-lock-reason: 'off-topic'

--- a/.github/workflows/support.yaml
+++ b/.github/workflows/support.yaml
@@ -1,0 +1,26 @@
+---
+
+name: 'Support requests'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+
+jobs:
+  support:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: dessant/support-requests@v2
+        with:
+          github-token: ${{ github.token }}
+          support-label: 'support'
+          issue-comment: >
+            :wave: @{issue-author}, we use the issue tracker exclusively
+            for bug reports and feature requests. However, this issue appears
+            to be a support request. Please use our support channels
+            to get help with our Helm charts.
+            - [Discord](https://discord.gg/sTMX7Vh)
+            - [GitHub Discussions](https://github.com/k8s-at-home/charts/discussions)
+          close-issue: true
+          lock-issue: false
+          issue-lock-reason: 'off-topic'

--- a/.github/workflows/support.yaml
+++ b/.github/workflows/support.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: dessant/support-requests@v2
       with:
-        github-token: ${{ github.token }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         support-label: 'support'
         issue-comment: >
           :wave: @{issue-author}, we use the issue tracker exclusively


### PR DESCRIPTION
**Description of the change**

- Adds an support workflow, when we label issues with the `support` label, the issue will be closed, and a message posted to the issue.
- Adds an invalid template workflow, when we label issues with the `invalid/template-incomplete` label, the issue will be closed, locked and a message posted to the issue.