### PR TITLE
[meta] remove source line matching chart home in template [ci-skip]

### DIFF
--- a/templates/chart/Chart.yaml
+++ b/templates/chart/Chart.yaml
@@ -10,7 +10,6 @@ home: https://github.com/k8s-at-home/charts/tree/master/charts/${CHARTNAME}
 icon: https://${CHARTNAME}.org/icon
 sources:
 - https://github.com/${CHARTNAME}/${CHARTNAME}-docker
-- https://github.com/k8s-at-home/charts/tree/master/charts/${CHARTNAME}
 maintainers:
 - name: ${CHARTNAME}
   email: ${CHARTNAME}@${CHARTNAME}.com


### PR DESCRIPTION
**Description of the change**

remove arguably redundant source line; reducing redundancy

**Benefits**

reducing redundancy

**Possible drawbacks**

doesn't also remove all the existing redundant lines

**Applicable issues**

> This one is a bit superfluous since it's also the `home` location of the chart

_Originally posted by @bjw-s in https://github.com/k8s-at-home/charts/pull/575#discussion_r580824153_
