### PR TITLE
[plex] fix typos

### DIFF
--- a/charts/plex/Chart.yaml
+++ b/charts/plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.20.2.3402
 description: Plex Media Server
 name: plex
-version: 2.3.0
+version: 2.3.1
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/plex/values.yaml
+++ b/charts/plex/values.yaml
@@ -150,8 +150,8 @@ plexPreferences:
     name: 41-plex-preferences
     defaultMode: 493  # 0755 in octal permission notation
     # Using mountPath & SubPath allow you to volume mount a configMap AS A FILE
-    # Unfortunately this also means that updates to the configMap are not automtically
-    # propagated to the file contents. But it's better then replacing the entire
+    # Unfortunately this also means that updates to the configMap are not automatically
+    # propagated to the file contents. But it's better than replacing the entire
     # /etc/cont-init.d/ directory which is the "normal" behavior when doing volume
     # mounts.
     mountPath: /etc/cont-init.d/41-plex-preferences


### PR DESCRIPTION
just some typos

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)