### PR TITLE
[uptimerobot] Swapping from configMapKeyRef to secretKeyRef

### DIFF
--- a/charts/uptimerobot/Chart.yaml
+++ b/charts/uptimerobot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: uptimerobot
-version: 3.0.0
+version: 3.0.1
 appVersion: 1.1.0
 description: A tool to get statistics from Uptime Robot and log it into InfluxDB
 keywords:

--- a/charts/uptimerobot/templates/deployment.yaml
+++ b/charts/uptimerobot/templates/deployment.yaml
@@ -39,14 +39,14 @@ spec:
             {{- if .Values.config.influxdb.username }}
             - name: INFLUX_USERNAME
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   name: {{ template "uptimerobot.fullname" . }}
                   key: influxdb-username
             {{- end }}
             {{- if .Values.config.influxdb.password }}
             - name: INFLUX_PASSWORD
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   name: {{ template "uptimerobot.fullname" . }}
                   key: influxdb-password
             {{- end }}


### PR DESCRIPTION
**Description of the change**

This PR is needed to fix the uptimerobot chart when using `config.influxdb.username` and `config.influxdb.password`. Currently the values get added to the secret uptimerobot but the deployment template references a configmap. But there is not configmap defined in the chart.

**Benefits**

This allows the chart to be deployed when using setting the influxdb creds.

**Possible drawbacks**

None

**Applicable issues**

#640 

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
