### PR TITLE
[duplicati] Add possibility to add additional volume mounts

### DIFF
--- a/charts/duplicati/Chart.yaml
+++ b/charts/duplicati/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.0.5.1
 description: Store securely encrypted backups on cloud storage services!
 name: duplicati
-version: 2.0.2
+version: 2.1.0
 keywords:
   - duplicati
 home: https://github.com/k8s-at-home/charts/tree/master/charts/duplicati

--- a/charts/duplicati/Chart.yaml
+++ b/charts/duplicati/Chart.yaml
@@ -11,5 +11,5 @@ sources:
   - https://hub.docker.com/r/linuxserver/duplicati/
   - https://github.com/duplicati/duplicati
 maintainers:
-  - name: skaro13
+  - name: simoncaron
     email: simon.caron@protonmail.com

--- a/charts/duplicati/Chart.yaml
+++ b/charts/duplicati/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.0.5.1
 description: Store securely encrypted backups on cloud storage services!
 name: duplicati
-version: 2.0.1
+version: 2.0.2
 keywords:
   - duplicati
 home: https://github.com/k8s-at-home/charts/tree/master/charts/duplicati

--- a/charts/duplicati/templates/deployment.yaml
+++ b/charts/duplicati/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
               subPath: {{ .Values.persistence.source.subPath }}
             {{- end }}
             {{- if .Values.additionalVolumeMounts }} 
-              {{- toYaml .Values.additionalVolumeMounts | indent 12}} 
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12}} 
             {{- end }} 
             - mountPath: /backups
               name: backups
@@ -102,7 +102,7 @@ spec:
         emptyDir: {}
       {{- end }}
       {{- if .Values.additionalVolumes }} 
-        {{- toYaml .Values.additionalVolumes | indent 6}} 
+        {{- toYaml .Values.additionalVolumes | nindent 6}} 
       {{- end }} 
       - name: backups
       {{- if .Values.persistence.backups.enabled }}

--- a/charts/duplicati/templates/deployment.yaml
+++ b/charts/duplicati/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
               subPath: {{ .Values.persistence.source.subPath }}
             {{- end }}
             {{- if .Values.additionalVolumeMounts }} 
-              {{ toYaml .Values.additionalVolumeMounts | indent 12}} 
+              {{- toYaml .Values.additionalVolumeMounts | indent 12}} 
             {{- end }} 
             - mountPath: /backups
               name: backups
@@ -102,7 +102,7 @@ spec:
         emptyDir: {}
       {{- end }}
       {{- if .Values.additionalVolumes }} 
-        {{ toYaml .Values.additionalVolumes | indent 6}} 
+        {{- toYaml .Values.additionalVolumes | indent 6}} 
       {{- end }} 
       - name: backups
       {{- if .Values.persistence.backups.enabled }}

--- a/charts/duplicati/templates/deployment.yaml
+++ b/charts/duplicati/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
             {{- if .Values.persistence.source.subPath }}
               subPath: {{ .Values.persistence.source.subPath }}
             {{- end }}
+            {{- if .Values.additionalVolumeMounts }} 
+            {{ toYaml .Values.additionalVolumeMounts | indent 12}} 
+            {{- end }} 
             - mountPath: /backups
               name: backups
             {{- if .Values.persistence.backups.subPath }}
@@ -98,6 +101,9 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
+      {{- if .Values.additionalVolumes }} 
+      {{ toYaml .Values.additionalVolumes | indent 6}} 
+      {{- end }} 
       - name: backups
       {{- if .Values.persistence.backups.enabled }}
         persistentVolumeClaim:

--- a/charts/duplicati/templates/deployment.yaml
+++ b/charts/duplicati/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
               subPath: {{ .Values.persistence.source.subPath }}
             {{- end }}
             {{- if .Values.additionalVolumeMounts }} 
-            {{ toYaml .Values.additionalVolumeMounts | indent 12}} 
+              {{ toYaml .Values.additionalVolumeMounts | indent 12}} 
             {{- end }} 
             - mountPath: /backups
               name: backups
@@ -102,7 +102,7 @@ spec:
         emptyDir: {}
       {{- end }}
       {{- if .Values.additionalVolumes }} 
-      {{ toYaml .Values.additionalVolumes | indent 6}} 
+        {{ toYaml .Values.additionalVolumes | indent 6}} 
       {{- end }} 
       - name: backups
       {{- if .Values.persistence.backups.enabled }}


### PR DESCRIPTION
**Description of the change**

Add the possibility to add additional volume mounts for example nfs.

**Benefits**

With this option you are able to mount also nfs shares to duplicati so that you can backup them.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)