### PR TITLE
[homer] configmap support

### DIFF
--- a/charts/homer/Chart.yaml
+++ b/charts/homer/Chart.yaml
@@ -4,7 +4,7 @@ description: A dead simple static HOMepage for your servER to keep your services
 icon: https://raw.githubusercontent.com/bastienwirtz/homer/main/public/logo.png
 home: https://github.com/bastienwirtz/homer
 name: homer
-version: 3.1.0
+version: 3.2.0
 kubeVersion: ">=1.16.0-0"
 sources:
 - https://github.com/bastienwirtz/homer

--- a/charts/homer/README.md
+++ b/charts/homer/README.md
@@ -75,7 +75,8 @@ N/A
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config | string | `"externalConfig: https://raw.githubusercontent.com/bastienwirtz/homer/main/public/assets/config.yml.dist\n"` | Homer configuration https://github.com/bastienwirtz/homer/blob/main/docs/configuration.md |
+| configmap.config | string | `"externalConfig: https://raw.githubusercontent.com/bastienwirtz/homer/main/public/assets/config.yml.dist\n"` | Homer configuration https://github.com/bastienwirtz/homer/blob/main/docs/configuration.md |
+| configmap.enabled | bool | `false` | Store homer configuration as a ConfigMap |
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"b4bz/homer"` |  |

--- a/charts/homer/README.md
+++ b/charts/homer/README.md
@@ -1,6 +1,6 @@
 # homer
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![AppVersion: 20.09.1](https://img.shields.io/badge/AppVersion-20.09.1-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 20.09.1](https://img.shields.io/badge/AppVersion-20.09.1-informational?style=flat-square)
 
 A dead simple static HOMepage for your servER to keep your services on hand, from a simple yaml configuration file.
 
@@ -18,7 +18,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://k8s-at-home.com/charts/ | common | 3.0.1 |
+| https://k8s-at-home.com/charts/ | common | 3.1.0 |
 
 ## TL;DR
 
@@ -75,6 +75,7 @@ N/A
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| config | string | `"externalConfig: https://raw.githubusercontent.com/bastienwirtz/homer/main/public/assets/config.yml.dist\n"` | Homer configuration https://github.com/bastienwirtz/homer/blob/main/docs/configuration.md |
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"b4bz/homer"` |  |
@@ -92,19 +93,19 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [1.0.0]
+### [3.2.0]
 
 #### Added
 
-- N/A
+- Added changelog.
+- Updated README to reflect common chart dependency version in use.
+- Enable homer configuration through values.yaml.
 
-#### Changed
+[3.2.0]: https://github.com/k8s-at-home/charts/tree/homer-3.1.0/charts
 
-- N/A
+### [1.0.0]
 
-#### Removed
-
-- N/A
+No changelog prior to 3.2.0
 
 [1.0.0]: #1.0.0
 

--- a/charts/homer/README_CHANGELOG.md.gotmpl
+++ b/charts/homer/README_CHANGELOG.md.gotmpl
@@ -9,19 +9,19 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [1.0.0]
+### [3.2.0]
 
 #### Added
 
-- N/A
+- Added changelog.
+- Updated README to reflect common chart dependency version in use.
+- Enable homer configuration through values.yaml.
 
-#### Changed
+[3.2.0]: https://github.com/k8s-at-home/charts/tree/homer-3.1.0/charts
 
-- N/A
+### [1.0.0]
 
-#### Removed
-
-- N/A
+No changelog prior to 3.2.0
 
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/homer/templates/_helpers.tpl
+++ b/charts/homer/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "homer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "homer.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "homer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/homer/templates/common.yaml
+++ b/charts/homer/templates/common.yaml
@@ -1,6 +1,15 @@
 {{/* Make sure all variables are set properly */}}
 {{- include "common.values.setup" . }}
 
+{{/* merge homer specific annotations with podAnnotations*/}}
+{{- define "homer.podAnnotations" -}}
+configmap/checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- end -}}
+
+{{- $homerPodAnnotations := include "homer.podAnnotations" . | fromYaml -}}
+{{- $podAnnotations := merge .Values.podAnnotations $homerPodAnnotations -}}
+{{- $_ := set .Values "podAnnotations" (deepCopy $podAnnotations) -}}
+
 {{/* Append the configMap to the additionalVolumes */}}
 {{- define "homer.configmap.volume" -}}
 name: config

--- a/charts/homer/templates/common.yaml
+++ b/charts/homer/templates/common.yaml
@@ -6,9 +6,11 @@
 configmap/checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- end -}}
 
+{{- if .Values.configmap.enabled -}}
 {{- $homerPodAnnotations := include "homer.podAnnotations" . | fromYaml -}}
 {{- $podAnnotations := merge .Values.podAnnotations $homerPodAnnotations -}}
 {{- $_ := set .Values "podAnnotations" (deepCopy $podAnnotations) -}}
+{{- end -}}
 
 {{/* Append the configMap to the additionalVolumes */}}
 {{- define "homer.configmap.volume" -}}
@@ -17,10 +19,10 @@ configMap:
   name: {{ template "common.names.fullname" . }}-config
 {{- end -}}
 
+{{- if .Values.configmap.enabled -}}
 {{- $volume := include "homer.configmap.volume" . | fromYaml -}}
-{{- if $volume -}}
-    {{- $additionalVolumes := append .Values.additionalVolumes $volume }}
-    {{- $_ := set .Values "additionalVolumes" (deepCopy $additionalVolumes) -}}
+{{- $additionalVolumes := append .Values.additionalVolumes $volume }}
+{{- $_ := set .Values "additionalVolumes" (deepCopy $additionalVolumes) -}}
 {{- end -}}
 
 {{/* Append the configMap volume to the additionalVolumeMounts */}}
@@ -30,10 +32,10 @@ mountPath: /www/assets/config.yml
 subPath: config.yml
 {{- end -}}
 
+{{- if .Values.configmap.enabled -}}
 {{- $volumeMount := include "homer.configmap.volumeMount" . | fromYaml -}}
-{{- if $volumeMount -}}
-    {{- $additionalVolumeMounts := append .Values.additionalVolumeMounts $volumeMount }}
-    {{- $_ := set .Values "additionalVolumeMounts" (deepCopy $additionalVolumeMounts) -}}
+{{- $additionalVolumeMounts := append .Values.additionalVolumeMounts $volumeMount }}
+{{- $_ := set .Values "additionalVolumeMounts" (deepCopy $additionalVolumeMounts) -}}
 {{- end -}}
 
 {{/* Render the templates */}}

--- a/charts/homer/templates/common.yaml
+++ b/charts/homer/templates/common.yaml
@@ -1,1 +1,31 @@
+{{/* Make sure all variables are set properly */}}
+{{- include "common.values.setup" . }}
+
+{{/* Append the configMap to the additionalVolumes */}}
+{{- define "homer.configmap.volume" -}}
+name: config
+configMap:
+  name: {{ template "common.names.fullname" . }}-config
+{{- end -}}
+
+{{- $volume := include "homer.configmap.volume" . | fromYaml -}}
+{{- if $volume -}}
+    {{- $additionalVolumes := append .Values.additionalVolumes $volume }}
+    {{- $_ := set .Values "additionalVolumes" (deepCopy $additionalVolumes) -}}
+{{- end -}}
+
+{{/* Append the configMap volume to the additionalVolumeMounts */}}
+{{- define "homer.configmap.volumeMount" -}}
+name: config
+mountPath: /www/assets/config.yml
+subPath: config.yml
+{{- end -}}
+
+{{- $volumeMount := include "homer.configmap.volumeMount" . | fromYaml -}}
+{{- if $volumeMount -}}
+    {{- $additionalVolumeMounts := append .Values.additionalVolumeMounts $volumeMount }}
+    {{- $_ := set .Values "additionalVolumeMounts" (deepCopy $additionalVolumeMounts) -}}
+{{- end -}}
+
+{{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/homer/templates/configmap.yaml
+++ b/charts/homer/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.configmap.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,4 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   config.yml: |
-{{ .Values.config | indent 4 }}
+{{ .Values.configmap.config | indent 4 }}
+{{- end -}}

--- a/charts/homer/templates/configmap.yaml
+++ b/charts/homer/templates/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "homer.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "homer.name" . }}
+    helm.sh/chart: {{ include "homer.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  config.yml: |
+{{ .Values.config | indent 4 }}

--- a/charts/homer/values.yaml
+++ b/charts/homer/values.yaml
@@ -30,7 +30,7 @@ persistence:
     emptyDir: false
     mountPath: /www/assets
 
-# Homer configuration
+# -- Homer configuration
 # https://github.com/bastienwirtz/homer/blob/main/docs/configuration.md
 config: |
   externalConfig: https://raw.githubusercontent.com/bastienwirtz/homer/main/public/assets/config.yml.dist

--- a/charts/homer/values.yaml
+++ b/charts/homer/values.yaml
@@ -30,7 +30,11 @@ persistence:
     emptyDir: false
     mountPath: /www/assets
 
-# -- Homer configuration
-# https://github.com/bastienwirtz/homer/blob/main/docs/configuration.md
-config: |
-  externalConfig: https://raw.githubusercontent.com/bastienwirtz/homer/main/public/assets/config.yml.dist
+
+configmap:
+  # -- Store homer configuration as a ConfigMap
+  enabled: false
+  # -- Homer configuration
+  # https://github.com/bastienwirtz/homer/blob/main/docs/configuration.md
+  config: |
+    externalConfig: https://raw.githubusercontent.com/bastienwirtz/homer/main/public/assets/config.yml.dist

--- a/charts/homer/values.yaml
+++ b/charts/homer/values.yaml
@@ -29,3 +29,8 @@ persistence:
     enabled: false
     emptyDir: false
     mountPath: /www/assets
+
+# Homer configuration
+# https://github.com/bastienwirtz/homer/blob/main/docs/configuration.md
+config: |
+  externalConfig: https://raw.githubusercontent.com/bastienwirtz/homer/main/public/assets/config.yml.dist


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Adds the ability to configure homer with a configmap containing the application configuration

**Benefits**

Configure the application with values.yaml

**Possible drawbacks**

N/A - Backwards compatible for users configuring homer with an alternative method.

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [X] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
