### PR TITLE
[mosquitto] added auth and config_dir

### DIFF
--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.7
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 1.2.0
+version: 1.3.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - mosquitto

--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -83,11 +83,17 @@ N/A
 | persistence.data.enabled | bool | `false` |  |
 | persistence.data.mountPath | string | `"/mosquitto/data"` |  |
 | persistence.data.size | string | `"100Mi"` |  |
+| persistence.configinc.accessMode | string | `"ReadWriteOnce"` |  |
+| persistence.configinc.emptyDir | bool | `false` |  |
+| persistence.configinc.enabled | bool | `false` |  |
+| persistence.configinc.mountPath | string | `"/mosquitto/configinc"` |  |
+| persistence.configinc.size | string | `"100Mi"` |  |
 | service.annotations | object | `{}` |  |
 | service.port.name | string | `"mqtt"` |  |
 | service.port.port | int | `1883` |  |
 | service.type | string | `"ClusterIP"` |  |
 | strategy.type | string | `"Recreate"` |  |
+| auth.enabled | bool | `false` | |
 
 ## Changelog
 

--- a/charts/mosquitto/templates/configmap.yaml
+++ b/charts/mosquitto/templates/configmap.yaml
@@ -7,9 +7,16 @@ metadata:
 data:
   mosquitto.conf: |
     listener {{ .Values.service.port.port }}
+    {{- if .Values.auth.enabled }}
+    allow_anonymous false
+    {{- else }}
     allow_anonymous true
+    {{- end }}
     {{- if .Values.persistence.data.enabled }}
     persistence true
     persistence_location {{ .Values.persistence.data.mountPath }}
     autosave_interval 1800
+    {{- end }}
+    {{- if .Values.persistence.configinc.enabled }}
+    include_dir {{ .Values.persistence.configinc.mountPath }}
     {{- end }}

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -21,11 +21,31 @@ service:
     port: 1883
     name: mqtt
 
+auth:
+  enabled: false
+
 persistence:
   data:
     enabled: false
     emptyDir: false
     mountPath: /mosquitto/data
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 100Mi
+    ## Do not delete the pvc upon helm uninstall
+    # skipuninstall: false
+    # existingClaim: ""
+  configinc:
+    # a persistent volume to place *.conf mosquitto-config-files in
+    enabled: false
+    emptyDir: false
+    mountPath: /mosquitto/configinc
     ## Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
**Description of the change**

Just added optiosn to allow enabling auth and config_directories for further config-options.

**Benefits**

* you will be able to enable auth and use config_dir for further settings.

- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [X] (optional) Variables are documented in the README.md

