### PR TITLE
[joplin-server][tdarr] Bump to re-trigger repo upload

### DIFF
--- a/charts/joplin-server/Chart.yaml
+++ b/charts/joplin-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.7.2
 description: This server allows you to sync any Joplin client
 name: joplin-server
-version: 1.0.0
+version: 1.0.1
 keywords:
   - joplin
   - notes

--- a/charts/tdarr/Chart.yaml
+++ b/charts/tdarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.00.07
 description: Tdarr is a self hosted web-app for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers etc.
 name: tdarr
-version: 1.0.0
+version: 1.0.1
 keywords:
   - transcoding
   - remux


### PR DESCRIPTION
**Description of the change**

Charts are not uploaded on public repo.

> helm search repo k8s-at-home | grep -i tdarr
> helm search repo k8s-at-home | grep -i joplin

Local installation is working.