### PR TITLE
[adguard-home] fix  volumes subpath

### DIFF
--- a/charts/stable/adguard-home/Chart.yaml
+++ b/charts/stable/adguard-home/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.102.0
 description: DNS proxy as ad-blocker for local network
 name: adguard-home
-version: 2.2.2
+version: 2.2.3
 keywords:
   - adguard-home
   - adguard

--- a/charts/stable/adguard-home/templates/deployment.yaml
+++ b/charts/stable/adguard-home/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
               readOnly: false
             - name: config
               mountPath: /opt/adguardhome/conf
-            {{- with .Values.persistence.conf.subPath }}
+            {{- with .Values.persistence.config.subPath }}
               subPath: {{ . }}
             {{- end }}
               readOnly: false

--- a/charts/stable/adguard-home/templates/deployment.yaml
+++ b/charts/stable/adguard-home/templates/deployment.yaml
@@ -59,9 +59,11 @@ spec:
           volumeMounts:
             - name: work
               mountPath: /opt/adguardhome/work
+              subPath: {{ .Values.persistence.work.subPath }}
               readOnly: false
             - name: config
               mountPath: /opt/adguardhome/conf
+              subPath: {{ .Values.persistence.conf.subPath }}
               readOnly: false
         {{- end }}
       {{- end }}
@@ -79,9 +81,11 @@ spec:
           volumeMounts:
             - name: work
               mountPath: /opt/adguardhome/work
+              subPath: {{ .Values.persistence.work.subPath }}
               readOnly: false
             - name: config
               mountPath: /opt/adguardhome/conf
+              subPath: {{ .Values.persistence.conf.subPath }}
               readOnly: false
             {{- if .Values.tlsSecretName }}
             - name: certs

--- a/charts/stable/adguard-home/templates/deployment.yaml
+++ b/charts/stable/adguard-home/templates/deployment.yaml
@@ -65,8 +65,8 @@ spec:
               readOnly: false
             - name: config
               mountPath: /opt/adguardhome/conf
-            {{- if .Values.persistence.conf.subPath }}
-              subPath: {{ .Values.persistence.conf.subPath }}
+            {{- with .Values.persistence.conf.subPath }}
+              subPath: {{ . }}
             {{- end }}
               readOnly: false
         {{- end }}

--- a/charts/stable/adguard-home/templates/deployment.yaml
+++ b/charts/stable/adguard-home/templates/deployment.yaml
@@ -59,11 +59,15 @@ spec:
           volumeMounts:
             - name: work
               mountPath: /opt/adguardhome/work
+            {{- if .Values.persistence.work.subPath }}
               subPath: {{ .Values.persistence.work.subPath }}
+            {{- end }}
               readOnly: false
             - name: config
               mountPath: /opt/adguardhome/conf
+            {{- if .Values.persistence.conf.subPath }}
               subPath: {{ .Values.persistence.conf.subPath }}
+            {{- end }}
               readOnly: false
         {{- end }}
       {{- end }}
@@ -81,11 +85,15 @@ spec:
           volumeMounts:
             - name: work
               mountPath: /opt/adguardhome/work
+            {{- if .Values.persistence.work.subPath }}
               subPath: {{ .Values.persistence.work.subPath }}
+            {{- end }}
               readOnly: false
             - name: config
               mountPath: /opt/adguardhome/conf
+            {{- if .Values.persistence.conf.subPath }}
               subPath: {{ .Values.persistence.conf.subPath }}
+            {{- end }}
               readOnly: false
             {{- if .Values.tlsSecretName }}
             - name: certs

--- a/charts/stable/adguard-home/templates/deployment.yaml
+++ b/charts/stable/adguard-home/templates/deployment.yaml
@@ -59,8 +59,8 @@ spec:
           volumeMounts:
             - name: work
               mountPath: /opt/adguardhome/work
-            {{- if .Values.persistence.work.subPath }}
-              subPath: {{ .Values.persistence.work.subPath }}
+            {{- with .Values.persistence.work.subPath }}
+              subPath: {{ . }}
             {{- end }}
               readOnly: false
             - name: config

--- a/charts/stable/adguard-home/templates/deployment.yaml
+++ b/charts/stable/adguard-home/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
               readOnly: false
             - name: config
               mountPath: /opt/adguardhome/conf
-            {{- with .Values.persistence.conf.subPath }}
+            {{- with .Values.persistence.config.subPath }}
               subPath: {{ . }}
             {{- end }}
               readOnly: false

--- a/charts/stable/adguard-home/templates/deployment.yaml
+++ b/charts/stable/adguard-home/templates/deployment.yaml
@@ -91,8 +91,8 @@ spec:
               readOnly: false
             - name: config
               mountPath: /opt/adguardhome/conf
-            {{- if .Values.persistence.conf.subPath }}
-              subPath: {{ .Values.persistence.conf.subPath }}
+            {{- with .Values.persistence.conf.subPath }}
+              subPath: {{ . }}
             {{- end }}
               readOnly: false
             {{- if .Values.tlsSecretName }}

--- a/charts/stable/adguard-home/templates/deployment.yaml
+++ b/charts/stable/adguard-home/templates/deployment.yaml
@@ -85,8 +85,8 @@ spec:
           volumeMounts:
             - name: work
               mountPath: /opt/adguardhome/work
-            {{- if .Values.persistence.work.subPath }}
-              subPath: {{ .Values.persistence.work.subPath }}
+            {{- with .Values.persistence.work.subPath }}
+              subPath: {{ . }}
             {{- end }}
               readOnly: false
             - name: config

--- a/charts/stable/adguard-home/templates/service.yaml
+++ b/charts/stable/adguard-home/templates/service.yaml
@@ -26,7 +26,7 @@ spec:
   {{- end }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   ports:
-    - port: 3000
+    - port: 80
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/stable/adguard-home/templates/service.yaml
+++ b/charts/stable/adguard-home/templates/service.yaml
@@ -26,7 +26,7 @@ spec:
   {{- end }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   ports:
-    - port: 80
+    - port: 3000
       targetPort: http
       protocol: TCP
       name: http


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

the goal of the change is to : 
- reflect subpath config in the values.yaml to show in the deployment

**Benefits**

- actually use subpath in volume mounts in the deployment when a user sets this parameter and expects it to work

**Possible drawbacks**

should be a seamless change for existing users, so can't think of any

**Applicable issues**

None


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
