### PR TITLE
[prometheus-nut-exporter] add target label

### DIFF
--- a/charts/stable/prometheus-nut-exporter/Chart.yaml
+++ b/charts/stable/prometheus-nut-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-nut-exporter
 description: Prometheus NUT Exporter a service monitor to send NUT server metrics to a Prometheus instance.
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: 1.0.1
 keywords:
 - nut

--- a/charts/stable/prometheus-nut-exporter/README.md
+++ b/charts/stable/prometheus-nut-exporter/README.md
@@ -109,6 +109,20 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.0.5]
+
+#### Added
+
+- target label based on source of the data
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
+
 ### [1.0.2]
 
 #### Added

--- a/charts/stable/prometheus-nut-exporter/templates/servicemonitor.yaml
+++ b/charts/stable/prometheus-nut-exporter/templates/servicemonitor.yaml
@@ -18,5 +18,8 @@ spec:
       params:
         target:
           - "{{ .hostname }}:{{ .port }}"
+      relabelings:
+        - sourceLabels: [__param_target]
+          targetLabel: target
     {{- end }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**
Add target label 

**Benefits**
Without this, there is no way to identify which server originated the metric in Prometheus.

**Possible drawbacks**
N/A

**Applicable issues**
N/A

**Additional information**
This is based on configuration suggested by the author and adjusted for backward compatibility.
See https://github.com/HON95/prometheus-nut-exporter#prometheus

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [x] (optional) Variables are documented in the README.md