### PR TITLE
[home-assistant] upgrade image tag to 2021.3.4

### DIFF
--- a/charts/stable/home-assistant/Chart.yaml
+++ b/charts/stable/home-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 2021.1.5
+appVersion: 2021.3.4
 description: Home Assistant
 name: home-assistant
-version: 7.0.1
+version: 7.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - home-assistant

--- a/charts/stable/home-assistant/values.yaml
+++ b/charts/stable/home-assistant/values.yaml
@@ -8,7 +8,7 @@
 image:
   repository: homeassistant/home-assistant
   pullPolicy: IfNotPresent
-  tag: 2021.1.5
+  tag: 2021.3.4
 
 strategy:
   type: Recreate


### PR DESCRIPTION
Signed-off-by: Fabio Brito d'Araujo e Oliveira <psychopenguin@gmail.com>

**Description of the change**

Upgrade for home assistant image tag to 2021.3.4

**Benefits**

Latest stable version of Home Assistant - Check changelog at https://www.home-assistant.io/blog/2021/03/03/release-20213/

**Possible drawbacks**

Check the breaking changes list before upgrade: https://www.home-assistant.io/blog/2021/03/03/release-20213/#breaking-changes

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [X] (optional) Variables are documented in the README.md
