### PR TITLE
[digitalocean-dyndns/ddclient] deprecate charts

### DIFF
--- a/charts/stable/ddclient/Chart.yaml
+++ b/charts/stable/ddclient/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3.9.1
 description: Perl client used to update dynamic DNS entries for accounts on Dynamic DNS Network Service Providers
 name: ddclient
-version: 4.0.1
+version: 4.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - ddclient
@@ -12,9 +12,7 @@ icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linu
 sources:
 - https://github.com/ddclient/ddclient
 - https://hub.docker.com/r/linuxserver/ddclient
-maintainers:
-- name: billimek
-  email: jeff@billimek.com
+deprecated: true
 dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com

--- a/charts/stable/digitalocean-dyndns/Chart.yaml
+++ b/charts/stable/digitalocean-dyndns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Dynamic DNS using DigitalOcean's DNS Services
 name: digitalocean-dyndns
-version: 2.0.3
+version: 2.0.4
 keywords:
 - digitalocean
 - dynamicdns
@@ -11,6 +11,4 @@ icon: https://i.imgur.com/cS6iqXD.png
 sources:
 - https://github.com/tunix/digitalocean-dyndns
 - https://github.com/k8s-at-home/charts
-maintainers:
-- name: billimek
-  email: jeff@billimek.com
+deprecated: true


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

deprecate both digitalocean-dyndns and ddclient charts

**Benefits**

It's a much more elegant solution to use a k8s CronJob to do this, rather then support charts for any providers dyndns chart.

I have laid out a guide below on how to use a configmap, secret and cronjob to accomplish this task. We should point people to it when asked or issues are raised relating on how to handle dyndns in your cluster

https://docs.k8s-at-home.com/guides/dyndns/

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

We could perhaps support a chart that wires this up automagically, but it might be hard because of all the different DNS APIs

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [x] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
