### PR TITLE
[teslamate] - bump teslamate default image to 1.22.0

### DIFF
--- a/charts/stable/teslamate/Chart.yaml
+++ b/charts/stable/teslamate/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.20.0
+appVersion: v1.22.0
 description: A self-hosted data logger for your Tesla 🚘
 name: teslamate
-version: 3.6.2
+version: 3.6.3
 keywords:
   - teslamate
   - tesla

--- a/charts/stable/teslamate/values.yaml
+++ b/charts/stable/teslamate/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: teslamate/teslamate
-  tag: 1.20.0
+  tag: 1.22.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
**Description of the change**

Update the default teslamate container image to latest (1.22.0)

**Benefits**

Fixes login issues with Tesla API servers which requires a new version of Teslamate.

**Possible drawbacks**


**Additional information**

Ref #715 and #716  originally submitted by @EasternPA

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md
