### PR TITLE
[valheim] - set realistic resource defaults for valheim

### DIFF
--- a/charts/stable/valheim/Chart.yaml
+++ b/charts/stable/valheim/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: latest
 description: Valheim dedicated gameserver with automatic update and world backup support
 name: valheim
-version: 2.0.1
+version: 2.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - valheim

--- a/charts/stable/valheim/values.yaml
+++ b/charts/stable/valheim/values.yaml
@@ -57,6 +57,13 @@ persistence:
     enabled: false
     mountPath: /config
 
+resources:
+  requests:
+    memory: 2048Mi
+    cpu: 300m
+  limits:
+    memory: 4096Mi
+
 probes:
   liveness:
     enabled: false


### PR DESCRIPTION
**Description of the change**

The default resource settings from the common lib chart aren't adequate enough for the resources needed for the valheim container.  This change sets reasonable CPU & memory requests/limits for running this particular workload.

**Benefits**

This will prevent OOMkills of valheim when deploying the chart

**Possible drawbacks**

Kubernetes will not be able to schedule this chart if there are not enough resources.

**Additional information**

Data collected from Prometheus about the actual CPU & memory usage of the valheim chart supporting this change:
![image](https://user-images.githubusercontent.com/6393612/112669853-90951680-8e36-11eb-8283-79364a4551a6.png)


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md
