### PR TITLE
[rtorrent-flood] fix rtorrentrc configmap

### DIFF
--- a/charts/stable/rtorrent-flood/Chart.yaml
+++ b/charts/stable/rtorrent-flood/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: latest
 description: rTorrent is a stable, high-performance and low resource consumption BitTorrent client.
 name: rtorrent-flood
-version: 6.0.0
+version: 6.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - rtorrent

--- a/charts/stable/rtorrent-flood/templates/configmap.yaml
+++ b/charts/stable/rtorrent-flood/templates/configmap.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "common.labels" . | nindent 4 }}
 data:
-  rtorrent.rc: |
+  .rtorrent.rc: |
 {{ .Values.config | indent 4 }}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This should fix the issue of `.rtorrent.rc` being a directory not a file

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [x] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
