### PR TITLE
[rtorrent-flood] update chart to reflect latest Docker image version

### DIFF
--- a/charts/stable/rtorrent-flood/Chart.yaml
+++ b/charts/stable/rtorrent-flood/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: latest
 description: rTorrent is a stable, high-performance and low resource consumption BitTorrent client.
 name: rtorrent-flood
-version: 6.2.1
+version: 7.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - rtorrent

--- a/charts/stable/rtorrent-flood/README.md
+++ b/charts/stable/rtorrent-flood/README.md
@@ -1,6 +1,6 @@
 # rtorrent-flood
 
-![Version: 6.1.0](https://img.shields.io/badge/Version-6.1.0-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 7.0.0](https://img.shields.io/badge/Version-7.0.0-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 rTorrent is a stable, high-performance and low resource consumption BitTorrent client.
 
@@ -21,7 +21,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.0.1 |
+| https://library-charts.k8s-at-home.com | common | 2.1.0 |
 
 ## TL;DR
 
@@ -78,13 +78,15 @@ N/A
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| args[0] | string | `"--port 3000"` |  |
-| args[1] | string | `"--allowedpath /downloads"` |  |
-| config | string | see URL to default config | Minimal configuration provided from https://github.com/jesec/rtorrent/blob/master/doc/rtorrent.rc |
+| config | string | string | Minimal configuration provided from https://github.com/jesec/rtorrent/blob/master/doc/rtorrent.rc |
+| env.FLOOD_OPTION_ALLOWEDPATH | string | `"/downloads"` |  |
+| env.FLOOD_OPTION_HOST | string | `"0.0.0.0"` |  |
+| env.FLOOD_OPTION_PORT | string | `"3000"` |  |
+| env.FLOOD_OPTION_RTORRENT | string | `"true"` |  |
 | env.HOME | string | `"/config"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"jesec/rtorrent-flood"` |  |
-| image.tag | string | `"latest"` |  |
+| image.tag | string | `"latest@sha256:5ff0125ea0e2befbc2ba2f2143e130819db645cb5ef68b44a0712b8162a16f47"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |

--- a/charts/stable/rtorrent-flood/values.yaml
+++ b/charts/stable/rtorrent-flood/values.yaml
@@ -18,18 +18,20 @@
 image:
   repository: jesec/rtorrent-flood
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: latest@sha256:5ff0125ea0e2befbc2ba2f2143e130819db645cb5ef68b44a0712b8162a16f47
 
 strategy:
   type: Recreate
 
+# Environment configuration - for more options see:
+# https://github.com/jesec/flood#configuration
 env:
   # TZ:
   HOME: "/config"
-
-args:
-- "--port 3000"
-- "--allowedpath /downloads"
+  FLOOD_OPTION_HOST: "0.0.0.0"
+  FLOOD_OPTION_PORT: "3000"
+  FLOOD_OPTION_RTORRENT: "true"
+  FLOOD_OPTION_ALLOWEDPATH: "/downloads"
 
 service:
   port:
@@ -71,7 +73,7 @@ persistence:
     # existingClaim: ""
 
 # -- Minimal configuration provided from https://github.com/jesec/rtorrent/blob/master/doc/rtorrent.rc
-# @default -- see URL to default config
+# @default -- string
 config: |
   session.use_lock.set = no
   method.insert = cfg.basedir,  private|const|string, (cat,(fs.homedir),"/.local/share/rtorrent/")


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

The latest version of rtorrent-flood now can work with envars, I have removed the args.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [x] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
