### PR TITLE
[home-assistant] Fixed broken chart sources URL

### DIFF
--- a/charts/stable/home-assistant/Chart.yaml
+++ b/charts/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2021.3.4
 description: Home Assistant
 name: home-assistant
-version: 7.2.1
+version: 7.2.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - home-assistant
@@ -13,7 +13,7 @@ icon: https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Home_Assistant_L
 sources:
 - https://github.com/home-assistant/home-assistant
 - https://github.com/cdr/code-server
-- https://github.com/k8s-at-home/charts/tree/master/charts/home-assistant
+- https://github.com/k8s-at-home/charts/tree/master/charts/stable/home-assistant
 maintainers:
 - name: billimek
   email: jeff@billimek.com


### PR DESCRIPTION
**Description of the change**

This change fixes the missing "stable" folder in the chart.yaml sources section for home-assistant.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
