### PR TITLE
[bitwardenrs] Update var name and chart patch ver

### DIFF
--- a/charts/stable/bitwardenrs/Chart.yaml
+++ b/charts/stable/bitwardenrs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bitwardenrs
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 2.1.1
+version: 2.1.2
 appVersion: 1.18.0
 keywords:
   - bitwarden

--- a/charts/stable/bitwardenrs/README.md
+++ b/charts/stable/bitwardenrs/README.md
@@ -1,6 +1,6 @@
 # bitwardenrs
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.18.0](https://img.shields.io/badge/AppVersion-1.18.0-informational?style=flat-square)
+![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.18.0](https://img.shields.io/badge/AppVersion-1.18.0-informational?style=flat-square)
 
 Unofficial Bitwarden compatible server written in Rust
 
@@ -185,7 +185,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
-[2.1.1]: #2.1.1
+[2.1.2]: #2.1.2
 
 ## Support
 

--- a/charts/stable/bitwardenrs/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/bitwardenrs/README_CHANGELOG.md.gotmpl
@@ -25,5 +25,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
-[2.1.1]: #2.1.1
+[2.1.2]: #2.1.2
 {{- end -}}

--- a/charts/stable/bitwardenrs/templates/deployment-ldapsync.yaml
+++ b/charts/stable/bitwardenrs/templates/deployment-ldapsync.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.ldapSync.enabled) (not .Values.ldapSync.existinSecret) }}
+{{- if and (.Values.ldapSync.enabled) (not .Values.ldapSync.existingSecret) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
