### PR TITLE
[adguard-home] fix conf mount path

### DIFF
--- a/charts/stable/adguard-home/Chart.yaml
+++ b/charts/stable/adguard-home/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.105.2
 description: DNS proxy as ad-blocker for local network
 name: adguard-home
-version: 3.1.0
+version: 3.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - adguard-home

--- a/charts/stable/adguard-home/values.yaml
+++ b/charts/stable/adguard-home/values.yaml
@@ -22,8 +22,20 @@ initContainers:
   - name: adguard-home-config
     mountPath: /tmp/AdGuardHome.yaml
     subPath: AdGuardHome.yaml
+  - name: shared-config
+    mountPath: /opt/adguardhome/conf
   securityContext:
     runAsUser: 0
+
+
+additionalVolumes:
+- name: shared-config
+  emptyDir: {}
+
+additionalVolumeMounts:
+- name: shared-config
+  mountPath: /opt/adguardhome/conf
+
 
 image:
   repository: adguard/adguardhome


### PR DESCRIPTION
The init container do not share the conf directory adguard container. So Moving the conf doing nothing.

This PR make the conf directory shared between the 2 containers and so fix as code configuration  