### PR TITLE
[bitwardenrs] [FIX] Add SMTP password

### DIFF
--- a/charts/stable/bitwardenrs/Chart.yaml
+++ b/charts/stable/bitwardenrs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bitwardenrs
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 2.1.5
+version: 2.1.6
 appVersion: 1.18.0
 keywords:
   - bitwarden

--- a/charts/stable/bitwardenrs/templates/configmap.yaml
+++ b/charts/stable/bitwardenrs/templates/configmap.yaml
@@ -29,6 +29,9 @@ data:
   {{- if and (not .existingSecret.enabled) .user }}
   SMTP_USERNAME: {{ .user | quote }}
   {{- end }}
+  {{- if .password }}
+  SMTP_PASSWORD: {{ .password | quote }}
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- with .Values.bitwardenrs.yubico }}

--- a/charts/stable/bitwardenrs/templates/configmap.yaml
+++ b/charts/stable/bitwardenrs/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
   {{- if and (not .existingSecret.enabled) .user }}
   SMTP_USERNAME: {{ .user | quote }}
   {{- end }}
-  {{- if .password }}
+  {{- if and (not .existingSecret.enabled) .password }}
   SMTP_PASSWORD: {{ .password | quote }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
**Adding the support of SMTP password**

**Benefits**
If not set, we cannot use SMTP with authentication

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

