### PR TITLE
[blocky] - default strategy should be RollingUpdate

### DIFF
--- a/charts/stable/blocky/Chart.yaml
+++ b/charts/stable/blocky/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.13
 description: DNS proxy as ad-blocker for local network
 name: blocky
-version: 6.2.0
+version: 6.2.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - blocky

--- a/charts/stable/blocky/values.yaml
+++ b/charts/stable/blocky/values.yaml
@@ -11,7 +11,7 @@ image:
   pullPolicy: IfNotPresent
 
 strategy:
-  type: Recreate
+  type: RollingUpdate
 
 env: {}
   # TZ:


### PR DESCRIPTION
**Description of the change**

Prior to the migration of blocky to the common chart, it used the default kubernetes deployment strategy of `RollingUpdate` which is (IMO) appropriate and desired for stateless workloads so as to not disrupt service when changes are applied.

This change will restore the default behavior of the blocky chart to RollingUpdate as it was prior to the migration to the common library chart.

**Benefits**

This allows for updates to blocky to happen in a rolling fashion so as to not disrupt service which can happen with `Recreate`.  As this serves DNS, this is especially important.

**Possible drawbacks**

You need to wait longer for a multi-replica rollout to complete.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)
