### PR TITLE
[adguard-home] fix persistence

### DIFF
--- a/charts/stable/adguard-home/Chart.yaml
+++ b/charts/stable/adguard-home/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.105.2
 description: DNS proxy as ad-blocker for local network
 name: adguard-home
-version: 3.1.0
+version: 3.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - adguard-home

--- a/charts/stable/adguard-home/values.yaml
+++ b/charts/stable/adguard-home/values.yaml
@@ -22,6 +22,8 @@ initContainers:
   - name: adguard-home-config
     mountPath: /tmp/AdGuardHome.yaml
     subPath: AdGuardHome.yaml
+  - name: config
+    mountPath: /opt/adguardhome/conf
   securityContext:
     runAsUser: 0
 
@@ -69,9 +71,9 @@ service:
 
 persistence:
   config:
-    enabled: false
+    enabled: true
     emptyDir:
-      enabled: false
+      enabled: true
     mountPath: /opt/adguardhome/conf
   data:
     enabled: false


### PR DESCRIPTION

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Fixes copying the AGH config file to the right location when the config vol is enabled.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
