### PR TITLE
[speedtest-prometheus] feat: add namespace selection for serviceMonitor

### DIFF
--- a/charts/stable/speedtest-prometheus/Chart.yaml
+++ b/charts/stable/speedtest-prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: speedtest-prometheus
 description: Prometheus Exporter for the official Speedtest CLI
 type: application
-version: 2.1.3
+version: 2.2.0
 appVersion: 1.1.0
 keywords:
 - speedtest

--- a/charts/stable/speedtest-prometheus/README.md
+++ b/charts/stable/speedtest-prometheus/README.md
@@ -1,6 +1,6 @@
 # speedtest-prometheus
 
-![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 Prometheus Exporter for the official Speedtest CLI
 
@@ -100,6 +100,12 @@ You can find an [example grafana dashboard](https://github.com/billimek/promethe
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [2.2.0]
+
+#### Added
+
+- namespace selection for the serviceMonitor
 
 ### [2.1.1]
 

--- a/charts/stable/speedtest-prometheus/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/speedtest-prometheus/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.2.0]
+
+#### Added
+
+- namespace selection for the serviceMonitor
+
 ### [2.1.1]
 
 #### Added

--- a/charts/stable/speedtest-prometheus/templates/servicemonitor.yaml
+++ b/charts/stable/speedtest-prometheus/templates/servicemonitor.yaml
@@ -3,12 +3,18 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "speedtest-prometheus.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
   labels:
     {{- include "speedtest-prometheus.labels" . | nindent 4 }}
   {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
   selector:
     matchLabels:
       {{- include "speedtest-prometheus.selectorLabels" . | nindent 6 }}

--- a/charts/stable/speedtest-prometheus/values.yaml
+++ b/charts/stable/speedtest-prometheus/values.yaml
@@ -52,5 +52,5 @@ serviceMonitor:
   enabled: false
   interval: "60m"
   scrapeTimeout: 90s
-  # namespace: default
+  # namespace: monitoring
   additionalLabels: {}


### PR DESCRIPTION
Signed-off-by: Julen Dixneuf <julend@padok.fr>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

When I first installed the current speedtest-prometheus chart, I was unable to collect metrics, since my Prometheus only watch the serviceMonitors on the monitoring namespace (default behavior, at least for kube-prometheus-stack). In `values.yaml`, it seems that the variable `serviceMonitor.namespace` can be set, but the logic was not implemented.
I've just added the possibility to deploy the serviceMonitor on another namespace than the release.

**Benefits**

More flexibility when deploying such a component. Also it's a common feature for helm chart with service monitors.

**Possible drawbacks**

I don't think I've done any breaking change.

**Applicable issues**

Nope.

**Additional information**

I have tested the new chart on my personal cluster without any issues, it works as intended. If I don't set the variable, it will still be deployed on the release's namespace.

That's my first PR, I might have missed some guidelines ! Correct me if necessary.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
