### PR TITLE
[multiple charts] swap images to kah

### DIFF
--- a/charts/stable/appdaemon/Chart.yaml
+++ b/charts/stable/appdaemon/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 4.0.5
+appVersion: 4.0.8
 description: AppDaemon is a loosely coupled, multi-threaded, sandboxed python execution environment for writing automation apps for various types of Home Automation Software including Home Assistant and MQTT.
 name: appdaemon
-version: 4.3.1
+version: 5.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - appdaemon
@@ -12,6 +12,7 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/appdaemon
 sources:
 - https://github.com/AppDaemon/appdaemon
+- https://hub.docker.com/r/acockburn/appdaemon/
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/appdaemon/README.md
+++ b/charts/stable/appdaemon/README.md
@@ -1,6 +1,6 @@
 # appdaemon
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![AppVersion: 4.0.5](https://img.shields.io/badge/AppVersion-4.0.5-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![AppVersion: 4.0.8](https://img.shields.io/badge/AppVersion-4.0.8-informational?style=flat-square)
 
 AppDaemon is a loosely coupled, multi-threaded, sandboxed python execution environment for writing automation apps for various types of Home Automation Software including Home Assistant and MQTT.
 
@@ -9,6 +9,7 @@ AppDaemon is a loosely coupled, multi-threaded, sandboxed python execution envir
 ## Source Code
 
 * <https://github.com/AppDaemon/appdaemon>
+* <https://hub.docker.com/r/acockburn/appdaemon/>
 
 ## Requirements
 
@@ -18,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -77,8 +78,8 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"k8sathome/appdaemon"` |  |
-| image.tag | string | `"v4.0.5"` |  |
+| image.repository | string | `"acockburn/appdaemon"` |  |
+| image.tag | string | `"4.0.8"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |

--- a/charts/stable/appdaemon/values.yaml
+++ b/charts/stable/appdaemon/values.yaml
@@ -5,12 +5,10 @@
 # https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml
 #
 
-# Use our own image at https://github.com/k8s-at-home/container-images/tree/main/appdaemon
-# until https://github.com/AppDaemon/appdaemon/pull/1002 is merged
 image:
-  repository: k8sathome/appdaemon
+  repository: acockburn/appdaemon
   pullPolicy: IfNotPresent
-  tag: v4.0.5
+  tag: 4.0.8
 
 strategy:
   type: Recreate

--- a/charts/stable/bazarr/Chart.yaml
+++ b/charts/stable/bazarr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.9.0.5
+appVersion: v0.9.4
 description: Bazarr is a companion application to Sonarr and Radarr. It manages and downloads subtitles based on your requirements
 name: bazarr
-version: 7.3.1
+version: 8.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - bazarr
@@ -14,8 +14,8 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/bazarr
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/bazarr.png
 sources:
-- https://hub.docker.com/r/linuxserver/bazarr/
 - https://github.com/morpheus65535/bazarr
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/bazarr/README.md
+++ b/charts/stable/bazarr/README.md
@@ -1,6 +1,6 @@
 # bazarr
 
-![Version: 7.2.0](https://img.shields.io/badge/Version-7.2.0-informational?style=flat-square) ![AppVersion: v0.9.0.5](https://img.shields.io/badge/AppVersion-v0.9.0.5-informational?style=flat-square)
+![Version: 8.0.0](https://img.shields.io/badge/Version-8.0.0-informational?style=flat-square) ![AppVersion: v0.9.4](https://img.shields.io/badge/AppVersion-v0.9.4-informational?style=flat-square)
 
 Bazarr is a companion application to Sonarr and Radarr. It manages and downloads subtitles based on your requirements
 
@@ -8,8 +8,8 @@ Bazarr is a companion application to Sonarr and Radarr. It manages and downloads
 
 ## Source Code
 
-* <https://hub.docker.com/r/linuxserver/bazarr/>
 * <https://github.com/morpheus65535/bazarr>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -78,8 +78,8 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linuxserver/bazarr"` |  |
-| image.tag | string | `"version-v0.9.0.5"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/bazarr"` |  |
+| image.tag | string | `"v0.9.4"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -95,6 +95,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [8.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -109,6 +115,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[8.0.0]: #8.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/bazarr/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/bazarr/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [8.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[8.0.0]: #8.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/bazarr/values.yaml
+++ b/charts/stable/bazarr/values.yaml
@@ -6,17 +6,15 @@
 #
 
 image:
-  repository: linuxserver/bazarr
+  repository: ghcr.io/k8s-at-home/bazarr
   pullPolicy: IfNotPresent
-  tag: version-v0.9.0.5
+  tag: v0.9.4
 
 strategy:
   type: Recreate
 
 env: {}
   # TZ: UTC
-  # PUID: 1001
-  # PGID: 1001
 
 service:
   port:

--- a/charts/stable/jackett/Chart.yaml
+++ b/charts/stable/jackett/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.17.591
+appVersion: v0.17.908
 description: API Support for your favorite torrent trackers
 name: jackett
-version: 8.3.1
+version: 9.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - jackett
@@ -10,8 +10,8 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/jackett
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/jackett-banner.png
 sources:
-- https://hub.docker.com/r/linuxserver/jackett/
 - https://github.com/Jackett/Jackett
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/jackett/README.md
+++ b/charts/stable/jackett/README.md
@@ -1,6 +1,6 @@
 # jackett
 
-![Version: 8.2.0](https://img.shields.io/badge/Version-8.2.0-informational?style=flat-square) ![AppVersion: v0.17.591](https://img.shields.io/badge/AppVersion-v0.17.591-informational?style=flat-square)
+![Version: 9.0.0](https://img.shields.io/badge/Version-9.0.0-informational?style=flat-square) ![AppVersion: v0.17.908](https://img.shields.io/badge/AppVersion-v0.17.908-informational?style=flat-square)
 
 API Support for your favorite torrent trackers
 
@@ -8,8 +8,8 @@ API Support for your favorite torrent trackers
 
 ## Source Code
 
-* <https://hub.docker.com/r/linuxserver/jackett/>
 * <https://github.com/Jackett/Jackett>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -78,8 +78,8 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linuxserver/jackett"` |  |
-| image.tag | string | `"version-v0.17.591"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/jackett"` |  |
+| image.tag | string | `"v0.17.908"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -95,6 +95,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [9.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -109,6 +115,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[9.0.0]: #9.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/jackett/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/jackett/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [9.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[9.0.0]: #9.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/jackett/values.yaml
+++ b/charts/stable/jackett/values.yaml
@@ -6,19 +6,15 @@
 #
 
 image:
-  repository: linuxserver/jackett
+  repository: ghcr.io/k8s-at-home/jackett
   pullPolicy: IfNotPresent
-  tag: version-v0.17.591
+  tag: v0.17.908
 
 strategy:
   type: Recreate
 
 env: {}
   # TZ: UTC
-  # PUID: 1001
-  # PGID: 1001
-  ## Allow Jackett to update inside of the container, but might cause outages if turned on.
-  # AUTOUPDATE: false
 
 service:
   port:

--- a/charts/stable/lidarr/Chart.yaml
+++ b/charts/stable/lidarr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.8.0.1886
+appVersion: v0.8.1.2134
 description: Looks and smells like Sonarr but made for music
 name: lidarr
-version: 8.3.1
+version: 9.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - lidarr
@@ -12,7 +12,7 @@ home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/lidarr
 icon: https://github.com/lidarr/Lidarr/blob/develop/Logo/512.png?raw=true
 sources:
 - https://github.com/Lidarr/Lidarr
-- https://hub.docker.com/r/linuxserver/lidarr
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/lidarr/README.md
+++ b/charts/stable/lidarr/README.md
@@ -1,6 +1,6 @@
 # lidarr
 
-![Version: 8.2.0](https://img.shields.io/badge/Version-8.2.0-informational?style=flat-square) ![AppVersion: 0.8.0.1886](https://img.shields.io/badge/AppVersion-0.8.0.1886-informational?style=flat-square)
+![Version: 9.0.0](https://img.shields.io/badge/Version-9.0.0-informational?style=flat-square) ![AppVersion: v0.8.1.2134](https://img.shields.io/badge/AppVersion-v0.8.1.2134-informational?style=flat-square)
 
 Looks and smells like Sonarr but made for music
 
@@ -9,7 +9,7 @@ Looks and smells like Sonarr but made for music
 ## Source Code
 
 * <https://github.com/Lidarr/Lidarr>
-* <https://hub.docker.com/r/linuxserver/lidarr>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -78,8 +78,8 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linuxserver/lidarr"` |  |
-| image.tag | string | `"version-0.8.0.1886"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/lidarr"` |  |
+| image.tag | string | `"v0.8.1.2134"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -99,8 +99,8 @@ N/A
 | probes.liveness.spec.timeoutSeconds | int | `10` |  |
 | prometheus.podMonitor.additionalLabels | object | `{}` |  |
 | prometheus.podMonitor.enabled | bool | `false` |  |
-| prometheus.podMonitor.interval | string | `"1m"` |  |
-| prometheus.podMonitor.scrapeTimeout | string | `"1m30s"` |  |
+| prometheus.podMonitor.interval | string | `"3m"` |  |
+| prometheus.podMonitor.scrapeTimeout | string | `"1m"` |  |
 | service.port.port | int | `8686` |  |
 | strategy.type | string | `"Recreate"` |  |
 
@@ -109,6 +109,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [9.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
 
 ### [1.0.0]
 
@@ -124,6 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[9.0.0]: #9.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/lidarr/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/lidarr/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [9.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[9.0.0]: #9.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -6,17 +6,15 @@
 #
 
 image:
-  repository: linuxserver/lidarr
+  repository: ghcr.io/k8s-at-home/lidarr
   pullPolicy: IfNotPresent
-  tag: version-0.8.0.1886
+  tag: v0.8.1.2134
 
 strategy:
   type: Recreate
 
 env: {}
   # TZ: UTC
-  # PUID: 1001
-  # PGID: 1001
 
 service:
   port:
@@ -74,8 +72,8 @@ persistence:
 prometheus:
   podMonitor:
     enabled: false
-    interval: 1m
-    scrapeTimeout: 1m30s
+    interval: 3m
+    scrapeTimeout: 1m
     additionalLabels: {}
 
 # # When using the prometheus.podMonitor the following

--- a/charts/stable/nzbget/Chart.yaml
+++ b/charts/stable/nzbget/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v21.0
 description: NZBGet is a Usenet downloader client
 name: nzbget
-version: 9.3.1
+version: 10.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - nzbget
@@ -10,8 +10,8 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/nzbget
 icon: https://avatars1.githubusercontent.com/u/3368377?s=400&v=4
 sources:
-- https://hub.docker.com/r/linuxserver/nzbget/
 - https://nzbget.net/
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/nzbget/README.md
+++ b/charts/stable/nzbget/README.md
@@ -1,6 +1,6 @@
 # nzbget
 
-![Version: 9.2.0](https://img.shields.io/badge/Version-9.2.0-informational?style=flat-square) ![AppVersion: v21.0](https://img.shields.io/badge/AppVersion-v21.0-informational?style=flat-square)
+![Version: 10.0.0](https://img.shields.io/badge/Version-10.0.0-informational?style=flat-square) ![AppVersion: v21.0](https://img.shields.io/badge/AppVersion-v21.0-informational?style=flat-square)
 
 NZBGet is a Usenet downloader client
 
@@ -8,8 +8,8 @@ NZBGet is a Usenet downloader client
 
 ## Source Code
 
-* <https://hub.docker.com/r/linuxserver/nzbget/>
 * <https://nzbget.net/>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -80,8 +80,8 @@ The default login details (change ASAP) are:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linuxserver/nzbget"` |  |
-| image.tag | string | `"version-v21.0"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/nzbget"` |  |
+| image.tag | string | `"v21.0"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -100,6 +100,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [10.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -114,6 +120,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[10.0.0]: #10.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/nzbget/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/nzbget/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [10.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[10.0.0]: #10.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/nzbget/values.yaml
+++ b/charts/stable/nzbget/values.yaml
@@ -6,9 +6,9 @@
 #
 
 image:
-  repository: linuxserver/nzbget
+  repository: ghcr.io/k8s-at-home/nzbget
   pullPolicy: IfNotPresent
-  tag: version-v21.0
+  tag: v21.0
 
 strategy:
   type: Recreate

--- a/charts/stable/nzbhydra2/Chart.yaml
+++ b/charts/stable/nzbhydra2/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v3.8.1
+appVersion: v3.14.0
 description: Usenet meta search
 name: nzbhydra2
-version: 7.3.1
+version: 8.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - nzbhydra2
@@ -10,8 +10,8 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/nzbhydra2
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/hydra-icon.png
 sources:
-- https://hub.docker.com/r/linuxserver/nzbhydra2
 - https://github.com/theotherp/nzbhydra2
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/nzbhydra2/README.md
+++ b/charts/stable/nzbhydra2/README.md
@@ -1,6 +1,6 @@
 # nzbhydra2
 
-![Version: 7.2.0](https://img.shields.io/badge/Version-7.2.0-informational?style=flat-square) ![AppVersion: v3.8.1](https://img.shields.io/badge/AppVersion-v3.8.1-informational?style=flat-square)
+![Version: 8.0.0](https://img.shields.io/badge/Version-8.0.0-informational?style=flat-square) ![AppVersion: v3.14.0](https://img.shields.io/badge/AppVersion-v3.14.0-informational?style=flat-square)
 
 Usenet meta search
 
@@ -8,8 +8,8 @@ Usenet meta search
 
 ## Source Code
 
-* <https://hub.docker.com/r/linuxserver/nzbhydra2>
 * <https://github.com/theotherp/nzbhydra2>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -78,8 +78,8 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linuxserver/nzbhydra2"` |  |
-| image.tag | string | `"version-v3.8.1"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/nzbhydra2"` |  |
+| image.tag | string | `"v3.14.0"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -116,6 +116,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [8.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -130,6 +136,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[8.0.0]: #8.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/nzbhydra2/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/nzbhydra2/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [8.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[8.0.0]: #8.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/nzbhydra2/values.yaml
+++ b/charts/stable/nzbhydra2/values.yaml
@@ -6,9 +6,9 @@
 #
 
 image:
-  repository: linuxserver/nzbhydra2
+  repository: ghcr.io/k8s-at-home/nzbhydra2
   pullPolicy: IfNotPresent
-  tag: version-v3.8.1
+  tag: v3.14.0
 
 strategy:
   type: Recreate

--- a/charts/stable/qbittorrent/Chart.yaml
+++ b/charts/stable/qbittorrent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 4.3.0
+appVersion: v4.3.4.1
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 name: qbittorrent
-version: 9.3.1
+version: 10.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - qbittorrent
@@ -10,7 +10,8 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/qbittorrent
 icon: https://cloud.githubusercontent.com/assets/14862437/23586868/89ef2922-01c4-11e7-869c-52aafcece17f.png
 sources:
-- https://hub.docker.com/r/linuxserver/qbittorrent/
+- https://github.com/qbittorrent/qBittorrent
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/qbittorrent/README.md
+++ b/charts/stable/qbittorrent/README.md
@@ -1,6 +1,6 @@
 # qbittorrent
 
-![Version: 9.2.0](https://img.shields.io/badge/Version-9.2.0-informational?style=flat-square) ![AppVersion: 4.3.0](https://img.shields.io/badge/AppVersion-4.3.0-informational?style=flat-square)
+![Version: 10.0.0](https://img.shields.io/badge/Version-10.0.0-informational?style=flat-square) ![AppVersion: v4.3.4.1](https://img.shields.io/badge/AppVersion-v4.3.4.1-informational?style=flat-square)
 
 qBittorrent is a cross-platform free and open-source BitTorrent client
 
@@ -8,7 +8,8 @@ qBittorrent is a cross-platform free and open-source BitTorrent client
 
 ## Source Code
 
-* <https://hub.docker.com/r/linuxserver/qbittorrent/>
+* <https://github.com/qbittorrent/qBittorrent>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -18,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -81,8 +82,8 @@ N/A
 | additionalVolumes[0].name | string | `"qbittorrent-scripts"` |  |
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linuxserver/qbittorrent"` |  |
-| image.tag | string | `"version-4.3.0202010181232-7086-1c663adeeubuntu18.04.1"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/qbittorrent"` |  |
+| image.tag | string | `"v4.3.4.1"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -108,6 +109,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [10.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -122,6 +129,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[10.0.0]: #10.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/qbittorrent/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/qbittorrent/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [10.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[10.0.0]: #10.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/qbittorrent/values.yaml
+++ b/charts/stable/qbittorrent/values.yaml
@@ -6,18 +6,15 @@
 #
 
 image:
-  repository: linuxserver/qbittorrent
+  repository: ghcr.io/k8s-at-home/qbittorrent
   pullPolicy: IfNotPresent
-  tag: version-4.3.0202010181232-7086-1c663adeeubuntu18.04.1
+  tag: v4.3.4.1
 
 strategy:
   type: Recreate
 
 env: {}
   # TZ: UTC
-  # PUID: 1001
-  # PGID: 1001
-  # UMASK: 022
 
 service:
   port:

--- a/charts/stable/radarr/Chart.yaml
+++ b/charts/stable/radarr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 3.0.2.4552
+appVersion: v3.0.2.4552
 description: A fork of Sonarr to work with movies à la Couchpotato
 name: radarr
-version: 10.3.1
+version: 11.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - radarr
@@ -12,7 +12,7 @@ home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/radarr
 icon: https://github.com/Radarr/Radarr/blob/aphrodite/Logo/512.png?raw=true
 sources:
 - https://github.com/Radarr/Radarr
-- https://hub.docker.com/r/linuxserver/radarr
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/radarr/README.md
+++ b/charts/stable/radarr/README.md
@@ -1,6 +1,6 @@
 # radarr
 
-![Version: 10.2.0](https://img.shields.io/badge/Version-10.2.0-informational?style=flat-square) ![AppVersion: 3.0.2.4552](https://img.shields.io/badge/AppVersion-3.0.2.4552-informational?style=flat-square)
+![Version: 11.0.0](https://img.shields.io/badge/Version-11.0.0-informational?style=flat-square) ![AppVersion: v3.0.2.4552](https://img.shields.io/badge/AppVersion-v3.0.2.4552-informational?style=flat-square)
 
 A fork of Sonarr to work with movies à la Couchpotato
 
@@ -9,7 +9,7 @@ A fork of Sonarr to work with movies à la Couchpotato
 ## Source Code
 
 * <https://github.com/Radarr/Radarr>
-* <https://hub.docker.com/r/linuxserver/radarr>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -78,8 +78,8 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linuxserver/radarr"` |  |
-| image.tag | string | `"version-3.0.2.4552"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/radarr"` |  |
+| image.tag | string | `"v3.0.2.4552"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -99,8 +99,8 @@ N/A
 | probes.liveness.spec.timeoutSeconds | int | `10` |  |
 | prometheus.podMonitor.additionalLabels | object | `{}` |  |
 | prometheus.podMonitor.enabled | bool | `false` |  |
-| prometheus.podMonitor.interval | string | `"1m"` |  |
-| prometheus.podMonitor.scrapeTimeout | string | `"1m30s"` |  |
+| prometheus.podMonitor.interval | string | `"3m"` |  |
+| prometheus.podMonitor.scrapeTimeout | string | `"1m"` |  |
 | service.port.port | int | `7878` |  |
 | strategy.type | string | `"Recreate"` |  |
 
@@ -109,6 +109,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [11.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
 
 ### [1.0.0]
 
@@ -124,6 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[11.0.0]: #11.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/radarr/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/radarr/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [11.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[11.0.0]: #11.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/radarr/values.yaml
+++ b/charts/stable/radarr/values.yaml
@@ -6,9 +6,9 @@
 #
 
 image:
-  repository: linuxserver/radarr
+  repository: ghcr.io/k8s-at-home/radarr
   pullPolicy: IfNotPresent
-  tag: version-3.0.2.4552
+  tag: v3.0.2.4552
 
 strategy:
   type: Recreate
@@ -74,8 +74,8 @@ persistence:
 prometheus:
   podMonitor:
     enabled: false
-    interval: 1m
-    scrapeTimeout: 1m30s
+    interval: 3m
+    scrapeTimeout: 1m
     additionalLabels: {}
 
 # # When using the prometheus.podMonitor the following

--- a/charts/stable/readarr/Chart.yaml
+++ b/charts/stable/readarr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.1.0.351
+appVersion: v0.1.0.587
 description: A fork of Radarr to work with Books & AudioBooks
 name: readarr
-version: 3.3.1
+version: 4.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - readarr
@@ -14,7 +14,7 @@ home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/readarr
 icon: https://readarr.com/img/logo.png
 sources:
 - https://github.com/Readarr/Readarr
-- https://readarr.com
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: mcmarkj
   email: mark@markmcw.uk

--- a/charts/stable/readarr/README.md
+++ b/charts/stable/readarr/README.md
@@ -1,6 +1,6 @@
 # readarr
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 0.1.0.351](https://img.shields.io/badge/AppVersion-0.1.0.351-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: v0.1.0.587](https://img.shields.io/badge/AppVersion-v0.1.0.587-informational?style=flat-square)
 
 A fork of Radarr to work with Books & AudioBooks
 
@@ -9,7 +9,7 @@ A fork of Radarr to work with Books & AudioBooks
 ## Source Code
 
 * <https://github.com/Readarr/Readarr>
-* <https://readarr.com>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -79,8 +79,8 @@ helm install readarr k8s-at-home/readarr -f values.yaml
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"hotio/readarr"` |  |
-| image.tag | string | `"nightly"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/readarr"` |  |
+| image.tag | string | `"v0.1.0.587"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -107,6 +107,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -121,6 +127,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[4.0.0]: #4.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/readarr/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/readarr/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[4.0.0]: #4.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/readarr/values.yaml
+++ b/charts/stable/readarr/values.yaml
@@ -6,17 +6,15 @@
 #
 
 image:
-  repository: hotio/readarr
+  repository: ghcr.io/k8s-at-home/readarr
   pullPolicy: IfNotPresent
-  tag: nightly
+  tag: v0.1.0.587
 
 strategy:
   type: Recreate
 
 env: {}
   # TZ: UTC
-  # PUID: 1001
-  # PGID: 1001
 
 service:
   port:

--- a/charts/stable/sabnzbd/Chart.yaml
+++ b/charts/stable/sabnzbd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 3.1.0
+appVersion: v3.2.1
 description: Free and easy binary newsreader
 name: sabnzbd
-version: 6.3.1
+version: 7.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - sabnzbd
@@ -10,8 +10,8 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/sabnzbd
 icon: https://avatars1.githubusercontent.com/u/960698?s=400&v=4
 sources:
-- https://hub.docker.com/r/linuxserver/sabnzbd/
 - https://sabnzbd.org/
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/sabnzbd/README.md
+++ b/charts/stable/sabnzbd/README.md
@@ -1,6 +1,6 @@
 # sabnzbd
 
-![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 7.0.0](https://img.shields.io/badge/Version-7.0.0-informational?style=flat-square) ![AppVersion: v3.2.1](https://img.shields.io/badge/AppVersion-v3.2.1-informational?style=flat-square)
 
 Free and easy binary newsreader
 
@@ -8,8 +8,8 @@ Free and easy binary newsreader
 
 ## Source Code
 
-* <https://hub.docker.com/r/linuxserver/sabnzbd/>
 * <https://sabnzbd.org/>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -83,8 +83,8 @@ You can do one of two things to solve this issue:
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linuxserver/sabnzbd"` |  |
-| image.tag | string | `"version-3.1.0"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/sabnzbd"` |  |
+| image.tag | string | `"v3.2.1"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -103,6 +103,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [7.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -117,6 +123,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[7.0.0]: #7.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/sabnzbd/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/sabnzbd/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [7.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[7.0.0]: #7.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/sabnzbd/values.yaml
+++ b/charts/stable/sabnzbd/values.yaml
@@ -6,17 +6,16 @@
 #
 
 image:
-  repository: linuxserver/sabnzbd
+  repository: ghcr.io/k8s-at-home/sabnzbd
   pullPolicy: IfNotPresent
-  tag: version-3.1.0
+  tag: v3.2.1
 
 strategy:
   type: Recreate
 
 env: {}
   # TZ: UTC
-  # PUID: 1001
-  # PGID: 1001
+  # HOST_WHITELIST_ENTRIES:
 
 service:
   port:

--- a/charts/stable/sonarr/Chart.yaml
+++ b/charts/stable/sonarr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 3.0.4.993
+appVersion: v3.0.6.1196
 description: Smart PVR for newsgroup and bittorrent users
 name: sonarr
-version: 10.3.1
+version: 11.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - sonarr
@@ -12,7 +12,7 @@ home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/sonarr
 icon: https://github.com/Sonarr/Sonarr/blob/phantom-develop/Logo/512.png?raw=true
 sources:
 - https://github.com/Sonarr/Sonarr
-- https://hub.docker.com/r/linuxserver/sonarr
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/sonarr/README.md
+++ b/charts/stable/sonarr/README.md
@@ -1,6 +1,6 @@
 # sonarr
 
-![Version: 10.2.0](https://img.shields.io/badge/Version-10.2.0-informational?style=flat-square) ![AppVersion: 3.0.4.993](https://img.shields.io/badge/AppVersion-3.0.4.993-informational?style=flat-square)
+![Version: 11.0.0](https://img.shields.io/badge/Version-11.0.0-informational?style=flat-square) ![AppVersion: v3.0.6.1196](https://img.shields.io/badge/AppVersion-v3.0.6.1196-informational?style=flat-square)
 
 Smart PVR for newsgroup and bittorrent users
 
@@ -9,7 +9,7 @@ Smart PVR for newsgroup and bittorrent users
 ## Source Code
 
 * <https://github.com/Sonarr/Sonarr>
-* <https://hub.docker.com/r/linuxserver/sonarr>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -78,8 +78,8 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linuxserver/sonarr"` |  |
-| image.tag | string | `"version-3.0.4.993"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/sonarr"` |  |
+| image.tag | string | `"v3.0.6.1196"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -99,8 +99,8 @@ N/A
 | probes.liveness.spec.timeoutSeconds | int | `10` |  |
 | prometheus.podMonitor.additionalLabels | object | `{}` |  |
 | prometheus.podMonitor.enabled | bool | `false` |  |
-| prometheus.podMonitor.interval | string | `"1m"` |  |
-| prometheus.podMonitor.scrapeTimeout | string | `"1m30s"` |  |
+| prometheus.podMonitor.interval | string | `"3m"` |  |
+| prometheus.podMonitor.scrapeTimeout | string | `"1m"` |  |
 | service.port.port | int | `8989` |  |
 | strategy.type | string | `"Recreate"` |  |
 
@@ -109,6 +109,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [11.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
 
 ### [1.0.0]
 
@@ -124,6 +130,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[11.0.0]: #11.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/sonarr/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/sonarr/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [11.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[11.0.0]: #11.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/sonarr/values.yaml
+++ b/charts/stable/sonarr/values.yaml
@@ -6,17 +6,15 @@
 #
 
 image:
-  repository: linuxserver/sonarr
+  repository: ghcr.io/k8s-at-home/sonarr
   pullPolicy: IfNotPresent
-  tag: version-3.0.4.993
+  tag: v3.0.6.1196
 
 strategy:
   type: Recreate
 
 env: {}
   # TZ: UTC
-  # PUID: 1001
-  # PGID: 1001
 
 service:
   port:
@@ -74,8 +72,8 @@ persistence:
 prometheus:
   podMonitor:
     enabled: false
-    interval: 1m
-    scrapeTimeout: 1m30s
+    interval: 3m
+    scrapeTimeout: 1m
     additionalLabels: {}
 
 # # When using the prometheus.podMonitor the following

--- a/charts/stable/tautulli/Chart.yaml
+++ b/charts/stable/tautulli/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.6.6
+appVersion: v2.7.0
 description: A Python based monitoring and tracking tool for Plex Media Server
 name: tautulli
-version: 8.3.1
+version: 9.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - tautulli
@@ -11,7 +11,7 @@ home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/tautulli
 icon: https://github.com/Tautulli/Tautulli/blob/master/data/interfaces/default/images/logo.png?raw=true
 sources:
 - https://github.com/Tautulli/Tautulli
-- https://hub.docker.com/r/tautulli/tautulli
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/tautulli/README.md
+++ b/charts/stable/tautulli/README.md
@@ -1,6 +1,6 @@
 # tautulli
 
-![Version: 8.2.0](https://img.shields.io/badge/Version-8.2.0-informational?style=flat-square) ![AppVersion: v2.6.6](https://img.shields.io/badge/AppVersion-v2.6.6-informational?style=flat-square)
+![Version: 9.0.0](https://img.shields.io/badge/Version-9.0.0-informational?style=flat-square) ![AppVersion: v2.7.0](https://img.shields.io/badge/AppVersion-v2.7.0-informational?style=flat-square)
 
 A Python based monitoring and tracking tool for Plex Media Server
 
@@ -9,7 +9,7 @@ A Python based monitoring and tracking tool for Plex Media Server
 ## Source Code
 
 * <https://github.com/Tautulli/Tautulli>
-* <https://hub.docker.com/r/tautulli/tautulli>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -78,8 +78,8 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"tautulli/tautulli"` |  |
-| image.tag | string | `"v2.6.6"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/tautulli"` |  |
+| image.tag | string | `"v2.7.0"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -91,6 +91,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [9.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
 
 ### [1.0.0]
 
@@ -106,6 +112,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[9.0.0]: #9.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/tautulli/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/tautulli/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [9.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[9.0.0]: #9.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/tautulli/values.yaml
+++ b/charts/stable/tautulli/values.yaml
@@ -6,17 +6,15 @@
 #
 
 image:
-  repository: tautulli/tautulli
+  repository: ghcr.io/k8s-at-home/tautulli
   pullPolicy: IfNotPresent
-  tag: v2.6.6
+  tag: v2.7.0
 
 strategy:
   type: Recreate
 
 env: {}
   # TZ: UTC
-  # PUID: 1001
-  # PGID: 1001
 
 service:
   port:

--- a/charts/stable/transmission/Chart.yaml
+++ b/charts/stable/transmission/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 3.0.0
+appVersion: v3.00
 description: Transmission is a cross-platform BitTorrent client
 name: transmission
-version: 3.3.1
+version: 4.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - transmission
@@ -10,8 +10,8 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/transmission
 icon: https://github.com/transmission/transmission/raw/master/extras/transmission-1920.jpg
 sources:
-- https://hub.docker.com/r/linuxserver/transmission
-- https://github.com/k8s-at-home/charts/tree/master/charts/transmission
+- https://github.com/transmission/transmission
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: ishioni
   email: helm@movishell.pl

--- a/charts/stable/transmission/README.md
+++ b/charts/stable/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: v3.00](https://img.shields.io/badge/AppVersion-v3.00-informational?style=flat-square)
 
 Transmission is a cross-platform BitTorrent client
 
@@ -8,8 +8,8 @@ Transmission is a cross-platform BitTorrent client
 
 ## Source Code
 
-* <https://hub.docker.com/r/linuxserver/transmission>
-* <https://github.com/k8s-at-home/charts/tree/master/charts/transmission>
+* <https://github.com/transmission/transmission>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -78,8 +78,8 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linuxserver/transmission"` |  |
-| image.tag | string | `"version-3.00-r2"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/transmission"` |  |
+| image.tag | string | `"v3.00"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
@@ -186,6 +186,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [2.0.0]
 
 #### Changed
@@ -198,6 +204,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial commit
 
+[4.0.0]: #4.0.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/transmission/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/transmission/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.0]
+
+#### Changed
+
+- **Breaking**: swap linuxserver.io images for k8s@home image
+
 ### [2.0.0]
 
 #### Changed
@@ -21,5 +27,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial commit
 
+[4.0.0]: #4.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/transmission/values.yaml
+++ b/charts/stable/transmission/values.yaml
@@ -6,9 +6,9 @@
 #
 
 image:
-  repository: linuxserver/transmission
+  repository: ghcr.io/k8s-at-home/transmission
   pullPolicy: IfNotPresent
-  tag: version-3.00-r2
+  tag: v3.00
 
 strategy:
   type: Recreate

--- a/charts/stable/xteve/Chart.yaml
+++ b/charts/stable/xteve/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 2.1.2.0120
+appVersion: v2.2.0.200
 description: M3U Proxy for Plex DVR and Emby Live TV.
 name: xteve
-version: 6.3.1
+version: 6.3.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - xteve
@@ -12,8 +12,8 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/xteve
 icon: https://raw.githubusercontent.com/xteve-project/xTeVe/master/html/img/logo_b_880x200.jpg
 sources:
-- https://xteve.de
 - https://github.com/xteve-project/xTeVe
+- https://github.com/k8s-at-home/container-images
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/charts/stable/xteve/README.md
+++ b/charts/stable/xteve/README.md
@@ -1,6 +1,6 @@
 # xteve
 
-![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![AppVersion: 2.1.2.0120](https://img.shields.io/badge/AppVersion-2.1.2.0120-informational?style=flat-square)
+![Version: 6.3.2](https://img.shields.io/badge/Version-6.3.2-informational?style=flat-square) ![AppVersion: v2.2.0.200](https://img.shields.io/badge/AppVersion-v2.2.0.200-informational?style=flat-square)
 
 M3U Proxy for Plex DVR and Emby Live TV.
 
@@ -8,8 +8,8 @@ M3U Proxy for Plex DVR and Emby Live TV.
 
 ## Source Code
 
-* <https://xteve.de>
 * <https://github.com/xteve-project/xTeVe>
+* <https://github.com/k8s-at-home/container-images>
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -78,8 +78,8 @@ N/A
 |-----|------|---------|-------------|
 | env | object | `{}` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"k8sathome/xteve"` |  |
-| image.tag | string | `"v2.1.2.0120"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/xteve"` |  |
+| image.tag | string | `"v2.2.0.200"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |

--- a/charts/stable/xteve/values.yaml
+++ b/charts/stable/xteve/values.yaml
@@ -6,9 +6,9 @@
 #
 
 image:
-  repository: k8sathome/xteve
+  repository: ghcr.io/k8s-at-home/xteve
   pullPolicy: IfNotPresent
-  tag: v2.1.2.0120
+  tag: v2.2.0.200
 
 strategy:
   type: Recreate


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

- Swap container images to kah images if supported
- Bump to the latest versions and update readmes
- Fix scrapeinterval and interval in arr exporters
- Move appdaemon back to official image

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
