### PR TITLE
[promcord] add service and servicemonitor

### DIFF
--- a/charts/stable/promcord/Chart.yaml
+++ b/charts/stable/promcord/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: latest
 description: Discord bot that provides metrics from a Discord server
 name: promcord
-version: 1.0.0
+version: 1.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - promcord

--- a/charts/stable/promcord/README.md
+++ b/charts/stable/promcord/README.md
@@ -83,7 +83,10 @@ N/A
 | prometheus.podMonitor.additionalLabels | object | `{}` |  |
 | prometheus.podMonitor.enabled | bool | `false` |  |
 | prometheus.podMonitor.interval | string | `"1m"` |  |
-| prometheus.podMonitor.scrapeTimeout | string | `"1m30s"` |  |
+| prometheus.podMonitor.scrapeTimeout | string | `"30s"` |  |
+| prometheus.serviceMonitor.additionalLabels | object | `{}` |  |
+| prometheus.serviceMonitor.enabled | bool | `false` |  |
+| prometheus.serviceMonitor.interval | string | `"1m"` |  |
 | strategy.type | string | `"Recreate"` |  |
 
 ## Changelog
@@ -106,7 +109,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+### [1.0.1]
+
+#### Added
+
+- Service
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
+
 [1.0.0]: #1.0.0
+[1.0.1]: #1.0.1
 
 ## Support
 

--- a/charts/stable/promcord/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/promcord/README_CHANGELOG.md.gotmpl
@@ -23,5 +23,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+### [1.0.1]
+
+#### Added
+
+- Service
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
+
 [1.0.0]: #1.0.0
+[1.0.1]: #1.0.1
 {{- end -}}

--- a/charts/stable/promcord/templates/podmonitor.yaml
+++ b/charts/stable/promcord/templates/podmonitor.yaml
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       {{- include "common.labels.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
-  - port: metrics
+  - port: http
     {{- with .Values.prometheus.podMonitor.interval }}
     interval: {{ . }}
     {{- end }}

--- a/charts/stable/promcord/values.yaml
+++ b/charts/stable/promcord/values.yaml
@@ -11,33 +11,8 @@ image:
   tag: "latest"
 
 service:
-  enabled: false
-  additionalPorts:
-  - port: 8080
-    name: metrics
-    protocol: TCP
-    targetPort: 8080
-
-## Probes configuration
-probes:
-  liveness:
-    enabled: true
-    custom: true
-    spec:
-      tcpSocket:
-        port: 8080
-  readiness:
-    enabled: true
-    custom: true
-    spec:
-      tcpSocket:
-        port: 8080
-  startup:
-    enabled: true
-    custom: true
-    spec:
-      tcpSocket:
-        port: 8080
+  port:
+    port: 8080
 
 strategy:
   type: Recreate
@@ -47,7 +22,7 @@ env:
   # -- Discord bot token
   # DISCORD_TOKEN:
 
-# Enable a prometheus-operator podmonitor
+# Enable prometheus-operator monitors
 prometheus:
   podMonitor:
     enabled: false


### PR DESCRIPTION
**Description of the change**

Added a Service

**Benefits**

Adds a named port for the PodMonitor to function as intended

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
