### PR TITLE
[speedtest-prometheus] deprecate chart

### DIFF
--- a/charts/stable/speedtest-prometheus/Chart.yaml
+++ b/charts/stable/speedtest-prometheus/Chart.yaml
@@ -12,6 +12,4 @@ home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/speedtest-
 icon: https://cdn.speedcheck.org/images/reviews/ookla-logo.png
 sources:
 - https://github.com/billimek/prometheus-speedtest-exporter
-maintainers:
-- name: billimek
-  email: jeff@billimek.com
+deprecated: true

--- a/charts/stable/speedtest-prometheus/Chart.yaml
+++ b/charts/stable/speedtest-prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: speedtest-prometheus
 description: Prometheus Exporter for the official Speedtest CLI
 type: application
-version: 2.2.0
+version: 2.2.1
 appVersion: 1.1.0
 keywords:
 - speedtest


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Superseeded by https://github.com/k8s-at-home/charts/tree/master/charts/stable/speedtest-exporter

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
