### PR TITLE
[sharry] use a config blockk

### DIFF
--- a/charts/stable/sharry/Chart.yaml
+++ b/charts/stable/sharry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.0
 description: Sharry allows to share files with others in a simple way. It is a self-hosted web application. The basic concept is to upload files and get a url back that can then be shared.
 name: sharry
-version: 2.3.1
+version: 3.0.0
 keywords:
   - file sharing
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/sharry

--- a/charts/stable/sharry/README.md
+++ b/charts/stable/sharry/README.md
@@ -1,6 +1,6 @@
 # sharry
 
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 Sharry allows to share files with others in a simple way. It is a self-hosted web application. The basic concept is to upload files and get a url back that can then be shared.
 
@@ -17,7 +17,7 @@ Sharry allows to share files with others in a simple way. It is a self-hosted we
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -74,33 +74,16 @@ N/A
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| additionalVolumeMounts[0].mountPath | string | `"/opt/sharry.conf"` |  |
-| additionalVolumeMounts[0].name | string | `"sharry-config"` |  |
-| additionalVolumeMounts[0].subPath | string | `"sharry.conf"` |  |
-| additionalVolumes[0].configMap.name | string | `"sharry-config"` |  |
-| additionalVolumes[0].name | string | `"sharry-config"` |  |
-| affinity | object | `{}` | Affinity settings for pod assignment of the GUI |
 | args[0] | string | `"/opt/sharry.conf"` |  |
+| config | object | see URL to default config | Full list of options https://eikek.github.io/sharry/doc/configure |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"eikek0/sharry"` | sharry image |
-| image.tag | string | `"1.6.0"` | sharry image tag |
-| ingress.annotations."nginx.ingress.kubernetes.io/client-body-buffer-size" | string | `"2048m"` | Nginx client Body Buffer Size |
-| ingress.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"2048m"` | Nginx Proxy Body Size |
+| image.repository | string | `"eikek0/sharry"` |  |
+| image.tag | string | `"1.6.0"` |  |
+| ingress.annotations."nginx.ingress.kubernetes.io/client-body-buffer-size" | string | `"2048m"` |  |
+| ingress.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"2048m"` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/proxy-buffering" | string | `"off"` |  |
 | ingress.enabled | bool | `false` |  |
-| nodeSelector | object | `{}` | Node labels for pod assignment of the GUI |
-| podAnnotations | object | `{}` | Pod annotations |
-| resources | object | `{}` |  |
-| service.port.port | int | `9090` | Kubernetes port where the GUI is exposed |
-| sharry.baseUrl | string | `"http://localhost:9090"` | This is the base URL this application is deployed to. |
-| sharry.chunkSize | string | `"512K"` | When storing binary data use chunks of this size. |
-| sharry.jdbcPassword | string | `""` | jdbc Password |
-| sharry.jdbcUrl | string | `"jdbc:h2://\"${java.io.tmpdir}\"/sharry-demo.db;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE"` | By default a H2 file-based database is configured. You can provide a postgresql or mariadb connection here. |
-| sharry.jdbcUser | string | `"sa"` | jdbc Username |
-| sharry.maxSize | string | `"1.5G"` | Maximum size of a share. |
-| sharry.maxValidity | string | `"365 days"` | Maximum validity for uploads. |
-| sharry.signup | string | `"open"` | The mode defines if new users can signup or not. It can have three values : open, invite, closed |
-| tolerations | list | `[]` | Toleration labels for pod assignment of the GUI |
+| service.port.port | int | `9090` |  |
 
 ## Changelog
 

--- a/charts/stable/sharry/templates/common.yaml
+++ b/charts/stable/sharry/templates/common.yaml
@@ -1,1 +1,31 @@
+{{/* Make sure all variables are set properly */}}
+{{- include "common.values.setup" . }}
+
+{{/* Append the configMap to the additionalVolumes */}}
+{{- define "sharry.configmap.volume" -}}
+name: sharry-config
+configMap:
+  name: {{ template "common.names.fullname" . }}-config
+{{- end -}}
+
+{{- $volume := include "sharry.configmap.volume" . | fromYaml -}}
+{{- if $volume -}}
+    {{- $additionalVolumes := append .Values.additionalVolumes $volume }}
+    {{- $_ := set .Values "additionalVolumes" (deepCopy $additionalVolumes) -}}
+{{- end -}}
+
+{{/* Append the configMap volume to the additionalVolumeMounts */}}
+{{- define "sharry.configmap.volumeMount" -}}
+name: sharry-config
+mountPath: /opt/sharry.conf
+subPath: sharry.conf
+{{- end -}}
+
+{{- $volumeMount := include "sharry.configmap.volumeMount" . | fromYaml -}}
+{{- if $volumeMount -}}
+    {{- $additionalVolumeMounts := append .Values.additionalVolumeMounts $volumeMount }}
+    {{- $_ := set .Values "additionalVolumeMounts" (deepCopy $additionalVolumeMounts) -}}
+{{- end -}}
+
+{{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/stable/sharry/templates/configmap.yaml
+++ b/charts/stable/sharry/templates/configmap.yaml
@@ -1,91 +1,9 @@
-
-{{/*
-Sharry Configuration files.
-*/}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "sharry-config"
+  name: {{ template "common.names.fullname" . }}-config
   labels:
     {{- include "common.labels" . | nindent 4 }}
 data:
   sharry.conf: |
-    sharry.restserver {
-      
-      {{- if .Values.sharry.baseUrl }}
-      base-url = "{{ .Values.sharry.baseUrl }}"
-      {{ end }}
-      bind {
-        address = "0.0.0.0"
-        port = {{- if .Values.service.port.port }}{{ .Values.service.port.port }}{{ end }}
-      }
-
-      backend {
-        auth {
-          fixed.enabled = true ## enabled admin:admin access
-        }
-
-        jdbc {
-          url = "{{- if .Values.sharry.jdbcUrl }}{{ .Values.sharry.jdbcUrl }}{{ end }}"
-          user = "{{- if .Values.sharry.jdbcUser }}{{ .Values.sharry.jdbcUser }}{{ end }}"
-          password = "{{- if .Values.sharry.jdbcPassword }}{{ .Values.sharry.jdbcPassword }}{{ end }}"
-        }
-
-      webapp {
-        # This is shown in the top right corner of the web application
-        app-name = "Sharry"
-
-        # The icon next to the app-name. Needs to be an URL to a image.
-        app-icon = ""
-
-        # The login and register page displays a logo image, by default
-        # the Sharry logo. This can be changed here. It needs to be an URL
-        # to an image.
-        app-logo = ""
-
-        # This is markdown that is inserted as the footer on each page in
-        # the ui. If left empty, a link to the project is rendered.
-        app-footer = ""
-
-        # Whether to display the footer on each page in the ui. Set it to
-        # false to hide it.
-        app-footer-visible = true
-
-        # Chunk size used for one request. The server will re-chunk the
-        # stream into smaller chunks. But the client can transfer more in
-        # one requests, resulting in faster uploads.
-        #
-        # You might need to adjust this value depending on your setup. A
-        # higher value usually means faster uploads.
-        chunk-size = "100M"
-
-        # Number of milliseconds the client should wait before doing a new
-        # upload attempt after something failed. The length of the array
-        # denotes the number of retries.
-        retry-delays = [0, 3000, 6000, 12000, 24000, 48000]
-
-        # The login page can display a welcome message that is readable by
-        # everyone. The text is processed as markdown.
-        welcome-message = ""
-
-      }
-
-      share {
-            # When storing binary data use chunks of this size.
-            chunk-size = "{{- if .Values.sharry.chunkSize }}{{ .Values.sharry.chunkSize }}{{ end }}"
-      
-            # Maximum size of a share.
-            max-size = "{{- if .Values.sharry.maxSize }}{{ .Values.sharry.maxSize }}{{ end }}"
-      
-            # Maximum validity for uploads
-            max-validity = {{- if .Values.sharry.maxValidity }}{{ .Values.sharry.maxValidity }}{{ end }}
-          }
-      
-              signup {
-                mode = "{{- if .Values.sharry.signup }}{{ .Values.sharry.signup }}{{ end }}"
-                invite-time = "3 days"
-                invite-password = "generate-invite"
-              }
-            }
-      
-          }
+{{ .Values.config | indent 4 }}

--- a/charts/stable/sharry/values.yaml
+++ b/charts/stable/sharry/values.yaml
@@ -27,7 +27,8 @@ ingress:
     # -- Full list of options https://eikek.github.io/sharry/doc/configure
 # @default -- see URL to default config
 config: |
- sharry.restserver {
+  sharry.restserver {
+    # base-url = "https://sharry.${DOMAIN}"
     backend {
       auth {
         fixed {

--- a/charts/stable/sharry/values.yaml
+++ b/charts/stable/sharry/values.yaml
@@ -16,7 +16,15 @@ service:
 args:
 - "/opt/sharry.conf"
 
-# -- Full list of options https://eikek.github.io/sharry/doc/configure
+ingress:
+  enabled: false
+  # -- Enable large file support with those annotations for nginx
+  # annotations:
+  #   nginx.ingress.kubernetes.io/client-body-buffer-size: "2048m"
+  #   nginx.ingress.kubernetes.io/proxy-body-size: "2048m"
+  #   nginx.ingress.kubernetes.io/proxy-buffering: "off"
+
+    # -- Full list of options https://eikek.github.io/sharry/doc/configure
 # @default -- see URL to default config
 config: |
  sharry.restserver {
@@ -31,10 +39,3 @@ config: |
       }
     }
   }
-
-ingress:
-  enabled: false
-  annotations:
-    nginx.ingress.kubernetes.io/client-body-buffer-size: "2048m"
-    nginx.ingress.kubernetes.io/proxy-body-size: "2048m"
-    nginx.ingress.kubernetes.io/proxy-buffering: "off"

--- a/charts/stable/sharry/values.yaml
+++ b/charts/stable/sharry/values.yaml
@@ -1,77 +1,28 @@
-# Default values for sharry.
-
+#
+## IMPORTANT NOTE
+##
+## This chart inherits from our common library chart. You can check the default values/options here:
+## https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml
+##
 image:
-  # -- sharry image
   repository: eikek0/sharry
-  # -- sharry image tag
   tag: 1.6.0
-  # sharry image pull policy
   pullPolicy: IfNotPresent
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
 
 service:
   port:
-    # -- Kubernetes port where the GUI is exposed
     port: 9090
 
 args:
 - "/opt/sharry.conf"
 
-sharry:
-  # -- This is the base URL this application is deployed to.
-  baseUrl: "http://localhost:9090"
-  # -- By default a H2 file-based database is configured. You can provide a postgresql or mariadb connection here.
-  jdbcUrl: "jdbc:h2://\"${java.io.tmpdir}\"/sharry-demo.db;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE"
-  # -- jdbc Username
-  jdbcUser: sa
-  # -- jdbc Password
-  jdbcPassword: ""
-  # -- When storing binary data use chunks of this size.
-  chunkSize: "512K"
-  # -- Maximum size of a share.
-  maxSize: "1.5G"
-  # -- Maximum validity for uploads.
-  maxValidity: "365 days"
-  # -- The mode defines if new users can signup or not. It can have three values : open, invite, closed
-  signup: "open"
-
-# -- Node labels for pod assignment of the GUI
-nodeSelector: {}
-
-# -- Toleration labels for pod assignment of the GUI
-tolerations: []
-
-# -- Affinity settings for pod assignment of the GUI
-affinity: {}
-
-# -- Pod annotations
-podAnnotations: {}
-
-additionalVolumes:
-- name: sharry-config
-  configMap:
-    name: sharry-config
-additionalVolumeMounts:
-- name: sharry-config
-  mountPath: /opt/sharry.conf
-  subPath: sharry.conf
+# -- Full list of options https://eikek.github.io/sharry/doc/configure
+# @default -- see URL to default config
+config: {}
 
 ingress:
   enabled: false
   annotations:
-    # -- Nginx client Body Buffer Size
     nginx.ingress.kubernetes.io/client-body-buffer-size: "2048m"
-    # -- Nginx Proxy Body Size
     nginx.ingress.kubernetes.io/proxy-body-size: "2048m"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"

--- a/charts/stable/sharry/values.yaml
+++ b/charts/stable/sharry/values.yaml
@@ -18,20 +18,19 @@ args:
 
 # -- Full list of options https://eikek.github.io/sharry/doc/configure
 # @default -- see URL to default config
-config: {}
-# e.g. to enable admin:admin authentication (disabled by default)
-# sharry.restserver {
-#    backend {
-#      auth {
-#        fixed {
-#          enabled = true
-#          user = "admin"
-#          password = "admin"
-#          order = 10
-#        }
-#      }
-#    }
-#  }
+config: |
+ sharry.restserver {
+    backend {
+      auth {
+        fixed {
+          enabled = false  # set to true to enable this auth provider
+          user = "admin"
+          password = "admin"
+          order = 10
+        }
+      }
+    }
+  }
 
 ingress:
   enabled: false

--- a/charts/stable/sharry/values.yaml
+++ b/charts/stable/sharry/values.yaml
@@ -19,6 +19,19 @@ args:
 # -- Full list of options https://eikek.github.io/sharry/doc/configure
 # @default -- see URL to default config
 config: {}
+# e.g. to enable admin:admin authentication (disabled by default)
+# sharry.restserver {
+#    backend {
+#      auth {
+#        fixed {
+#          enabled = true
+#          user = "admin"
+#          password = "admin"
+#          order = 10
+#        }
+#      }
+#    }
+#  }
 
 ingress:
   enabled: false

--- a/charts/stable/sharry/values.yaml
+++ b/charts/stable/sharry/values.yaml
@@ -29,6 +29,10 @@ ingress:
 config: |
   sharry.restserver {
     # base-url = "https://sharry.${DOMAIN}"
+    bind {
+      address = "0.0.0.0"
+      port = 9090
+    }
     backend {
       auth {
         fixed {


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
Use a config block for sharry and some clean up

**Benefits**
Fixes a security issue where using the chart would always expose admin:admin account
without the ability to disable it.

**Possible drawbacks**
User has to dig a bit in the configuration to configure authentication

**Applicable issues**
N/A

**Additional information**
I've tried to do a bit of clean up along the way, there may be a :bug: 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
