### PR TITLE
[wallabag] add dependency charts

### DIFF
--- a/charts/stable/wallabag/Chart.yaml
+++ b/charts/stable/wallabag/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.4.1
 description: A self hostable application for saving web pages, freely.
 name: wallabag
-version: 2.3.1
+version: 2.4.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - wallabag
@@ -17,3 +17,15 @@ dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com
   version: 2.3.1
+- name: redis
+  version: 6.2.2
+  repository: https://charts.bitnami.com/bitnami
+  condition: redis.enabled
+- name: postgresql
+  version: 10.3.15
+  repository: https://charts.bitnami.com/bitnami
+  condition: postgresql.enabled
+- name: mariadb
+  version: 9.3.6
+  repository: https://charts.bitnami.com/bitnami
+  condition: mariadb.enabled

--- a/charts/stable/wallabag/Chart.yaml
+++ b/charts/stable/wallabag/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
   repository: https://library-charts.k8s-at-home.com
   version: 2.3.1
 - name: redis
-  version: 6.2.2
+  version: 14.1.0
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled
 - name: postgresql

--- a/charts/stable/wallabag/README.md
+++ b/charts/stable/wallabag/README.md
@@ -21,7 +21,7 @@ Kubernetes: `>=1.16.0-0`
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mariadb | 9.3.6 |
 | https://charts.bitnami.com/bitnami | postgresql | 10.3.15 |
-| https://charts.bitnami.com/bitnami | redis | 6.2.2 |
+| https://charts.bitnami.com/bitnami | redis | 14.1.0 |
 | https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
@@ -85,6 +85,13 @@ Default login is `wallabag:wallabag`.
 | image.repository | string | `"wallabag/wallabag"` |  |
 | image.tag | string | `"2.4.1"` |  |
 | ingress.enabled | bool | `false` |  |
+| mariadb.architecture | string | `"standalone"` |  |
+| mariadb.auth.database | string | `"wallabag"` |  |
+| mariadb.auth.password | string | `"wallabag-pass"` |  |
+| mariadb.auth.rootPassword | string | `"wallabag-rootpass"` |  |
+| mariadb.auth.username | string | `"wallabag"` |  |
+| mariadb.enabled | bool | `false` |  |
+| mariadb.primary.persistence.enabled | bool | `false` |  |
 | persistence.cache.emptyDir.enabled | bool | `false` |  |
 | persistence.cache.enabled | bool | `false` |  |
 | persistence.cache.mountPath | string | `"/var/www/wallabag/var/cache"` |  |

--- a/charts/stable/wallabag/README.md
+++ b/charts/stable/wallabag/README.md
@@ -1,6 +1,6 @@
 # wallabag
 
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
 
 A self hostable application for saving web pages, freely.
 
@@ -19,7 +19,10 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.2.0 |
+| https://charts.bitnami.com/bitnami | mariadb | 9.3.6 |
+| https://charts.bitnami.com/bitnami | postgresql | 10.3.15 |
+| https://charts.bitnami.com/bitnami | redis | 6.2.2 |
+| https://library-charts.k8s-at-home.com | common | 2.3.1 |
 
 ## TL;DR
 
@@ -88,6 +91,13 @@ Default login is `wallabag:wallabag`.
 | persistence.images.emptyDir.enabled | bool | `false` |  |
 | persistence.images.enabled | bool | `false` |  |
 | persistence.images.mountPath | string | `"/var/www/wallabag/web/assets/images"` |  |
+| postgresql.enabled | bool | `false` |  |
+| postgresql.persistence.enabled | bool | `false` |  |
+| postgresql.postgresqlDatabase | string | `"wallabag"` |  |
+| postgresql.postgresqlPassword | string | `"wallabag-pass"` |  |
+| postgresql.postgresqlUsername | string | `"wallabag"` |  |
+| redis.auth.enabled | bool | `false` |  |
+| redis.enabled | bool | `false` |  |
 | service.port.port | int | `80` |  |
 | strategy.type | string | `"RollingUpdate"` |  |
 

--- a/charts/stable/wallabag/values.yaml
+++ b/charts/stable/wallabag/values.yaml
@@ -84,3 +84,20 @@ persistence:
     emptyDir:
       enabled: false
     mountPath: /var/www/wallabag/var/cache
+
+# Enabled postgres
+# ... for more options see https://github.com/bitnami/charts/tree/master/bitnami/postgresql
+postgresql:
+  enabled: false
+  postgresqlUsername: wallabag
+  postgresqlPassword: wallabag-pass
+  postgresqlDatabase: wallabag
+  persistence:
+    enabled: false
+
+# Enabled redis
+# ... for more options see https://github.com/bitnami/charts/tree/master/bitnami/redis
+redis:
+  enabled: false
+  auth:
+    enabled: false

--- a/charts/stable/wallabag/values.yaml
+++ b/charts/stable/wallabag/values.yaml
@@ -85,6 +85,20 @@ persistence:
       enabled: false
     mountPath: /var/www/wallabag/var/cache
 
+# Enabled mariadb
+# ... for more options see https://github.com/bitnami/charts/tree/master/bitnami/mariadb
+mariadb:
+  enabled: false
+  architecture: standalone
+  auth:
+    database: wallabag
+    username: wallabag
+    password: wallabag-pass
+    rootPassword: wallabag-rootpass
+  primary:
+    persistence:
+      enabled: false
+
 # Enabled postgres
 # ... for more options see https://github.com/bitnami/charts/tree/master/bitnami/postgresql
 postgresql:


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
Add dependency charts for postgresql, mariadb and redis to wallabag

**Benefits**
Easier installation

**Possible drawbacks**
N/A

**Applicable issues**
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
