### PR TITLE
[CI] Remove check-version, turnstyle

### DIFF
--- a/.github/workflows/charts-lint-test.yaml
+++ b/.github/workflows/charts-lint-test.yaml
@@ -82,79 +82,6 @@ jobs:
           echo "::set-output name=detected::true"
         fi
 
-  check_version:
-    needs:
-    - changes-lint
-    if: |
-      !contains(github.event.head_commit.message, '[ci-skip]') &&
-      needs.changes-lint.outputs.detected == 'true'
-    name: Check chart version numbers
-    strategy:
-      matrix: ${{ fromJson(needs.changes-lint.outputs.matrix) }}
-      fail-fast: true
-      max-parallel: 15
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: Get version
-      id: version-get
-      run: |
-        shopt -s extglob
-        OUTPUT=$(helm inspect chart ${{ matrix.chart }} | grep "^version:")
-        VERSION=${OUTPUT#"version:"}
-        echo "::set-output name=version::${VERSION##*( )}"
-        shopt -u extglob
-
-    - name: Parse version
-      id: version-parse
-      uses: apexskier/github-semver-parse@v1
-      with:
-        version: ${{ steps.version-get.outputs.version }}
-
-    - name: Check version
-      id: version-check
-      run: |
-        if [[ ${{ matrix.chart }} =~ ^charts\/(.*)\/.* ]]; then
-          TYPE="${BASH_REMATCH[1]}"  
-          case $TYPE in
-            stable)
-              if [[ ${{ steps.version-parse.outputs.major }} -lt 1 ]]; then
-                echo "::error file=${{ matrix.chart }}::Chart version for \"$TYPE\" charts must be >= 1.0.0"
-                exit 1
-              fi
-            ;;
-
-            incubator)
-              if [[ ${{ steps.version-parse.outputs.major }} -gt 0 ]]; then
-                echo "::error file=${{ matrix.chart }}::Chart version for \"$TYPE\" charts must be < 1.0.0"
-                exit 1
-              fi
-            ;;
-
-            *)
-              echo "::error file=${{ matrix.chart }}::Unhandled chart type: $TYPE"
-              exit 1
-          esac
-        fi
-
-  # Summarize matrix https://github.community/t/status-check-for-a-matrix-jobs/127354/7
-  check_version_success:
-    needs: 
-    - changes-lint
-    - check_version
-    if: ${{ always() }}
-    name: Version check successful
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Check Version matrix status
-      if: ${{ !contains(github.event.head_commit.message, '[ci-skip]') && needs.changes-lint.outputs.detected == 'true' && needs.check_version.result != 'success' }}
-      run: |
-        exit 1
-
   lint:
     needs:
     - changes-lint
@@ -238,7 +165,6 @@ jobs:
   install:
     needs:
     - changes-install
-    - check_version_success
     - lint_success
     if: |
       !contains(github.event.head_commit.message, '[ci-skip]')

--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -1,5 +1,7 @@
 name: "Charts: Release"
 
+concurrency: helm-release
+
 on:
   workflow_dispatch:
   push:
@@ -13,30 +15,11 @@ on:
     - '!charts/**/README_CONFIG.md.gotmpl'
 
 jobs:
-  pre-release:
-    if: "!contains(github.event.head_commit.message, '[ci-skip]')"
-    runs-on: ubuntu-20.04
-    timeout-minutes: 5
-    steps:
-    - name: Block concurrent jobs
-      uses: softprops/turnstyle@v1
-      with:
-        continue-after-seconds: 180
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   release:
     if: "!contains(github.event.head_commit.message, '[ci-skip]')"
     needs: pre-release
     runs-on: ubuntu-20.04
     steps:
-    - name: Block concurrent jobs
-      uses: softprops/turnstyle@v1
-      with:
-        continue-after-seconds: 180
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Checkout
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
**Description of the change**

- Removes the check_version step from the CI
- Removes turnstyle in favor of Github's official concurrency

**Benefits**

- Removes the 100's of jobs that are spawned by the job matrix. Since we don't often have incubator charts, I don't think we are at risk of missing any incorrect version numbers during PR review.
- Removes dependency on turnstyle action. Using the official Github supported way should be favored.

**Possible drawbacks**

- We are still human, so we might miss an incorrect version number during PR review sometime...
- Github concurrency is still in beta and might change a bit over time. Worked fine so far during testing

