### PR TITLE
[stable/bitwardenrs] fix ldap labels and names

### DIFF
--- a/charts/stable/bitwardenrs/Chart.yaml
+++ b/charts/stable/bitwardenrs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bitwardenrs
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 2.1.10
+version: 2.1.11
 appVersion: 1.18.0
 keywords:
   - bitwarden

--- a/charts/stable/bitwardenrs/templates/_helpers.tpl
+++ b/charts/stable/bitwardenrs/templates/_helpers.tpl
@@ -52,17 +52,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Ldap labels
+Ldap Sync Selector labels
 */}}
-{{- define "bitwardenrsLdap.labels" -}}
-helm.sh/chart: {{ include "bitwardenrs.chart" . }}
-{{ include "bitwardenrsLdap.selectorLabels" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
-{{- define "bitwardenrsLdap.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "bitwardenrs.name" . }}-ldap
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{- define "bitwardenrs.selectorLabels.ldapSync" -}}
+{{ include "bitwardenrs.selectorLabels" . }}
+app.kubernetes.io/component: ldap-sync
 {{- end -}}
 
 {{/*

--- a/charts/stable/bitwardenrs/templates/deployment-ldapsync.yaml
+++ b/charts/stable/bitwardenrs/templates/deployment-ldapsync.yaml
@@ -3,17 +3,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{- include "bitwardenrsLdap.labels" . | nindent 4 }}
-  name: {{ include "bitwardenrs.name" . }}-ldap
+    {{- include "bitwardenrs.labels" . | nindent 4 }}
+  name: {{ include "bitwardenrs.fullname" . }}-ldap
 spec:
   selector:
     matchLabels:
-      {{- include "bitwardenrsLdap.selectorLabels" . | nindent 6 }}
+      {{- include "bitwardenrs.selectorLabels.ldapSync" . | nindent 6 }}
   replicas: 1
   template:
     metadata:
       labels:
-        {{- include "bitwardenrsLdap.selectorLabels" . | nindent 8 }}
+        {{- include "bitwardenrs.selectorLabels.ldapSync" . | nindent 8 }}
     spec:
       initContainers:
       containers:

--- a/charts/stable/bitwardenrs/templates/secret-ldapsync.yaml
+++ b/charts/stable/bitwardenrs/templates/secret-ldapsync.yaml
@@ -5,7 +5,7 @@ data:
 kind: Secret
 metadata:
   labels:
-  {{- include "bitwardenrsLdap.labels" . | nindent 4 }}
-  name: {{ include "bitwardenrs.name" . -}}-ldap
+    {{- include "bitwardenrs.labels" . | nindent 4 }}
+  name: {{ template "bitwardenrs.fullname" . }}-ldap
 type: Opaque
 {{- end }}


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek23@gmail.com>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
Changes labels and names of ldap sync resources

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
This fixes an issue when the chart, having ldapSync enabled, is installed, uninstalled and installed again, where the ldap secret was not deleted, because label mismatch.

It also fixes an issue when ldapSync is enabled and the chart is installed several times using different release names, where the ldap secret and the deployment got the same name, because the fullname var was not used.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
