### PR TITLE
[bitwarden_rs] Deprecate Bitwarden_rs chart

### DIFF
--- a/charts/stable/bitwardenrs/Chart.yaml
+++ b/charts/stable/bitwardenrs/Chart.yaml
@@ -14,7 +14,4 @@ keywords:
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/bitwardenrs
 sources:
   - https://github.com/dani-garcia/bitwarden_rs
-maintainers:
-  - name: DirtyCajunRice
-    email: nick@cajun.pro
 icon: https://raw.githubusercontent.com/bitwarden/brand/master/icons/256x256.png

--- a/charts/stable/bitwardenrs/Chart.yaml
+++ b/charts/stable/bitwardenrs/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v2
 name: bitwardenrs
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 2.1.10
+version: 2.1.11
 appVersion: 1.18.0
+deprecated: true
 keywords:
   - bitwarden
   - bitwardenrs

--- a/charts/stable/bitwardenrs/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/bitwardenrs/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.1.11]
+
+#### Added
+
+- Deprecated the chart
+
 ### [2.0.1]
 
 #### Added


### PR DESCRIPTION
**Description of the change**

This PR deprecates the bitwarden_rs chart in favor of the new vaultwarden chart.

However: In stark contrast with previous deprecations, I suggest keeping it active for a few months to ease people moving over to the vaultwarden chart.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

- promotes using the new name for bitwarden_rs (vaultwarden)
- promotes using a chart which uses the library chart

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

- deprecates a much used chart

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #892

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
