### PR TITLE
[appdaemon] Add persistence.config.mountPath

### DIFF
--- a/charts/stable/appdaemon/Chart.yaml
+++ b/charts/stable/appdaemon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.8
 description: AppDaemon is a loosely coupled, multi-threaded, sandboxed python execution environment for writing automation apps for various types of Home Automation Software including Home Assistant and MQTT.
 name: appdaemon
-version: 5.1.0
+version: 6.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - appdaemon

--- a/charts/stable/appdaemon/README.md
+++ b/charts/stable/appdaemon/README.md
@@ -1,6 +1,6 @@
 # appdaemon
 
-![Version: 5.0.1](https://img.shields.io/badge/Version-5.0.1-informational?style=flat-square) ![AppVersion: 4.0.8](https://img.shields.io/badge/AppVersion-4.0.8-informational?style=flat-square)
+![Version: 6.0.0](https://img.shields.io/badge/Version-6.0.0-informational?style=flat-square) ![AppVersion: 4.0.8](https://img.shields.io/badge/AppVersion-4.0.8-informational?style=flat-square)
 
 AppDaemon is a loosely coupled, multi-threaded, sandboxed python execution environment for writing automation apps for various types of Home Automation Software including Home Assistant and MQTT.
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.3.1 |
+| https://library-charts.k8s-at-home.com | common | 2.5.0 |
 
 ## TL;DR
 
@@ -83,6 +83,7 @@ N/A
 | ingress.enabled | bool | `false` |  |
 | persistence.config.emptyDir.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
+| persistence.config.mountPath | string | `"/conf"` |  |
 | service.port.port | int | `5050` |  |
 | strategy.type | string | `"Recreate"` |  |
 
@@ -91,6 +92,20 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [6.0.0]
+
+#### Added
+
+- Added persistence.config.mountPath
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- Commented items under persistence.
 
 ### [5.0.1]
 

--- a/charts/stable/appdaemon/README.md.gotmpl
+++ b/charts/stable/appdaemon/README.md.gotmpl
@@ -143,3 +143,4 @@ helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }} -
 {{ template "custom.support" . }}
 
 {{ template "helm-docs.versionFooter" . }}
+{{ "" }}

--- a/charts/stable/appdaemon/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/appdaemon/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,20 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [6.0.0]
+
+#### Added
+
+- Added persistence.config.mountPath
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- Commented items under persistence.
+
 ### [5.0.1]
 
 #### Added

--- a/charts/stable/appdaemon/values.yaml
+++ b/charts/stable/appdaemon/values.yaml
@@ -36,15 +36,4 @@ persistence:
     enabled: false
     emptyDir:
       enabled: false
-    ## Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    # storageClass: "-"
-    # accessMode: ReadWriteOnce
-    # size: 1Gi
-    ## Set to true to retain the PVC upon helm uninstall
-    # skipuninstall: false
-    # existingClaim: ""
+    mountPath: /conf


### PR DESCRIPTION

Signed-off-by: Nicholas Wilde <ncwilde43@gmail.com>

**Description of the change**

- Add `persistence.config.mountPath`
- Removed commented items in persistence.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #899

**Additional information**

- Bumped to major version because adding the `mountPath` might break existing installations? Advice on this is welcome.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
