### PR TITLE
[oauth2-proxy] Update oauth2-proxy website urls

### DIFF
--- a/charts/stable/oauth2-proxy/Chart.yaml
+++ b/charts/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 5.0.4
+version: 5.0.5
 apiVersion: v1
 appVersion: 7.0.1
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/oauth2-proxy

--- a/charts/stable/oauth2-proxy/README.md
+++ b/charts/stable/oauth2-proxy/README.md
@@ -68,7 +68,7 @@ helm install oauth2-proxy k8s-at-home/oauth2-proxy -f values.yaml
 
 ### SSL Configuration
 
-See: [SSL Configuration](https://pusher.github.io/oauth2_proxy/tls-configuration).
+See: [SSL Configuration](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/tls).
 Use ```values.yaml``` like:
 
 ```yaml
@@ -105,11 +105,11 @@ data:
 |-----|------|---------|-------------|
 | affinity | object | `{}` | node/pod affinities Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | authenticatedEmailsFile.enabled | bool | `false` | Enables authorize individual email addresses |
-| authenticatedEmailsFile.restricted_access | string | `""` | [email addresses](https://github.com/pusher/oauth2_proxy#email-authentication) list config |
+| authenticatedEmailsFile.restricted_access | string | `""` | [email addresses](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider#email-authentication) list config |
 | authenticatedEmailsFile.template | string | `""` | Name of the configmap that is handled outside of that chart It's a simpler way to maintain only one configmap (user list) instead changing it for each oauth2-proxy service. Be aware the value name in the extern config map in data needs to be named to "restricted_user_access". One email per line example: restricted_access: |-   name1@domain   name2@domain If you override the config with restricted_access it will configure a user list within this chart what takes care of the config map resource. |
 | config.clientID | string | `"XXXXXXX"` | OAuth client ID |
 | config.clientSecret | string | `"XXXXXXXX"` | OAuth client secret |
-| config.configFile | string | `"email_domains = [ \"*\" ]\nupstreams = [ \"file:///dev/null\" ]"` | google service account json contents serviceAccountJson: xxxx -- Alternatively, use an existing secret (see google-secret.yaml for required fields) existingSecret: google-secret -- custom [oauth2_proxy.cfg](https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line |
+| config.configFile | string | `"email_domains = [ \"*\" ]\nupstreams = [ \"file:///dev/null\" ]"` | google service account json contents serviceAccountJson: xxxx -- Alternatively, use an existing secret (see google-secret.yaml for required fields) existingSecret: google-secret -- custom [oauth2_proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/contrib/oauth2-proxy.cfg.example) contents for settings not overridable via environment nor command line |
 | config.cookieSecret | string | `"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"` | server specific cookie for the secret; create a new one with `openssl rand -base64 32 | head -c 32 | base64` |
 | config.existingConfig | string | `nil` | xisting Kubernetes configmap to use for the configuration file. See [config template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/configmap.yaml) for the required values |
 | config.google | object | `{}` |  |
@@ -118,7 +118,7 @@ data:
 | extraVolumeMounts | list | `[]` | list of extra volumeMounts |
 | extraVolumes | list | `[]` | list of extra volumes |
 | htpasswdFile.enabled | bool | `false` | enable htpasswd-file option |
-| htpasswdFile.entries | object | `{}` | list of [SHA encrypted user:passwords](https://pusher.github.io/oauth2_proxy/configuration#command-line-options) |
+| htpasswdFile.entries | object | `{}` | list of [SHA encrypted user:passwords](https://oauth2-proxy.github.io/oauth2-proxy/configuration#command-line-options) |
 | htpasswdFile.existingSecret | string | `""` | existing Kubernetes secret to use for OAuth2 htpasswd file |
 | httpScheme | string | `"http"` | `http` or `https`. `name` used for port on the deployment. `httpGet` port `name` and `scheme` used for `liveness`- and `readinessProbes`. `name` and `targetPort` used for the service. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
@@ -166,7 +166,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Changed
 
-- This version upgrade oauth2-proxy to v4.0.0. Please see the [changelog](https://github.com/pusher/oauth2_proxy/blob/v4.0.0/CHANGELOG.md#v400) in order to upgrade.
+- This version upgrade oauth2-proxy to v4.0.0. Please see the [changelog](https://github.com/oauth2-proxy/oauth2-proxy/blob/v4.0.0/CHANGELOG.md#v400) in order to upgrade.
 
 ### [2.0.0]
 

--- a/charts/stable/oauth2-proxy/README.md
+++ b/charts/stable/oauth2-proxy/README.md
@@ -1,6 +1,6 @@
 # oauth2-proxy
 
-![Version: 5.0.4](https://img.shields.io/badge/Version-5.0.4-informational?style=flat-square) ![AppVersion: 7.0.1](https://img.shields.io/badge/AppVersion-7.0.1-informational?style=flat-square)
+![Version: 5.0.5](https://img.shields.io/badge/Version-5.0.5-informational?style=flat-square) ![AppVersion: 7.0.1](https://img.shields.io/badge/AppVersion-7.0.1-informational?style=flat-square)
 
 A reverse proxy that provides authentication with Google, Github or other providers
 
@@ -221,6 +221,12 @@ Due to [this issue](https://github.com/helm/helm/issues/6583) there may be error
 #### Removed
 
 - N/A
+
+### [5.0.5]
+
+#### Fixed
+
+- Update oauth2-proxy website URLs.
 
 [5.0.4]: #5.0.4
 [5.0.1]: #5.0.1

--- a/charts/stable/oauth2-proxy/README.md.gotmpl
+++ b/charts/stable/oauth2-proxy/README.md.gotmpl
@@ -143,3 +143,4 @@ helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }} -
 {{ template "custom.support" . }}
 
 {{ template "helm-docs.versionFooter" . }}
+{{ "" }}

--- a/charts/stable/oauth2-proxy/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/oauth2-proxy/README_CHANGELOG.md.gotmpl
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Changed
 
-- This version upgrade oauth2-proxy to v4.0.0. Please see the [changelog](https://github.com/pusher/oauth2_proxy/blob/v4.0.0/CHANGELOG.md#v400) in order to upgrade.
+- This version upgrade oauth2-proxy to v4.0.0. Please see the [changelog](https://github.com/oauth2-proxy/oauth2-proxy/blob/v4.0.0/CHANGELOG.md#v400) in order to upgrade.
 
 ### [2.0.0]
 

--- a/charts/stable/oauth2-proxy/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/oauth2-proxy/README_CHANGELOG.md.gotmpl
@@ -69,6 +69,12 @@ Due to [this issue](https://github.com/helm/helm/issues/6583) there may be error
 
 - N/A
 
+### [5.0.5]
+
+#### Fixed
+
+- Update oauth2-proxy website URLs.
+
 [5.0.4]: #5.0.4
 [5.0.1]: #5.0.1
 {{- end -}}

--- a/charts/stable/oauth2-proxy/README_CONFIG.md.gotmpl
+++ b/charts/stable/oauth2-proxy/README_CONFIG.md.gotmpl
@@ -7,7 +7,7 @@
 
 ### SSL Configuration
 
-See: [SSL Configuration](https://pusher.github.io/oauth2_proxy/tls-configuration).
+See: [SSL Configuration](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/tls).
 Use ```values.yaml``` like:
 
 ```yaml

--- a/charts/stable/oauth2-proxy/values.yaml
+++ b/charts/stable/oauth2-proxy/values.yaml
@@ -16,7 +16,7 @@ config:
     # -- Alternatively, use an existing secret (see google-secret.yaml for required fields)
     # existingSecret: google-secret
 
-  # -- custom [oauth2_proxy.cfg](https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line
+  # -- custom [oauth2_proxy.cfg](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/contrib/oauth2-proxy.cfg.example) contents for settings not overridable via environment nor command line
   configFile: |-
     email_domains = [ "*" ]
     upstreams = [ "file:///dev/null" ]
@@ -64,7 +64,7 @@ authenticatedEmailsFile:
   # config map resource.
   template: ""
 
-  # -- [email addresses](https://github.com/pusher/oauth2_proxy#email-authentication) list config
+  # -- [email addresses](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider#email-authentication) list config
   restricted_access: ""
 
 service:
@@ -205,7 +205,7 @@ htpasswdFile:
   enabled: false
   # -- existing Kubernetes secret to use for OAuth2 htpasswd file
   existingSecret: ""
-  # -- list of [SHA encrypted user:passwords](https://pusher.github.io/oauth2_proxy/configuration#command-line-options)
+  # -- list of [SHA encrypted user:passwords](https://oauth2-proxy.github.io/oauth2-proxy/configuration#command-line-options)
   entries: {}
   # One row for each user
   # example:


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

oauth2-proxy was moved under the oauth2-proxy organization.

This pull request fixes outdated oauth2-proxy urls.

**Benefits**

<!-- What benefits will be realized by the code change? -->

People can visit new oauth2-proxy website and repository, not 404.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

None (maybe)

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
