### PR TITLE
[syncthing] Syncthing version bump

### DIFF
--- a/charts/stable/syncthing/Chart.yaml
+++ b/charts/stable/syncthing/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.15.1
+appVersion: 1.16.1
 description: Open Source Continuous File Synchronization
 name: syncthing
-version: 1.2.0
+version: 1.3.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - syncthing

--- a/charts/stable/syncthing/README.md
+++ b/charts/stable/syncthing/README.md
@@ -117,6 +117,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Changed
 
 - Updated syncthing container image version to `v1.16.1`.
+- Updated common chart dependency to `2.5.0`.
 
 #### Removed
 

--- a/charts/stable/syncthing/README.md
+++ b/charts/stable/syncthing/README.md
@@ -1,6 +1,6 @@
 # syncthing
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 1.15.1](https://img.shields.io/badge/AppVersion-1.15.1-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.15.1-informational?style=flat-square)
 
 Open Source Continuous File Synchronization
 
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.3.1 |
+| https://library-charts.k8s-at-home.com | common | 2.5.0 |
 
 ## TL;DR
 
@@ -78,7 +78,7 @@ N/A
 |-----|------|---------|-------------|
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"syncthing/syncthing"` |  |
-| image.tag | string | `"1.15.1"` |  |
+| image.tag | string | `"1.16.1"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.data.emptyDir.enabled | bool | `false` |  |
 | persistence.data.enabled | bool | `false` |  |
@@ -108,6 +108,20 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.3.0]
+
+#### Added
+
+- N/A
+
+#### Changed
+
+- Updated syncthing container image version to `v1.16.1`.
+
+#### Removed
+
+- N/A
+
 ### [1.1.2]
 
 #### Added
@@ -136,6 +150,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[1.3.0]: #1.3.0
 [1.1.2]: #1.1.2
 [1.0.0]: #1.0.0
 

--- a/charts/stable/syncthing/README.md
+++ b/charts/stable/syncthing/README.md
@@ -1,6 +1,6 @@
 # syncthing
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.15.1-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
 
 Open Source Continuous File Synchronization
 
@@ -8,8 +8,8 @@ Open Source Continuous File Synchronization
 
 ## Source Code
 
-- <https://syncthing.net/>
-- <https://github.com/syncthing/syncthing>
+* <https://syncthing.net/>
+* <https://github.com/syncthing/syncthing>
 
 ## Requirements
 
@@ -17,9 +17,9 @@ Kubernetes: `>=1.16.0-0`
 
 ## Dependencies
 
-| Repository                             | Name   | Version |
-| -------------------------------------- | ------ | ------- |
-| https://library-charts.k8s-at-home.com | common | 2.5.0   |
+| Repository | Name | Version |
+|------------|------|---------|
+| https://library-charts.k8s-at-home.com | common | 2.5.0 |
 
 ## TL;DR
 
@@ -74,33 +74,33 @@ N/A
 
 **Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
 
-| Key                                                 | Type   | Default                 | Description |
-| --------------------------------------------------- | ------ | ----------------------- | ----------- |
-| image.pullPolicy                                    | string | `"IfNotPresent"`        |             |
-| image.repository                                    | string | `"syncthing/syncthing"` |             |
-| image.tag                                           | string | `"1.16.1"`              |             |
-| ingress.enabled                                     | bool   | `false`                 |             |
-| persistence.data.emptyDir.enabled                   | bool   | `false`                 |             |
-| persistence.data.enabled                            | bool   | `false`                 |             |
-| persistence.data.mountPath                          | string | `"/var/syncthing"`      |             |
-| service.additionalServices[0].enabled               | bool   | `true`                  |             |
-| service.additionalServices[0].externalTrafficPolicy | string | `"Local"`               |             |
-| service.additionalServices[0].nameSuffix            | string | `"listen"`              |             |
-| service.additionalServices[0].port.name             | string | `"listen"`              |             |
-| service.additionalServices[0].port.port             | int    | `22000`                 |             |
-| service.additionalServices[0].port.protocol         | string | `"TCP"`                 |             |
-| service.additionalServices[0].port.targetPort       | int    | `22000`                 |             |
-| service.additionalServices[0].type                  | string | `"NodePort"`            |             |
-| service.additionalServices[1].enabled               | bool   | `true`                  |             |
-| service.additionalServices[1].externalTrafficPolicy | string | `"Local"`               |             |
-| service.additionalServices[1].nameSuffix            | string | `"discovery"`           |             |
-| service.additionalServices[1].port.name             | string | `"discovery"`           |             |
-| service.additionalServices[1].port.port             | int    | `21027`                 |             |
-| service.additionalServices[1].port.protocol         | string | `"UDP"`                 |             |
-| service.additionalServices[1].port.targetPort       | int    | `21027`                 |             |
-| service.additionalServices[1].type                  | string | `"NodePort"`            |             |
-| service.port.port                                   | int    | `8384`                  |             |
-| strategy.type                                       | string | `"Recreate"`            |             |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"syncthing/syncthing"` |  |
+| image.tag | string | `"1.16.1"` |  |
+| ingress.enabled | bool | `false` |  |
+| persistence.data.emptyDir.enabled | bool | `false` |  |
+| persistence.data.enabled | bool | `false` |  |
+| persistence.data.mountPath | string | `"/var/syncthing"` |  |
+| service.additionalServices[0].enabled | bool | `true` |  |
+| service.additionalServices[0].externalTrafficPolicy | string | `"Local"` |  |
+| service.additionalServices[0].nameSuffix | string | `"listen"` |  |
+| service.additionalServices[0].port.name | string | `"listen"` |  |
+| service.additionalServices[0].port.port | int | `22000` |  |
+| service.additionalServices[0].port.protocol | string | `"TCP"` |  |
+| service.additionalServices[0].port.targetPort | int | `22000` |  |
+| service.additionalServices[0].type | string | `"NodePort"` |  |
+| service.additionalServices[1].enabled | bool | `true` |  |
+| service.additionalServices[1].externalTrafficPolicy | string | `"Local"` |  |
+| service.additionalServices[1].nameSuffix | string | `"discovery"` |  |
+| service.additionalServices[1].port.name | string | `"discovery"` |  |
+| service.additionalServices[1].port.port | int | `21027` |  |
+| service.additionalServices[1].port.protocol | string | `"UDP"` |  |
+| service.additionalServices[1].port.targetPort | int | `21027` |  |
+| service.additionalServices[1].type | string | `"NodePort"` |  |
+| service.port.port | int | `8384` |  |
+| strategy.type | string | `"Recreate"` |  |
 
 ## Changelog
 
@@ -162,6 +162,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Ask a [question](https://github.com/k8s-at-home/organization/discussions)
 - Join our [Discord](https://discord.gg/sTMX7Vh) community
 
----
-
+----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/stable/syncthing/README.md
+++ b/charts/stable/syncthing/README.md
@@ -8,8 +8,8 @@ Open Source Continuous File Synchronization
 
 ## Source Code
 
-* <https://syncthing.net/>
-* <https://github.com/syncthing/syncthing>
+- <https://syncthing.net/>
+- <https://github.com/syncthing/syncthing>
 
 ## Requirements
 
@@ -17,9 +17,9 @@ Kubernetes: `>=1.16.0-0`
 
 ## Dependencies
 
-| Repository | Name | Version |
-|------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.5.0 |
+| Repository                             | Name   | Version |
+| -------------------------------------- | ------ | ------- |
+| https://library-charts.k8s-at-home.com | common | 2.5.0   |
 
 ## TL;DR
 
@@ -74,33 +74,33 @@ N/A
 
 **Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"syncthing/syncthing"` |  |
-| image.tag | string | `"1.16.1"` |  |
-| ingress.enabled | bool | `false` |  |
-| persistence.data.emptyDir.enabled | bool | `false` |  |
-| persistence.data.enabled | bool | `false` |  |
-| persistence.data.mountPath | string | `"/var/syncthing"` |  |
-| service.additionalServices[0].enabled | bool | `true` |  |
-| service.additionalServices[0].externalTrafficPolicy | string | `"Local"` |  |
-| service.additionalServices[0].nameSuffix | string | `"listen"` |  |
-| service.additionalServices[0].port.name | string | `"listen"` |  |
-| service.additionalServices[0].port.port | int | `22000` |  |
-| service.additionalServices[0].port.protocol | string | `"TCP"` |  |
-| service.additionalServices[0].port.targetPort | int | `22000` |  |
-| service.additionalServices[0].type | string | `"NodePort"` |  |
-| service.additionalServices[1].enabled | bool | `true` |  |
-| service.additionalServices[1].externalTrafficPolicy | string | `"Local"` |  |
-| service.additionalServices[1].nameSuffix | string | `"discovery"` |  |
-| service.additionalServices[1].port.name | string | `"discovery"` |  |
-| service.additionalServices[1].port.port | int | `21027` |  |
-| service.additionalServices[1].port.protocol | string | `"UDP"` |  |
-| service.additionalServices[1].port.targetPort | int | `21027` |  |
-| service.additionalServices[1].type | string | `"NodePort"` |  |
-| service.port.port | int | `8384` |  |
-| strategy.type | string | `"Recreate"` |  |
+| Key                                                 | Type   | Default                 | Description |
+| --------------------------------------------------- | ------ | ----------------------- | ----------- |
+| image.pullPolicy                                    | string | `"IfNotPresent"`        |             |
+| image.repository                                    | string | `"syncthing/syncthing"` |             |
+| image.tag                                           | string | `"1.16.1"`              |             |
+| ingress.enabled                                     | bool   | `false`                 |             |
+| persistence.data.emptyDir.enabled                   | bool   | `false`                 |             |
+| persistence.data.enabled                            | bool   | `false`                 |             |
+| persistence.data.mountPath                          | string | `"/var/syncthing"`      |             |
+| service.additionalServices[0].enabled               | bool   | `true`                  |             |
+| service.additionalServices[0].externalTrafficPolicy | string | `"Local"`               |             |
+| service.additionalServices[0].nameSuffix            | string | `"listen"`              |             |
+| service.additionalServices[0].port.name             | string | `"listen"`              |             |
+| service.additionalServices[0].port.port             | int    | `22000`                 |             |
+| service.additionalServices[0].port.protocol         | string | `"TCP"`                 |             |
+| service.additionalServices[0].port.targetPort       | int    | `22000`                 |             |
+| service.additionalServices[0].type                  | string | `"NodePort"`            |             |
+| service.additionalServices[1].enabled               | bool   | `true`                  |             |
+| service.additionalServices[1].externalTrafficPolicy | string | `"Local"`               |             |
+| service.additionalServices[1].nameSuffix            | string | `"discovery"`           |             |
+| service.additionalServices[1].port.name             | string | `"discovery"`           |             |
+| service.additionalServices[1].port.port             | int    | `21027`                 |             |
+| service.additionalServices[1].port.protocol         | string | `"UDP"`                 |             |
+| service.additionalServices[1].port.targetPort       | int    | `21027`                 |             |
+| service.additionalServices[1].type                  | string | `"NodePort"`            |             |
+| service.port.port                                   | int    | `8384`                  |             |
+| strategy.type                                       | string | `"Recreate"`            |             |
 
 ## Changelog
 
@@ -161,5 +161,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Ask a [question](https://github.com/k8s-at-home/organization/discussions)
 - Join our [Discord](https://discord.gg/sTMX7Vh) community
 
-----------------------------------------------
+---
+
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/stable/syncthing/README.md.gotmpl
+++ b/charts/stable/syncthing/README.md.gotmpl
@@ -143,3 +143,4 @@ helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }} -
 {{ template "custom.support" . }}
 
 {{ template "helm-docs.versionFooter" . }}
+{{ "" }}

--- a/charts/stable/syncthing/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/syncthing/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,21 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.3.0]
+
+#### Added
+
+- N/A
+
+#### Changed
+
+- Updated syncthing container image version to `v1.16.1`.
+- Updated common chart dependency to `2.5.0`.
+
+#### Removed
+
+- N/A
+
 ### [1.1.2]
 
 #### Added
@@ -37,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[1.3.0]: #1.3.0
 [1.1.2]: #1.1.2
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/syncthing/values.yaml
+++ b/charts/stable/syncthing/values.yaml
@@ -8,7 +8,7 @@
 image:
   repository: syncthing/syncthing
   pullPolicy: IfNotPresent
-  tag: 1.15.1
+  tag: 1.16.1
 
 strategy:
   type: Recreate

--- a/charts/stable/syncthing/values.yaml
+++ b/charts/stable/syncthing/values.yaml
@@ -36,7 +36,6 @@ service:
       targetPort: 21027
     externalTrafficPolicy: Local
 
-
 ingress:
   enabled: false
 


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This PR bumps the Syncthing container version to `1.16.1` and common chart dependency to `2.5.0`. 

**Benefits**

Updating to the most recent release of the container.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
