### PR TITLE
[pod-gateway-setter] add pod-gateway-setter

### DIFF
--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -14,6 +14,7 @@ excluded-charts:
 - charts/stable/zalando-postgres-cluster
 - charts/stable/zigbee2mqtt
 - charts/stable/founderyvtt
+- charts/stable/pod-gateway-setter
 chart-repos:
 - bitnami=https://charts.bitnami.com/bitnami
 - k8s-at-home-libraries=https://library-charts.k8s-at-home.com

--- a/charts/stable/pod-gateway-setter/.helmignore
+++ b/charts/stable/pod-gateway-setter/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS file for Kubernetes
+OWNERS
+# helm-docs templates
+*.gotmpl

--- a/charts/stable/pod-gateway-setter/Chart.yaml
+++ b/charts/stable/pod-gateway-setter/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+appVersion: 1.0.0
+description: Admision controller to change the default gateway and DNS server of PODs
+name: pod-gateway-setter
+version: 1.0.0
+kubeVersion: ">=1.16.0-0"
+keywords:
+- pod-gateway-setter
+home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/pod-gateway-setter
+icon: https://pod-gateway-setter.org/icon
+sources:
+- https://github.com/pod-gateway-setter/pod-gateway-setter-docker
+maintainers:
+- name: angelnu
+  email: git@angelnu.com
+dependencies:
+- name: common
+  repository: https://library-charts.k8s-at-home.com
+  version: 2.5.0

--- a/charts/stable/pod-gateway-setter/README.md
+++ b/charts/stable/pod-gateway-setter/README.md
@@ -125,7 +125,7 @@ certificates.
 | probes.readiness.spec.initialDelaySeconds | int | `1` |  |
 | probes.readiness.spec.timeoutSeconds | int | `10` |  |
 | probes.startup.custom | bool | `true` |  |
-| probes.startup.enabled | bool | `false` |  |
+| probes.startup.enabled | bool | `true` |  |
 | probes.startup.spec.failureThreshold | int | `30` |  |
 | probes.startup.spec.httpGet.path | string | `"/wh/health"` |  |
 | probes.startup.spec.httpGet.port | int | `8080` |  |

--- a/charts/stable/pod-gateway-setter/README.md
+++ b/charts/stable/pod-gateway-setter/README.md
@@ -69,15 +69,24 @@ helm install pod-gateway-setter k8s-at-home/pod-gateway-setter -f values.yaml
 
 You need to set `gateway` to the hostname or address of your gateway. Then
 all PODs in namespaces with the matching label (`routed-gateway=true` by default)
-will be routed to this gateway. DNS server in the PODs will also be set to
-the gateway.
+will be processed by the webhook.
 
-Please notice that other labels might be configured. This is usuefull, for
-example, to install multiple copies of the chart, each routing a different
-namespace to a different gateway.
+The webhook by default changes all processed pods (remove `--setGatewayDefault`
+if you want to change the default). You can also change the default for a
+POD by adding a label or annotation (`setGateway` by default).
 
-**IMPORTAN**: Do not deploy this chart to a namespace controlled by this
+Processed PODs will get their default gateway changed. DNS server will
+also be set to the gateway (at least the option `--keepDNS` is used).
+
+Multiple instances of this chart might be installed that use different label
+values. This is usufull, for example, to route multiple pod groups, each with
+a different gateway.
+
+**IMPORTANT**: Do not deploy this chart to a namespace controlled by this
 webhook. This would result in a likelly deathlock when upgrading the chart.
+
+**NOTE**: This char requires the cert-manager CRD to generate the required
+certificates.
 
 ## Values
 
@@ -90,10 +99,13 @@ webhook. This would result in a likelly deathlock when upgrading the chart.
 | additionalVolumeMounts[0].readOnly | bool | `true` |  |
 | args[0] | string | `"--tls-cert-file-path=/tls/tls.crt"` |  |
 | args[1] | string | `"--tls-key-file-path=/tls/tls.key"` |  |
+| args[2] | string | `"--setGatewayDefault"` |  |
+| args[3] | string | `"--setGatewayLabel=setGateway"` |  |
+| args[4] | string | `"--setGatewayAnnotation=setGateway"` |  |
 | gateway | string | `"10.0.2.7"` | Gateway to route traffic to. Can be an hostname or an IP |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/k8s-at-home/gateway-admision-controller"` |  |
-| image.tag | string | `"dev"` |  |
+| image.tag | string | `"v2.0.0"` |  |
 | ingress.enabled | bool | `false` |  |
 | namespaceSelector | object | `{"matchLabels":{"routed-gateway":"true"}}` | Selector for namespace. All pods in this namespace will get their default gateway changed |
 | probes.liveness.custom | bool | `true` |  |

--- a/charts/stable/pod-gateway-setter/README.md
+++ b/charts/stable/pod-gateway-setter/README.md
@@ -1,0 +1,156 @@
+# pod-gateway-setter
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+
+Admision controller to change the default gateway and DNS server of PODs
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
+## Source Code
+
+* <https://github.com/pod-gateway-setter/pod-gateway-setter-docker>
+
+## Requirements
+
+Kubernetes: `>=1.16.0-0`
+
+## Dependencies
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://library-charts.k8s-at-home.com | common | 2.5.0 |
+
+## TL;DR
+
+```console
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm repo update
+helm install pod-gateway-setter k8s-at-home/pod-gateway-setter
+```
+
+## Installing the Chart
+
+To install the chart with the release name `pod-gateway-setter`
+
+```console
+helm install pod-gateway-setter k8s-at-home/pod-gateway-setter
+```
+
+## Uninstalling the Chart
+
+To uninstall the `pod-gateway-setter` deployment
+
+```console
+helm uninstall pod-gateway-setter
+```
+
+The command removes all the Kubernetes components associated with the chart **including persistent volumes** and deletes the release.
+
+## Configuration
+
+Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
+Other values may be used from the [values.yaml](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml) from the [common library](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common).
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```console
+helm install pod-gateway-setter \
+  --set env.TZ="America/New York" \
+    k8s-at-home/pod-gateway-setter
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart.
+
+```console
+helm install pod-gateway-setter k8s-at-home/pod-gateway-setter -f values.yaml
+```
+
+## Custom configuration
+
+You need to set `gateway` to the hostname or address of your gateway. Then
+all PODs in namespaces with the matching label (`routed-gateway=true` by default)
+will be routed to this gateway. DNS server in the PODs will also be set to
+the gateway.
+
+Please notice that other labels might be configured. This is usuefull, for
+example, to install multiple copies of the chart, each routing a different
+namespace to a different gateway.
+
+**IMPORTAN**: Do not deploy this chart to a namespace controlled by this
+webhook. This would result in a likelly deathlock when upgrading the chart.
+
+## Values
+
+**Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| additionalVolumeMounts[0].mountPath | string | `"/tls"` |  |
+| additionalVolumeMounts[0].name | string | `"certs"` |  |
+| additionalVolumeMounts[0].readOnly | bool | `true` |  |
+| args[0] | string | `"--tls-cert-file-path=/tls/tls.crt"` |  |
+| args[1] | string | `"--tls-key-file-path=/tls/tls.key"` |  |
+| gateway | string | `"10.0.2.7"` | Gateway to route traffic to. Can be an hostname or an IP |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"ghcr.io/k8s-at-home/gateway-admision-controller"` |  |
+| image.tag | string | `"dev"` |  |
+| ingress.enabled | bool | `false` |  |
+| namespaceSelector | object | `{"matchLabels":{"routed-gateway":"true"}}` | Selector for namespace. All pods in this namespace will get their default gateway changed |
+| probes.liveness.custom | bool | `true` |  |
+| probes.liveness.enabled | bool | `true` |  |
+| probes.liveness.spec.failureThreshold | int | `5` |  |
+| probes.liveness.spec.httpGet.path | string | `"/wh/health"` |  |
+| probes.liveness.spec.httpGet.port | int | `8080` |  |
+| probes.liveness.spec.httpGet.scheme | string | `"HTTPS"` |  |
+| probes.liveness.spec.initialDelaySeconds | int | `1` |  |
+| probes.liveness.spec.timeoutSeconds | int | `10` |  |
+| probes.readiness.custom | bool | `true` |  |
+| probes.readiness.enabled | bool | `true` |  |
+| probes.readiness.spec.failureThreshold | int | `5` |  |
+| probes.readiness.spec.httpGet.path | string | `"/wh/health"` |  |
+| probes.readiness.spec.httpGet.port | int | `8080` |  |
+| probes.readiness.spec.httpGet.scheme | string | `"HTTPS"` |  |
+| probes.readiness.spec.initialDelaySeconds | int | `1` |  |
+| probes.readiness.spec.timeoutSeconds | int | `10` |  |
+| probes.startup.custom | bool | `true` |  |
+| probes.startup.enabled | bool | `false` |  |
+| probes.startup.spec.failureThreshold | int | `30` |  |
+| probes.startup.spec.httpGet.path | string | `"/wh/health"` |  |
+| probes.startup.spec.httpGet.port | int | `8080` |  |
+| probes.startup.spec.httpGet.scheme | string | `"HTTPS"` |  |
+| probes.startup.spec.periodSeconds | int | `1` |  |
+| service.port.path | string | `"/wh/mutating/setgateway"` |  |
+| service.port.port | int | `8080` |  |
+| strategy.type | string | `"RollingUpdate"` |  |
+
+## Changelog
+
+All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [1.0.0]
+
+#### Added
+
+- Initial version
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
+
+[1.0.0]: #1.0.0
+
+## Support
+
+- See the [Docs](https://docs.k8s-at-home.com/our-helm-charts/getting-started/)
+- Open an [issue](https://github.com/k8s-at-home/charts/issues/new/choose)
+- Ask a [question](https://github.com/k8s-at-home/organization/discussions)
+- Join our [Discord](https://discord.gg/sTMX7Vh) community
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/stable/pod-gateway-setter/README.md.gotmpl
+++ b/charts/stable/pod-gateway-setter/README.md.gotmpl
@@ -1,0 +1,146 @@
+{{- define "custom.repository.organization" -}}
+k8s-at-home
+{{- end -}}
+
+{{- define "custom.repository.url" -}}
+https://github.com/k8s-at-home/charts
+{{- end -}}
+
+{{- define "custom.helm.url" -}}
+https://k8s-at-home.com/charts/
+{{- end -}}
+
+{{- define "custom.helm.path" -}}
+{{ template "custom.repository.organization" . }}/{{ template "chart.name" . }}
+{{- end -}}
+
+{{- define "custom.notes" -}}
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+{{- end -}}
+
+{{- define "custom.requirements" -}}
+## Requirements
+
+{{ template "chart.kubeVersionLine" . }}
+{{- end -}}
+
+{{- define "custom.dependencies" -}}
+## Dependencies
+
+{{ template "chart.requirementsTable" . }}
+{{- end -}}
+
+{{- define "custom.install.tldr" -}}
+## TL;DR
+
+```console
+helm repo add {{ template "custom.repository.organization" . }} {{ template "custom.helm.url" . }}
+helm repo update
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.install" -}}
+## Installing the Chart
+
+To install the chart with the release name `{{ template "chart.name" . }}`
+
+```console
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.uninstall" -}}
+## Uninstalling the Chart
+
+To uninstall the `{{ template "chart.name" . }}` deployment
+
+```console
+helm uninstall {{ template "chart.name" . }}
+```
+
+The command removes all the Kubernetes components associated with the chart **including persistent volumes** and deletes the release.
+{{- end -}}
+
+{{- define "custom.configuration.header" -}}
+## Configuration
+{{- end -}}
+
+{{- define "custom.configuration.readValues" -}}
+Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
+Other values may be used from the [values.yaml](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml) from the [common library](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common).
+{{- end -}}
+
+{{- define "custom.configuration.example.set" -}}
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```console
+helm install {{ template "chart.name" . }} \
+  --set env.TZ="America/New York" \
+    {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.configuration.example.file" -}}
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart.
+
+```console
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }} -f values.yaml
+```
+{{- end -}}
+
+{{- define "custom.valuesSection" -}}
+## Values
+
+**Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
+
+{{ template "chart.valuesTable" . }}
+{{- end -}}
+
+{{- define "custom.support" -}}
+## Support
+
+- See the [Docs](https://docs.k8s-at-home.com/our-helm-charts/getting-started/)
+- Open an [issue](https://github.com/k8s-at-home/charts/issues/new/choose)
+- Ask a [question](https://github.com/k8s-at-home/organization/discussions)
+- Join our [Discord](https://discord.gg/sTMX7Vh) community
+{{- end -}}
+
+{{ template "chart.header" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "custom.notes" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "custom.requirements" . }}
+
+{{ template "custom.dependencies" . }}
+
+{{ template "custom.install.tldr" . }}
+
+{{ template "custom.install" . }}
+
+{{ template "custom.uninstall" . }}
+
+{{ template "custom.configuration.header" . }}
+
+{{ template "custom.configuration.readValues" . }}
+
+{{ template "custom.configuration.example.set" . }}
+
+{{ template "custom.configuration.example.file" . }}
+
+{{ template "custom.custom.configuration" . }}
+
+{{ template "custom.valuesSection" . }}
+
+{{ template "custom.changelog" . }}
+
+{{ template "custom.support" . }}
+
+{{ template "helm-docs.versionFooter" . }}
+{{ "" }}

--- a/charts/stable/pod-gateway-setter/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/pod-gateway-setter/README_CHANGELOG.md.gotmpl
@@ -1,0 +1,27 @@
+{{- define "custom.changelog.header" -}}
+## Changelog
+{{- end -}}
+
+{{- define "custom.changelog" -}}
+{{ template "custom.changelog.header" . }}
+
+All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [1.0.0]
+
+#### Added
+
+- Initial version
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
+
+[1.0.0]: #1.0.0
+{{- end -}}

--- a/charts/stable/pod-gateway-setter/README_CONFIG.md.gotmpl
+++ b/charts/stable/pod-gateway-setter/README_CONFIG.md.gotmpl
@@ -7,14 +7,20 @@
 
 You need to set `gateway` to the hostname or address of your gateway. Then
 all PODs in namespaces with the matching label (`routed-gateway=true` by default)
-will be routed to this gateway. DNS server in the PODs will also be set to
-the gateway.
+will be processed by the webhook.
 
-Please notice that other labels might be configured. This is usuefull, for
-example, to install multiple copies of the chart, each routing a different
-namespace to a different gateway.
+The webhook by default changes all processed pods (remove `--setGatewayDefault`
+if you want to change the default). You can also change the default for a
+POD by adding a label or annotation (`setGateway` by default).
 
-**IMPORTAN**: Do not deploy this chart to a namespace controlled by this
+Processed PODs will get their default gateway changed. DNS server will
+also be set to the gateway (at least the option `--keepDNS` is used).
+
+Multiple instances of this chart might be installed that use different label
+values. This is usufull, for example, to route multiple pod groups, each with
+a different gateway.
+
+**IMPORTANT**: Do not deploy this chart to a namespace controlled by this
 webhook. This would result in a likelly deathlock when upgrading the chart.
 
 **NOTE**: This char requires the cert-manager CRD to generate the required

--- a/charts/stable/pod-gateway-setter/README_CONFIG.md.gotmpl
+++ b/charts/stable/pod-gateway-setter/README_CONFIG.md.gotmpl
@@ -1,0 +1,23 @@
+{{- define "custom.custom.configuration.header" -}}
+## Custom configuration
+{{- end -}}
+
+{{- define "custom.custom.configuration" -}}
+{{ template "custom.custom.configuration.header" . }}
+
+You need to set `gateway` to the hostname or address of your gateway. Then
+all PODs in namespaces with the matching label (`routed-gateway=true` by default)
+will be routed to this gateway. DNS server in the PODs will also be set to
+the gateway.
+
+Please notice that other labels might be configured. This is usuefull, for
+example, to install multiple copies of the chart, each routing a different
+namespace to a different gateway.
+
+**IMPORTAN**: Do not deploy this chart to a namespace controlled by this
+webhook. This would result in a likelly deathlock when upgrading the chart.
+
+**NOTE**: This char requires the cert-manager CRD to generate the required
+certificates.
+
+{{- end -}}

--- a/charts/stable/pod-gateway-setter/templates/NOTES.txt
+++ b/charts/stable/pod-gateway-setter/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/stable/pod-gateway-setter/templates/admissionregistration.yaml
+++ b/charts/stable/pod-gateway-setter/templates/admissionregistration.yaml
@@ -1,0 +1,29 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "common.names.fullname" . | quote }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "pod-gateway-setter.servingCertificate" . }}"
+webhooks:
+- name: "pod-policy.example.com"
+  namespaceSelector:
+  {{- with .Values.namespaceSelector }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  - apiGroups:   [""]
+    apiVersions: ["v1"]
+    operations:  ["CREATE"]
+    resources:   ["pods"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace | quote }}
+      name: {{ include "common.names.fullname" . | quote }}
+      path: {{ .Values.service.port.path | quote }}
+      port: {{ .Values.service.port.port }}
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5

--- a/charts/stable/pod-gateway-setter/templates/admissionregistration.yaml
+++ b/charts/stable/pod-gateway-setter/templates/admissionregistration.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "pod-gateway-setter.servingCertificate" . }}"
 webhooks:
-- name: "pod-policy.example.com"
+- name: "{{ include "common.names.fullname" . }}.svc.cluster.local"
   namespaceSelector:
   {{- with .Values.namespaceSelector }}
     {{ toYaml . | nindent 4 }}

--- a/charts/stable/pod-gateway-setter/templates/common.yaml
+++ b/charts/stable/pod-gateway-setter/templates/common.yaml
@@ -1,0 +1,40 @@
+{{/* Make sure all variables are set properly */}}
+{{- include "common.values.setup" . }}
+
+{{- define "pod-gateway-setter.selfSignedIssuer" -}}
+{{ printf "%s-selfsign" (include "common.names.fullname" .) }}
+{{- end -}}
+
+{{- define "pod-gateway-setter.rootCAIssuer" -}}
+{{ printf "%s-ca" (include "common.names.fullname" .) }}
+{{- end -}}
+
+{{- define "pod-gateway-setter.rootCACertificate" -}}
+{{ printf "%s-ca" (include "common.names.fullname" .) }}
+{{- end -}}
+
+{{- define "pod-gateway-setter.servingCertificate" -}}
+{{ printf "%s-webhook-tls" (include "common.names.fullname" .) }}
+{{- end -}}
+
+
+{{/* Append the cert secret to the additionalVolumes */}}
+{{- define "pod-gateway-setter.servingCertificate.volume" -}}
+name: certs
+secret:
+  secretName: {{ include "pod-gateway-setter.servingCertificate" . }}
+{{- end -}}
+
+{{- $volume := include "pod-gateway-setter.servingCertificate.volume" . | fromYaml -}}
+{{- if $volume -}}
+  {{- $additionalVolumes := append .Values.additionalVolumes $volume }}
+  {{- $_ := set .Values "additionalVolumes" (deepCopy $additionalVolumes) -}}
+{{- end -}}
+
+
+{{/* Append generated args */}}
+{{- $noop := printf "--webhook-listen-address=:%s" (.Values.service.port.port |toString) | append .Values.args | set .Values "args" -}}
+{{- $noop := printf "--gateway=%s"                  .Values.gateway                      | append .Values.args | set .Values "args" -}}
+
+{{/* Render the templates */}}
+{{ include "common.all" . }}

--- a/charts/stable/pod-gateway-setter/templates/pki.yaml
+++ b/charts/stable/pod-gateway-setter/templates/pki.yaml
@@ -1,0 +1,66 @@
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "pod-gateway-setter.selfSignedIssuer" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+
+---
+
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "pod-gateway-setter.rootCACertificate" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "pod-gateway-setter.rootCACertificate" . }}
+  duration: 43800h # 5y
+  issuerRef:
+    name: {{ include "pod-gateway-setter.selfSignedIssuer" . }}
+    kind: Issuer
+  commonName: "ca.pod-gateway-setter.cert-manager"
+  isCA: true
+
+---
+
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "pod-gateway-setter.rootCAIssuer" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "pod-gateway-setter.rootCACertificate" . }}
+
+---
+
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "pod-gateway-setter.servingCertificate" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "pod-gateway-setter.servingCertificate" . }}
+  duration: 8760h # 1y
+  issuerRef:
+    name: {{ include "pod-gateway-setter.rootCAIssuer" . }}
+    kind: Issuer
+  dnsNames:
+  - {{ include "common.names.fullname" . }}
+  - {{ include "common.names.fullname" . }}.{{ .Release.Namespace }}
+  - {{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.svc

--- a/charts/stable/pod-gateway-setter/values.yaml
+++ b/charts/stable/pod-gateway-setter/values.yaml
@@ -1,0 +1,91 @@
+#
+# IMPORTANT NOTE
+#
+# This chart inherits from our common library chart. You can check the default values/options here:
+# https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml
+#
+
+image:
+  repository: ghcr.io/k8s-at-home/gateway-admision-controller
+  pullPolicy: IfNotPresent
+  tag: dev
+
+# -- Gateway to route traffic to.
+# Can be an hostname or an IP
+gateway: 10.0.2.7
+
+# -- Selector for namespace.
+# All pods in this namespace will get their default gateway changed
+namespaceSelector:
+  matchLabels:
+    routed-gateway: "true"
+  # matchExpressions:
+  # - key: notTouch
+  #   operator: NotIn
+  #   values: ["1"]
+
+strategy:
+  type: RollingUpdate
+
+# Args for webhook
+# See more information in the container git repository at
+# https://github.com/k8s-at-home/gateway-admision-controller
+args:
+- --tls-cert-file-path=/tls/tls.crt
+- --tls-key-file-path=/tls/tls.key
+# - --debug
+# - --development
+# - --keepDNS
+# - --keepGatewayLabel=keepGAteway
+# - --keepGatewayAnnotation=keepGateway
+# Set by Helm chart:
+# --webhook-listen-address=:<set to service port>
+# --gateway=<set automatically to 'gateway'>
+
+service:
+  port:
+    path: /wh/mutating/setgateway
+    port: 8080
+
+ingress:
+  enabled: false
+
+additionalVolumeMounts:
+- name: certs
+  mountPath: /tls
+  readOnly: true
+
+# Probes configuration
+probes:
+  liveness:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        scheme: HTTPS
+        port: 8080
+        path: /wh/health
+      initialDelaySeconds: 1
+      failureThreshold: 5
+      timeoutSeconds: 10
+  readiness:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        scheme: HTTPS
+        port: 8080
+        path: /wh/health
+      initialDelaySeconds: 1
+      failureThreshold: 5
+      timeoutSeconds: 10
+  startup:
+    enabled: false
+    custom: true
+    spec:
+      httpGet:
+        scheme: HTTPS
+        port: 8080
+        path: /wh/health
+      failureThreshold: 30
+      periodSeconds: 1

--- a/charts/stable/pod-gateway-setter/values.yaml
+++ b/charts/stable/pod-gateway-setter/values.yaml
@@ -81,7 +81,7 @@ probes:
       failureThreshold: 5
       timeoutSeconds: 10
   startup:
-    enabled: false
+    enabled: true
     custom: true
     spec:
       httpGet:

--- a/charts/stable/pod-gateway-setter/values.yaml
+++ b/charts/stable/pod-gateway-setter/values.yaml
@@ -8,7 +8,7 @@
 image:
   repository: ghcr.io/k8s-at-home/gateway-admision-controller
   pullPolicy: IfNotPresent
-  tag: dev
+  tag: v2.0.0
 
 # -- Gateway to route traffic to.
 # Can be an hostname or an IP
@@ -33,11 +33,12 @@ strategy:
 args:
 - --tls-cert-file-path=/tls/tls.crt
 - --tls-key-file-path=/tls/tls.key
+- --setGatewayDefault
+- --setGatewayLabel=setGateway
+- --setGatewayAnnotation=setGateway
 # - --debug
 # - --development
 # - --keepDNS
-# - --keepGatewayLabel=keepGAteway
-# - --keepGatewayAnnotation=keepGateway
 # Set by Helm chart:
 # --webhook-listen-address=:<set to service port>
 # --gateway=<set automatically to 'gateway'>


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
This chart installs a mutator webhook admission controller in order to change
the default gateway and DNS of selected pods. Pods are selected by
labeling their namespace as described in the README.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Allow routing egress traffic of pods through a different gateway, such
as a VPN forwarder, traffic shapper, etc.

VPN forwarder will be provided as separated chart.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
Another chart - more maintenance.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes NA

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
