### PR TITLE
[unifi] Version bump to 6.2.25

### DIFF
--- a/charts/stable/unifi/Chart.yaml
+++ b/charts/stable/unifi/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 6.0.45
+appVersion: 6.2.25
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 2.0.3
+version: 2.0.4
 keywords:
   - ubiquiti
   - unifi

--- a/charts/stable/unifi/README.md
+++ b/charts/stable/unifi/README.md
@@ -1,6 +1,6 @@
 # unifi
 
-![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![AppVersion: 6.0.45](https://img.shields.io/badge/AppVersion-6.0.45-informational?style=flat-square)
+![Version: 2.0.4](https://img.shields.io/badge/Version-2.0.4-informational?style=flat-square) ![AppVersion: 6.2.25](https://img.shields.io/badge/AppVersion-6.2.25-informational?style=flat-square)
 
 Ubiquiti Network's Unifi Controller
 
@@ -152,7 +152,7 @@ ingress:
 | guiService.type | string | `"ClusterIP"` | Kubernetes service type |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"jacobalberty/unifi"` |  |
-| image.tag | string | `"5.14.23"` |  |
+| image.tag | string | `"6.2.25"` |  |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":["chart-example.local"],"path":"/","tls":[]}` | Ingress settings |
 | jvmInitHeapSize | string | `nil` | Java Virtual Machine (JVM) initial, and minimum, heap size Unset value means there is no lower limit |
 | jvmMaxHeapSize | string | `"1024M"` | Java Virtual Machine (JVM) maximum heap size For larger installations a larger value is recommended. For memory constrained system this value can be lowered. |

--- a/charts/stable/unifi/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/unifi/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,20 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.0.4]
+
+#### Added
+
+- N/A
+
+#### Changed
+
+- Bump controller version to 6.2.25
+
+#### Removed
+
+- N/A
+
 ### [2.0.2]
 
 #### Fixed

--- a/charts/stable/unifi/values.yaml
+++ b/charts/stable/unifi/values.yaml
@@ -7,7 +7,7 @@ strategyType: Recreate
 
 image:
   repository: jacobalberty/unifi
-  tag: 5.14.23
+  tag: 6.2.25
   pullPolicy: IfNotPresent
 
 # If enabled, the controller, discovery, GUI, STUN and syslog services will not be


### PR DESCRIPTION
Consistently change the application version everywhere. Before this
change, the chart was reporting an `appVersion` that was not
reflecting the default tag used to deploy the application.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

This is my first contribution to the project. Please, let me know if I should do something else :)
