### PR TITLE
[syncthing] feat: bump syncthing version and add maintainer

### DIFF
--- a/charts/stable/syncthing/Chart.yaml
+++ b/charts/stable/syncthing/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.16.1
+appVersion: 1.17.0
 description: Open Source Continuous File Synchronization
 name: syncthing
-version: 1.3.0
+version: 1.4.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - syncthing
@@ -15,6 +15,7 @@ sources:
 maintainers:
 - name: FlipEnergy
   email: dennis.zhang.nrg@gmail.com
+- name: claughinghouse
 dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com

--- a/charts/stable/syncthing/Chart.yaml
+++ b/charts/stable/syncthing/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.17.0
 description: Open Source Continuous File Synchronization
 name: syncthing
-version: 1.4.0
+version: 1.3.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - syncthing

--- a/charts/stable/syncthing/README.md
+++ b/charts/stable/syncthing/README.md
@@ -1,6 +1,6 @@
 # syncthing
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: 1.16.1](https://img.shields.io/badge/AppVersion-1.16.1-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
 
 Open Source Continuous File Synchronization
 
@@ -78,7 +78,7 @@ N/A
 |-----|------|---------|-------------|
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"syncthing/syncthing"` |  |
-| image.tag | string | `"1.16.1"` |  |
+| image.tag | string | `"1.17.0"` |  |
 | ingress.enabled | bool | `false` |  |
 | persistence.data.emptyDir.enabled | bool | `false` |  |
 | persistence.data.enabled | bool | `false` |  |
@@ -107,6 +107,20 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [1.4.0]
+
+#### Added
+
+- N/A
+
+#### Changed
+
+- Updated syncthing container image version to `v1.17.0`.
+
+#### Removed
+
+- N/A
 
 ### [1.3.0]
 
@@ -151,6 +165,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[1.4.0]: #1.4.0
 [1.3.0]: #1.3.0
 [1.1.2]: #1.1.2
 [1.0.0]: #1.0.0

--- a/charts/stable/syncthing/README.md
+++ b/charts/stable/syncthing/README.md
@@ -1,6 +1,6 @@
 # syncthing
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![AppVersion: 1.17.0](https://img.shields.io/badge/AppVersion-1.17.0-informational?style=flat-square)
 
 Open Source Continuous File Synchronization
 
@@ -108,7 +108,7 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [1.4.0]
+### [1.3.1]
 
 #### Added
 
@@ -165,7 +165,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
-[1.4.0]: #1.4.0
+[1.3.1]: #1.3.1
 [1.3.0]: #1.3.0
 [1.1.2]: #1.1.2
 [1.0.0]: #1.0.0

--- a/charts/stable/syncthing/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/syncthing/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,20 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.4.0]
+
+#### Added
+
+- N/A
+
+#### Changed
+
+- Updated syncthing container image version to `v1.17.0`.
+
+#### Removed
+
+- N/A
+
 ### [1.3.0]
 
 #### Added
@@ -52,6 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[1.4.0]: #1.4.0
 [1.3.0]: #1.3.0
 [1.1.2]: #1.1.2
 [1.0.0]: #1.0.0

--- a/charts/stable/syncthing/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/syncthing/README_CHANGELOG.md.gotmpl
@@ -9,7 +9,7 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [1.4.0]
+### [1.3.1]
 
 #### Added
 
@@ -66,7 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
-[1.4.0]: #1.4.0
+[1.3.1]: #1.3.1
 [1.3.0]: #1.3.0
 [1.1.2]: #1.1.2
 [1.0.0]: #1.0.0

--- a/charts/stable/syncthing/values.yaml
+++ b/charts/stable/syncthing/values.yaml
@@ -8,7 +8,7 @@
 image:
   repository: syncthing/syncthing
   pullPolicy: IfNotPresent
-  tag: 1.16.1
+  tag: 1.17.0
 
 strategy:
   type: Recreate


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Bump syncthing to `v1.17.0`

**Benefits**

Update to current release version. 

**Possible drawbacks**

None. 

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
