### PR TITLE
[thelounge] Updated thelounge to 4.3.0 and up dep commons to 3.0.0

### DIFF
--- a/charts/stable/thelounge/Chart.yaml
+++ b/charts/stable/thelounge/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "4.2.0"
+appVersion: "4.3.0"
 description: The Lounge, modern web IRC client designed for self-hosting
 name: thelounge
-version: 1.2.0
+version: 2.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - thelounge
@@ -20,4 +20,4 @@ maintainers:
 dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com
-  version: 2.5.0
+  version: 3.0.0

--- a/charts/stable/thelounge/README.md
+++ b/charts/stable/thelounge/README.md
@@ -1,6 +1,6 @@
 # thelounge
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 4.2.0](https://img.shields.io/badge/AppVersion-4.2.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: 4.3.0](https://img.shields.io/badge/AppVersion-4.3.0-informational?style=flat-square)
 
 The Lounge, modern web IRC client designed for self-hosting
 
@@ -18,7 +18,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.5.0 |
+| https://library-charts.k8s-at-home.com | common | 3.0.0 |
 
 ## TL;DR
 
@@ -78,11 +78,10 @@ N/A
 | env.THELOUNGE_HOME | string | `"/config"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"thelounge/thelounge"` |  |
-| image.tag | string | `"4.2.0-alpine"` |  |
-| ingress.enabled | bool | `false` |  |
-| persistence.config.emptyDir.enabled | bool | `false` |  |
+| image.tag | string | `"4.3.0-alpine"` |  |
+| ingress.main.enabled | bool | `false` |  |
 | persistence.config.enabled | bool | `false` |  |
-| service.port.port | int | `9000` |  |
+| service.main.ports.http.port | int | `9000` |  |
 | strategy.type | string | `"Recreate"` |  |
 
 ## Changelog
@@ -90,6 +89,21 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [2.0.0]
+
+#### Added
+
+- N/A
+
+#### Changed
+
+- Changed Commons Dep to 3.0.0
+- bumped app ver to 4.3.0
+
+#### Removed
+
+- N/A
 
 ### [1.1.2]
 

--- a/charts/stable/thelounge/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/thelounge/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,22 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+### [2.0.0]
+
+#### Added
+
+- N/A
+
+#### Changed
+
+- Changed Commons Dep to 3.0.0
+- bumped app ver to 4.3.0
+
+#### Removed
+
+- N/A
+
 ### [1.1.2]
 
 #### Added

--- a/charts/stable/thelounge/values.yaml
+++ b/charts/stable/thelounge/values.yaml
@@ -8,7 +8,7 @@
 image:
   repository: thelounge/thelounge
   pullPolicy: IfNotPresent
-  tag: 4.2.0-alpine
+  tag: 4.3.0-alpine
 
 strategy:
   type: Recreate
@@ -19,14 +19,15 @@ env:
   THELOUNGE_HOME: "/config"
 
 service:
-  port:
-    port: 9000
+  main:
+    ports:
+      http:
+        port: 9000
 
 ingress:
-  enabled: false
+  main:
+    enabled: false
 
 persistence:
   config:
     enabled: false
-    emptyDir:
-      enabled: false


### PR DESCRIPTION


**Description of the change**

Updates and upgrades

**Benefits**

New things in Common with commons!

**Possible drawbacks**

not backwards compatable

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
