### PR TITLE
added privileged flag to readme for clarity

### DIFF
--- a/charts/stable/zigbee2mqtt/README.md
+++ b/charts/stable/zigbee2mqtt/README.md
@@ -98,6 +98,13 @@ affinity:
 
 ... where a node with an attached zigbee controller USB device is labeled with `app: zigbee-controller`
 
+If you are getting errors, that the device cannot be opened when starting Zigbee2Mqtt, try uncommenting the privileged flag:
+
+```
+securityContext:
+  privileged: true
+```
+
 ## Values
 
 **Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)


### PR DESCRIPTION
**added privileged flag to readme for clarity**

Just a little mention of the flag for anyone beeing confused, why the device cannot be opened.

**Benefits**

Well, it will be more clear and easier to find if it has been overlooked in the values.yaml.

**Possible drawbacks**

none

**Applicable issues**

none

**Additional information**

none
