### PR TITLE
[zigbee2mqtt] Migrate to common v3

### DIFF
--- a/charts/stable/zigbee2mqtt/Chart.yaml
+++ b/charts/stable/zigbee2mqtt/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.17.1
+appVersion: 1.19.1
 description: Bridges events and allows you to control your Zigbee devices via MQTT
 name: zigbee2mqtt
-version: 7.4.0
+version: 8.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - zigbee
@@ -13,11 +13,11 @@ icon: https://www.zigbee2mqtt.io/images/logo.png
 sources:
 - https://github.com/Koenkk/zigbee2mqtt
 maintainers:
-- name: ishioni
-  email: helm@movishell.pl
 - name: masantiago
   email: miguelangel.santiago@hotmail.com
+- name: bjw-s
+  email: me@bjw-s.dev
 dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com
-  version: 2.5.0
+  version: 3.0.1

--- a/charts/stable/zigbee2mqtt/README.md
+++ b/charts/stable/zigbee2mqtt/README.md
@@ -98,6 +98,13 @@ affinity:
 
 ... where a node with an attached zigbee controller USB device is labeled with `app: zigbee-controller`
 
+If you are getting errors, that the device cannot be opened when starting Zigbee2Mqtt, try uncommenting the privileged flag:
+
+```
+securityContext:
+  privileged: true
+```
+
 ## Values
 
 **Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)

--- a/charts/stable/zigbee2mqtt/README.md
+++ b/charts/stable/zigbee2mqtt/README.md
@@ -152,6 +152,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[8.0.0]: #800
 [1.0.0]: #100
 
 ## Support

--- a/charts/stable/zigbee2mqtt/README.md
+++ b/charts/stable/zigbee2mqtt/README.md
@@ -1,6 +1,6 @@
 # zigbee2mqtt
 
-![Version: 7.4.0](https://img.shields.io/badge/Version-7.4.0-informational?style=flat-square) ![AppVersion: 1.17.1](https://img.shields.io/badge/AppVersion-1.17.1-informational?style=flat-square)
+![Version: 8.0.0](https://img.shields.io/badge/Version-8.0.0-informational?style=flat-square) ![AppVersion: 1.19.1](https://img.shields.io/badge/AppVersion-1.19.1-informational?style=flat-square)
 
 Bridges events and allows you to control your Zigbee devices via MQTT
 
@@ -18,7 +18,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 2.5.0 |
+| https://library-charts.k8s-at-home.com | common | 3.0.1 |
 
 ## TL;DR
 
@@ -111,38 +111,32 @@ securityContext:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| additionalVolumeMounts | list | `[]` |  |
-| additionalVolumes | list | `[]` |  |
-| config.advanced.homeassistant_discovery_topic | string | `"homeassistant"` |  |
-| config.advanced.homeassistant_status_topic | string | `"homeassistant/status"` |  |
-| config.advanced.last_seen | string | `"ISO_8601"` |  |
-| config.advanced.log_level | string | `"info"` |  |
-| config.advanced.log_output[0] | string | `"console"` |  |
-| config.advanced.network_key | string | `"GENERATE"` |  |
-| config.experimental.new_api | bool | `true` |  |
-| config.frontend.port | int | `8080` |  |
-| config.homeassistant | bool | `false` |  |
-| config.mqtt.base_topic | string | `"zigbee2mqtt"` |  |
-| config.mqtt.include_device_information | bool | `true` |  |
-| config.mqtt.server | string | `"mqtt://localhost"` |  |
-| config.permit_join | bool | `true` |  |
-| config.serial | string | `nil` |  |
-| env.ZIGBEE2MQTT_DATA | string | `"/data"` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"koenkk/zigbee2mqtt"` |  |
-| image.tag | string | `"1.17.1"` |  |
-| ingress.enabled | bool | `false` |  |
-| persistence.data.emptyDir.enabled | bool | `false` |  |
-| persistence.data.enabled | bool | `false` |  |
-| persistence.data.mountPath | string | `"/data"` |  |
-| service.port.port | int | `8080` |  |
-| strategy.type | string | `"Recreate"` |  |
+| affinity | object | `{}` | Affinity constraint rules to place the Pod on a specific node. [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| config | object | See values.yaml | zigbee2mqtt configuration settings. This will be copied into the container's persistent storage at first run only. Further configuration should be done in the application itself! See [project documentation](https://www.zigbee2mqtt.io/information/configuration.html) for more information. |
+| env | object | See below | environment variables. See [image docs](https://www.zigbee2mqtt.io/information/configuration.html#override-via-environment-variables) for more details. |
+| env.ZIGBEE2MQTT_DATA | string | `"/data"` | Set the data folder for Zigbee2MQTT. |
+| image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
+| image.repository | string | `"koenkk/zigbee2mqtt"` | image repository |
+| image.tag | string | `"1.19.1"` | image tag |
+| ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
+| persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
+| persistence.usb | object | See values.yaml | Configure a hostPathMount to mount a USB device in the container. |
+| securityContext.privileged | bool | `nil` | Privileged securityContext may be required if USB controller is accessed directly through the host machine |
+| service | object | See values.yaml | Configures service settings for the chart. Normally this does not need to be modified. |
 
 ## Changelog
 
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [8.0.0]
+
+#### Changed
+
+- **BREAKING**: Upgraded the common library dependency to version 3.0.1. This introduces several breaking changes (`service`, `ingress` and `persistence` keys have been refactored).
+  Be sure to check out the [library chart](https://github.com/k8s-at-home/library-charts/blob/common-3.0.1/charts/stable/common/) for the up-to-date values.
+- Changed image tag to `1.19.1`.
 
 ### [1.0.0]
 
@@ -158,7 +152,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
-[1.0.0]: #1.0.0
+[1.0.0]: #100
 
 ## Support
 

--- a/charts/stable/zigbee2mqtt/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/zigbee2mqtt/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,14 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [8.0.0]
+
+#### Changed
+
+- **BREAKING**: Upgraded the common library dependency to version 3.0.1. This introduces several breaking changes (`service`, `ingress` and `persistence` keys have been refactored).
+  Be sure to check out the [library chart](https://github.com/k8s-at-home/library-charts/blob/common-3.0.1/charts/stable/common/) for the up-to-date values.
+- Changed image tag to `1.19.1`.
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +31,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
-[1.0.0]: #1.0.0
+[1.0.0]: #100
 {{- end -}}

--- a/charts/stable/zigbee2mqtt/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/zigbee2mqtt/README_CHANGELOG.md.gotmpl
@@ -31,5 +31,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[8.0.0]: #800
 [1.0.0]: #100
 {{- end -}}

--- a/charts/stable/zigbee2mqtt/README_CONFIG.md.gotmpl
+++ b/charts/stable/zigbee2mqtt/README_CONFIG.md.gotmpl
@@ -35,4 +35,11 @@ affinity:
 ```
 
 ... where a node with an attached zigbee controller USB device is labeled with `app: zigbee-controller`
+
+If you are getting errors, that the device cannot be opened when starting Zigbee2Mqtt, try uncommenting the privileged flag:
+
+```
+securityContext:
+  privileged: true
+```
 {{- end -}}

--- a/charts/stable/zigbee2mqtt/ci/ct-values.yaml
+++ b/charts/stable/zigbee2mqtt/ci/ct-values.yaml
@@ -1,8 +1,9 @@
 ingress:
-  enabled: true
+  main:
+    enabled: true
+
 persistence:
   data:
     enabled: true
-    emptyDir:
-      enabled: true
+    type: emptyDir
     mountPath: /data

--- a/charts/stable/zigbee2mqtt/templates/common.yaml
+++ b/charts/stable/zigbee2mqtt/templates/common.yaml
@@ -1,31 +1,17 @@
 {{/* Make sure all variables are set properly */}}
 {{- include "common.values.setup" . }}
 
-{{/* Append the configMap to the additionalVolumes */}}
-{{- define "zigbee2mqtt.configmap.volume" -}}
-name: zigbee2mqtt-settings
-configMap:
-  name: {{ template "common.names.fullname" . }}-settings
+{{/* Append the configMap volume to the volumes */}}
+{{- define "zigbee2mqtt.settingsVolume" -}}
+enabled: "true"
+mountPath: "/app/configuration.yaml"
+subPath: "configuration.yaml"
+type: "custom"
+volumeSpec:
+  configMap:
+    name: {{ include "common.names.fullname" . }}-settings
 {{- end -}}
-
-{{- $volume := include "zigbee2mqtt.configmap.volume" . | fromYaml -}}
-{{- if $volume -}}
-    {{- $additionalVolumes := append .Values.additionalVolumes $volume }}
-    {{- $_ := set .Values "additionalVolumes" (deepCopy $additionalVolumes) -}}
-{{- end -}}
-
-{{/* Append the configMap volume to the additionalVolumeMounts */}}
-{{- define "zigbee2mqtt.configmap.volumeMount" -}}
-name: zigbee2mqtt-settings
-mountPath: /app/configuration.yaml
-subPath: configuration.yaml
-{{- end -}}
-
-{{- $volumeMount := include "zigbee2mqtt.configmap.volumeMount" . | fromYaml -}}
-{{- if $volumeMount -}}
-    {{- $additionalVolumeMounts := append .Values.additionalVolumeMounts $volumeMount }}
-    {{- $_ := set .Values "additionalVolumeMounts" (deepCopy $additionalVolumeMounts) -}}
-{{- end -}}
+{{- $_ := set .Values.persistence "zigbee2mqtt-settings" (include "zigbee2mqtt.settingsVolume" . | fromYaml) -}}
 
 {{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/stable/zigbee2mqtt/values.yaml
+++ b/charts/stable/zigbee2mqtt/values.yaml
@@ -6,58 +6,53 @@
 #
 
 image:
+  # -- image repository
   repository: koenkk/zigbee2mqtt
+  # -- image tag
+  tag: 1.19.1
+  # -- image pull policy
   pullPolicy: IfNotPresent
-  tag: 1.17.1
 
-strategy:
-  type: Recreate
-
+# -- environment variables. See [image docs](https://www.zigbee2mqtt.io/information/configuration.html#override-via-environment-variables) for more details.
+# @default -- See below
 env:
+  # -- Set the data folder for Zigbee2MQTT.
   ZIGBEE2MQTT_DATA: /data
 
+# -- Configures service settings for the chart. Normally this does not need to be modified.
+# @default -- See values.yaml
 service:
-  port:
-    port: 8080
+  main:
+    ports:
+      http:
+        port: 8080
 
 ingress:
-  enabled: false
+  # -- Enable and configure ingress settings for the chart under this key.
+  # @default -- See values.yaml
+  main:
+    enabled: false
 
-# Privileged may be required if USB controller is accessed directly through the host machine
-# securityContext:
-#   privileged: true
+securityContext:
+  # -- (bool) Privileged securityContext may be required if USB controller is accessed directly through the host machine
+  privileged:  # true
 
+# -- Configure persistence settings for the chart under this key.
+# @default -- See values.yaml
 persistence:
   data:
     enabled: false
-    emptyDir:
-      enabled: false
     mountPath: /data
-    ## Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    # storageClass: "-"
-    # accessMode: ReadWriteOnce
-    # size: 1Gi
-    ## Do not delete the pvc upon helm uninstall
-    # skipuninstall: false
-    # existingClaim: ""
+  # -- Configure a hostPathMount to mount a USB device in the container.
+  # @default -- See values.yaml
+  usb:
+    enabled: false
+    type: hostPath
+    hostPath: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2400981-if00
 
-# Path to your zigbee device in the container
-additionalVolumeMounts: []
-#  - name: usb
-#    mountPath: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2400981-if00
-
-# Path to your zigbee device on the host
-additionalVolumes: []
-#  - name: usb
-#    hostPath:
-#      path: /dev/serial/by-id/usb-dresden_elektronik_ingenieurtechnik_GmbH_ConBee_II_DE2400981-if00
-
-# affinity:
+# -- Affinity constraint rules to place the Pod on a specific node.
+# [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
+affinity: {}
 #   nodeAffinity:
 #     requiredDuringSchedulingIgnoredDuringExecution:
 #       nodeSelectorTerms:
@@ -67,8 +62,11 @@ additionalVolumes: []
 #           values:
 #           - zigbee-controller
 
-# zigbee2mqtt configuration settings
-# https://www.zigbee2mqtt.io/information/configuration.html
+# -- zigbee2mqtt configuration settings.
+# This will be copied into the container's persistent storage at first run only.
+# Further configuration should be done in the application itself!
+# See [project documentation](https://www.zigbee2mqtt.io/information/configuration.html) for more information.
+# @default -- See values.yaml
 config:
   # These will be applied ONLY on first run
   # Home Assistant integration (MQTT discovery)


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Upgrades `zigbee2mqtt` chart to the latest common library version.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
