### PR TITLE
[zwave2mqtt] deprecate chart

### DIFF
--- a/charts/stable/zwave2mqtt/Chart.yaml
+++ b/charts/stable/zwave2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.6
 description: Fully configurable Zwave to MQTT gateway and Control Panel using NodeJS and Vue
 name: zwave2mqtt
-version: 8.4.0
+version: 8.4.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - zwave
@@ -12,9 +12,7 @@ home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/zwave2mqtt
 icon: https://raw.githubusercontent.com/zwave-js/zwavejs2mqtt/v4.0.0/static/logo.png
 sources:
 - https://github.com/OpenZWave/Zwave2Mqtt
-maintainers:
-- name: billimek
-  email: jeff@billimek.com
+deprecated: true
 dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com


### PR DESCRIPTION
**Description of the change**

deprecate zwave2mqtt in favor of zwavejs2mqtt