### PR TITLE
[adguard-home] Fix port

### DIFF
--- a/charts/stable/adguard-home/Chart.yaml
+++ b/charts/stable/adguard-home/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.106.3
 description: DNS proxy as ad-blocker for local network
 name: adguard-home
-version: 4.0.0
+version: 4.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - adguard-home

--- a/charts/stable/adguard-home/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/adguard-home/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.1]
+
+#### Fixed
+
+- Fixed the default protocol for the `dns-udp` port.
+
 ### [4.0.0]
 
 #### Changed
@@ -37,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[4.0.1]: #4.0.1
 [4.0.0]: #4.0.0
 [3.3.1]: #3.3.1
 [3.0.0]: #3.0.0

--- a/charts/stable/adguard-home/values.yaml
+++ b/charts/stable/adguard-home/values.yaml
@@ -79,7 +79,7 @@ service:
       dns-udp:
         enabled: true
         port: 53
-        protocol: TCP
+        protocol: UDP
         targetPort: 53
     externalTrafficPolicy: Local
 


### PR DESCRIPTION
Signed-off-by: Bᴇʀɴᴅ Sᴄʜᴏʀɢᴇʀs <me@bjw-s.dev>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Fixes the default protocol for the UDP port.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

Intentionally did not regenerate README. Want to see if the CI does it now 😄 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
