### PR TITLE
[pod-gateway] fix pod-gateway service definition

### DIFF
--- a/charts/stable/pod-gateway/Chart.yaml
+++ b/charts/stable/pod-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.6
 description: Admision controller to change the default gateway and DNS server of PODs
 name: pod-gateway
-version: 3.0.1
+version: 3.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - pod-gateway

--- a/charts/stable/pod-gateway/README.md
+++ b/charts/stable/pod-gateway/README.md
@@ -1,6 +1,6 @@
 # pod-gateway
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
+![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
 
 Admision controller to change the default gateway and DNS server of PODs
 
@@ -142,6 +142,12 @@ certificates. It does not install it as dependency to avoid conflicts.
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [3.0.2]
+
+#### Fixed
+
+- ClusterIP must be none - fixed service definition
 
 ### [3.0.1]
 

--- a/charts/stable/pod-gateway/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/pod-gateway/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.0.2]
+
+#### Fixed
+
+- ClusterIP must be none - fixed service definition
+
 ### [3.0.1]
 
 #### Fixed

--- a/charts/stable/pod-gateway/templates/common.yaml
+++ b/charts/stable/pod-gateway/templates/common.yaml
@@ -55,10 +55,10 @@ probes:
 
 service:
   main:
+    type: ClusterIP
+    clusterIP: None
     ports:
       http:
-        type: ClusterIP
-        clusterIP: None
         port: 4789
         protocol: UDP
 


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
