### PR TITLE
[zalando-postgres-cluster ] Enable additional settings for dumpBackup

### DIFF
--- a/charts/stable/zalando-postgres-cluster/CHANGELOG.md
+++ b/charts/stable/zalando-postgres-cluster/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0]
 
+### Changed
+
+- Support for persistence volume settings in dumpBackup
 ## [1.0.0]
 
 ### Changed

--- a/charts/stable/zalando-postgres-cluster/Chart.yaml
+++ b/charts/stable/zalando-postgres-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.1.0
+version: 2.2.0
 description: Creates a postgres cluster using the Zalando Postgres operator and local storage
 name: zalando-postgres-cluster
 appVersion: 1.0.0

--- a/charts/stable/zalando-postgres-cluster/README.md
+++ b/charts/stable/zalando-postgres-cluster/README.md
@@ -81,7 +81,7 @@ Features added by this wrapper:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | dumpBackup.enabled | bool | `false` | Enable backups to a PVC |
-| dumpBackup.existingClaim | string | `nil` | exiting claim |
+| dumpBackup.existingClaim | string | `nil` | existing claim |
 | dumpBackup.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | dumpBackup.image.repository | string | `"postgres"` | image used for the backups |
 | dumpBackup.image.tag | string | `"latest"` | image pull tag |
@@ -90,7 +90,7 @@ Features added by this wrapper:
 | dumpBackup.schedule | string | `"@daily"` | Backup schedule for postgres dumps |
 | dumpBackup.subpath | string | `nil` | Persistent volume claim subpath for the backups @default: <subpathPrefix/<release-name> |
 | dumpBackup.subpathPrefix | string | `"backup/db"` | Persistent volume claim subpath prefix for the backups |
-| dumpBackup.type | string | `nil` | type of persistence volume to use |
+| dumpBackup.type | string | `nil` | Sets the persistence type. Valid options are pvc, emptyDir, hostPath or custom. See [common chart persistence doc](https://github.com/k8s-at-home/library-charts/blob/main/charts/stable/common/values.yaml) |
 | persistentVolumes.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | persistentVolumes.annotations | object | `{}` |  |
 | persistentVolumes.hostPath | string | `nil` | Local path for the persistent volumes @default: <hostPathPrefix/<release-name> |

--- a/charts/stable/zalando-postgres-cluster/README.md
+++ b/charts/stable/zalando-postgres-cluster/README.md
@@ -1,6 +1,6 @@
 # zalando-postgres-cluster
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Creates a postgres cluster using the Zalando Postgres operator and local storage
 
@@ -80,15 +80,17 @@ Features added by this wrapper:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| dumpBackup.existingClaim | string | `nil` |  |
-| dumpBackup.image.pullPolicy | string | `"IfNotPresent"` |  |
-| dumpBackup.image.repository | string | `"postgres"` |  |
-| dumpBackup.image.tag | string | `"latest"` |  |
-| dumpBackup.resources.requests.cpu | string | `"5m"` |  |
-| dumpBackup.resources.requests.memory | string | `"10Mi"` |  |
+| dumpBackup.enabled | bool | `false` | Enable backups to a PVC |
+| dumpBackup.existingClaim | string | `nil` | exiting claim |
+| dumpBackup.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
+| dumpBackup.image.repository | string | `"postgres"` | image used for the backups |
+| dumpBackup.image.tag | string | `"latest"` | image pull tag |
+| dumpBackup.resources.requests.cpu | string | `"5m"` | requested cpu for backup |
+| dumpBackup.resources.requests.memory | string | `"10Mi"` | requested memory for backup |
 | dumpBackup.schedule | string | `"@daily"` | Backup schedule for postgres dumps |
 | dumpBackup.subpath | string | `nil` | Persistent volume claim subpath for the backups @default: <subpathPrefix/<release-name> |
 | dumpBackup.subpathPrefix | string | `"backup/db"` | Persistent volume claim subpath prefix for the backups |
+| dumpBackup.type | string | `nil` | type of persistence volume to use |
 | persistentVolumes.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | persistentVolumes.annotations | object | `{}` |  |
 | persistentVolumes.hostPath | string | `nil` | Local path for the persistent volumes @default: <hostPathPrefix/<release-name> |

--- a/charts/stable/zalando-postgres-cluster/templates/backupCronjob.yaml
+++ b/charts/stable/zalando-postgres-cluster/templates/backupCronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dumpBackup.existingClaim -}}
+{{- if or .Values.dumpBackup.enabled .Values.dumpBackup.existingClaim -}}
 # ------------------- CronJob ------------------- #
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -50,7 +50,7 @@ spec:
                 subPath: {{ include "zalando-postgres-cluster.backupPVCSubpath" . }}
           restartPolicy: OnFailure
           volumes:
-            - name: backup-volume
-              persistentVolumeClaim:
-                claimName: {{ .Values.dumpBackup.existingClaim }}
+            {{- $valuesCopy := deepCopy . -}}
+            {{- $_ := set $valuesCopy.Values "persistence" (dict "backup-volume" .Values.dumpBackup ) -}}
+            {{- include "common.controller.volumes" $valuesCopy | nindent 12 }}
 {{- end -}}

--- a/charts/stable/zalando-postgres-cluster/values.yaml
+++ b/charts/stable/zalando-postgres-cluster/values.yaml
@@ -63,7 +63,10 @@ dumpBackup:
   enabled: false
   # -- existing claim
   existingClaim:
-  # -- type of persistence volume to use
+  # -- Sets the persistence type.
+  # Valid options are pvc, emptyDir, hostPath or custom.
+  # See
+  # [common chart persistence doc](https://github.com/k8s-at-home/library-charts/blob/main/charts/stable/common/values.yaml)
   type:
   # -- Backup schedule for postgres dumps
   schedule: "@daily"

--- a/charts/stable/zalando-postgres-cluster/values.yaml
+++ b/charts/stable/zalando-postgres-cluster/values.yaml
@@ -61,7 +61,7 @@ persistentVolumes:
 dumpBackup:
   # -- Enable backups to a PVC
   enabled: false
-  # -- exiting claim
+  # -- existing claim
   existingClaim:
   # -- type of persistence volume to use
   type:

--- a/charts/stable/zalando-postgres-cluster/values.yaml
+++ b/charts/stable/zalando-postgres-cluster/values.yaml
@@ -59,8 +59,12 @@ persistentVolumes:
 
 
 dumpBackup:
-  # Enable backups to a PVC
+  # -- Enable backups to a PVC
+  enabled: false
+  # -- exiting claim
   existingClaim:
+  # -- type of persistence volume to use
+  type:
   # -- Backup schedule for postgres dumps
   schedule: "@daily"
   # -- Persistent volume claim subpath prefix for the backups
@@ -69,10 +73,15 @@ dumpBackup:
   # @default: <subpathPrefix/<release-name>
   subpath:
   image:
+    # -- image used for the backups
     repository: postgres
+    # -- image pull policy
     pullPolicy: IfNotPresent
+    # -- image pull tag
     tag: latest
   resources:
     requests:
+      # -- requested memory for backup
       memory: "10Mi"
+      # -- requested cpu for backup
       cpu: "5m"


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Allow the dumpBackup to take options of the common lib-chart persistence volume.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Additional settings for the backup volume

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None: only minor update so compatible with old values.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes NA

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
