### PR TITLE
[pod-gateway] Fix bug with duplicate strategy definitions in webhook-deployment.yaml

### DIFF
--- a/charts/stable/pod-gateway/Chart.yaml
+++ b/charts/stable/pod-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.6
 description: Admision controller to change the default gateway and DNS server of PODs
 name: pod-gateway
-version: 3.2.0
+version: 3.2.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - pod-gateway

--- a/charts/stable/pod-gateway/templates/webhook-deployment.yaml
+++ b/charts/stable/pod-gateway/templates/webhook-deployment.yaml
@@ -103,5 +103,3 @@ spec:
           terminationMessagePolicy: File
           imagePullPolicy: {{ .Values.image.pullPolicy }}
       restartPolicy: Always
-  strategy:
-    type: {{ .Values.webhook.strategy.type }}


### PR DESCRIPTION


<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Remove one of the `strategy:` definitions in webhook-deployment.yaml. This was causing validation errors when installing.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Chart should pass helm/kubectl validator now.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
