### PR TITLE
[multus] Set cni version in values.yaml

### DIFF
--- a/charts/stable/multus/Chart.yaml
+++ b/charts/stable/multus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v3.7.1
 description: multus CNI allows multiple NICs per pod
 name: multus
-version: 2.0.1
+version: 2.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - multus

--- a/charts/stable/multus/README.md
+++ b/charts/stable/multus/README.md
@@ -1,6 +1,6 @@
 # multus
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: v3.7.1](https://img.shields.io/badge/AppVersion-v3.7.1-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![AppVersion: v3.7.1](https://img.shields.io/badge/AppVersion-v3.7.1-informational?style=flat-square)
 
 multus CNI allows multiple NICs per pod
 
@@ -96,7 +96,7 @@ rm -rf  /var/lib/rancher/k3s/agent/etc/cni/net.d/*multus*
 | cni.image.tag | string | `"v0.9.1"` | CNI installer tag |
 | cni.paths.bin | string | `"/var/lib/rancher/k3s/data/current/bin"` | CNI plugin binaries folder for k3s. Change to `/opt/cni/bin` for non k3s |
 | cni.paths.config | string | `"/var/lib/rancher/k3s/agent/etc/cni/net.d"` | CNI config folder for k3s. Change to `/etc/cni/net.d` for non k3s |
-| cni.paths.version | string | `"0.3.1"` | CNI interface version |
+| cni.version | string | `"0.3.1"` | CNI interface version |
 | image.pullPolicy | string | `"IfNotPresent"` | multus installer pull policy |
 | image.repository | string | `"ghcr.io/k8snetworkplumbingwg/multus-cni"` | multus installer repostory |
 | image.tag | string | `"v3.7.1"` | multus installer tag |
@@ -106,6 +106,12 @@ rm -rf  /var/lib/rancher/k3s/agent/etc/cni/net.d/*multus*
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [2.0.2]
+
+#### Changed
+
+- Correct cni version in values.yaml
 
 ### [2.0.1]
 

--- a/charts/stable/multus/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/multus/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.0.2]
+
+#### Changed
+
+- Correct cni version in values.yaml
+
 ### [2.0.1]
 
 #### Changed

--- a/charts/stable/multus/values.yaml
+++ b/charts/stable/multus/values.yaml
@@ -31,5 +31,5 @@ cni:
     # Change to `/opt/cni/bin` for non k3s
     bin: /var/lib/rancher/k3s/data/current/bin
 
-    # -- CNI interface version
-    version: "0.3.1"
+  # -- CNI interface version
+  version: "0.3.1"


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Another typo - cni version was not set correctly (wrong number of spaces).
Chart boots but then it is not able to provision new pods.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
