### PR TITLE
[airsonic] Use airsonic-advanced

### DIFF
--- a/charts/stable/airsonic/Chart.yaml
+++ b/charts/stable/airsonic/Chart.yaml
@@ -2,19 +2,20 @@ apiVersion: v2
 appVersion: 10.6.2
 description: Airsonic is a Free and Open Source community driven media server
 name: airsonic
-version: 3.2.0
+version: 4.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - airsonic
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/airsonic
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/airsonic-logo.png
 sources:
-- https://github.com/airsonic/airsonic
-- https://github.com/linuxserver/docker-airsonic
+- https://github.com/airsonic-advanced/airsonic-advanced
 - https://github.com/k8s-at-home/charts/tree/master/charts/airsonic
 maintainers:
 - name: Patricol
   url: https://patricol.co/
+- name: bjw-s
+  email: me@bjw-s.dev
 dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com

--- a/charts/stable/airsonic/README.md
+++ b/charts/stable/airsonic/README.md
@@ -1,6 +1,6 @@
 # airsonic
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 10.6.2](https://img.shields.io/badge/AppVersion-10.6.2-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: 10.6.2](https://img.shields.io/badge/AppVersion-10.6.2-informational?style=flat-square)
 
 Airsonic is a Free and Open Source community driven media server
 
@@ -8,8 +8,7 @@ Airsonic is a Free and Open Source community driven media server
 
 ## Source Code
 
-* <https://github.com/airsonic/airsonic>
-* <https://github.com/linuxserver/docker-airsonic>
+* <https://github.com/airsonic-advanced/airsonic-advanced>
 * <https://github.com/k8s-at-home/charts/tree/master/charts/airsonic>
 
 ## Requirements
@@ -79,17 +78,17 @@ by not constantly monitoring media folders.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| env | object | See below | environment variables. See [image docs](https://docs.linuxserver.io/images/docker-airsonic#environment-variables-e) for more details. |
-| env.CONTEXT_PATH | string | `nil` | Used to set the base path for reverse proxies eg. /booksonic, /books, etc. |
+| enableServiceLinks | bool | `false` | Enable Kubernetes service links. Disabled by default, since AIRSONIC_* environment vars potentially clash with the application. |
+| env | object | See below | environment variables. |
+| env.CONTEXT_PATH | string | `nil` | Used to set the base path for reverse proxies eg. /airsonic, /music, etc. |
 | env.JAVA_OPTS | string | `nil` | For passing additional java options. For some reverse proxies, you may need to pass `JAVA_OPTS=-Dserver.use-forward-headers=true` for airsonic to generate the proper URL schemes. |
-| env.PGID | string | `"1001"` | Specify the group ID the application will run as |
-| env.PUID | string | `"1001"` | Specify the user ID the application will run as |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
-| image.repository | string | `"linuxserver/airsonic"` | image repository |
-| image.tag | string | `"version-v10.6.2"` | image tag |
+| image.repository | string | `"airsonicadvanced/airsonic-advanced"` | image repository |
+| image.tag | string | `"latest@sha256:f7cbafac28063dce99b443037547b4fe40ae270b7bc5e47efea9bb5d6751ca9d"` | image tag The specific digest is for the `amd64` image, but arm compatible images are also available. |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
+| probes | object | See values.yaml | Configures the probes for the main Pod. |
 | service | object | See values.yaml | Configures service settings for the chart. Normally this does not need to be modified. |
 
 ## Changelog
@@ -97,6 +96,15 @@ by not constantly monitoring media folders.
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [4.0.0]
+
+#### Changed
+
+- **BREAKING**: Changed image from linuxserver.io image to airsonic-advanced (https://github.com/airsonic-advanced/airsonic-advanced).
+
+#### Removed
+- Default values for `PGID` and `PUID` environment variables have been removed.
 
 ### [3.0.0]
 
@@ -120,6 +128,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[4.0.0]: #4.0.0
 [3.0.0]: #3.0.0
 [1.0.0]: #1.0.0
 

--- a/charts/stable/airsonic/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/airsonic/README_CHANGELOG.md.gotmpl
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **BREAKING**: Changed image from linuxserver.io image to airsonic-advanced (https://github.com/airsonic-advanced/airsonic-advanced).
 
 #### Removed
+
 - Default values for `PGID` and `PUID` environment variables have been removed.
 
 ### [3.0.0]

--- a/charts/stable/airsonic/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/airsonic/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,15 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.0]
+
+#### Changed
+
+- **BREAKING**: Changed image from linuxserver.io image to airsonic-advanced (https://github.com/airsonic-advanced/airsonic-advanced).
+
+#### Removed
+- Default values for `PGID` and `PUID` environment variables have been removed.
+
 ### [3.0.0]
 
 #### Changed
@@ -31,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[4.0.0]: #4.0.0
 [3.0.0]: #3.0.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/airsonic/values.yaml
+++ b/charts/stable/airsonic/values.yaml
@@ -7,25 +7,26 @@
 
 image:
   # -- image repository
-  repository: linuxserver/airsonic
+  repository: airsonicadvanced/airsonic-advanced
   # -- image tag
-  tag: version-v10.6.2
+  # The specific digest is for the `amd64` image, but arm compatible images are also available.
+  tag: latest@sha256:f7cbafac28063dce99b443037547b4fe40ae270b7bc5e47efea9bb5d6751ca9d
   # -- image pull policy
   pullPolicy: IfNotPresent
 
-# -- environment variables. See [image docs](https://docs.linuxserver.io/images/docker-airsonic#environment-variables-e) for more details.
+# -- environment variables.
 # @default -- See below
 env:
   # -- Set the container timezone
   TZ: UTC
-  # -- Specify the user ID the application will run as
-  PUID: "1001"
-  # -- Specify the group ID the application will run as
-  PGID: "1001"
-  # -- Used to set the base path for reverse proxies eg. /booksonic, /books, etc.
+  # -- Used to set the base path for reverse proxies eg. /airsonic, /music, etc.
   CONTEXT_PATH:  # "url-base"
   # -- For passing additional java options. For some reverse proxies, you may need to pass `JAVA_OPTS=-Dserver.use-forward-headers=true` for airsonic to generate the proper URL schemes.
   JAVA_OPTS:
+
+# -- Enable Kubernetes service links.
+# Disabled by default, since AIRSONIC_* environment vars potentially clash with the application.
+enableServiceLinks: false
 
 # -- Configures service settings for the chart. Normally this does not need to be modified.
 # @default -- See values.yaml
@@ -58,3 +59,40 @@ persistence:
   media:
     enabled: false
     mountPath: /media
+
+# -- Configures the probes for the main Pod.
+# @default -- See values.yaml
+probes:
+  liveness:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /rest/ping
+        port: http
+      initialDelaySeconds: 0
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+  readiness:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /rest/ping
+        port: http
+      initialDelaySeconds: 0
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+  startup:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /rest/ping
+        port: http
+      initialDelaySeconds: 0
+      periodSeconds: 5
+      timeoutSeconds: 1
+      failureThreshold: 30


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Use `airsonic-advanced` instead of linuxserver airsonic image

**Benefits**

Better featureset

**Possible drawbacks**

No specific image versions are available for the current codebase, so tagged a specific digest.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1058 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
