### PR TITLE
[pod-gateway] Fix issue where values.yaml defined 'configFile' wouldn't work in vpn addon

### DIFF
--- a/charts/stable/pod-gateway/Chart.yaml
+++ b/charts/stable/pod-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.6
 description: Admision controller to change the default gateway and DNS server of PODs
 name: pod-gateway
-version: 3.2.1
+version: 3.2.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - pod-gateway

--- a/charts/stable/pod-gateway/README.md
+++ b/charts/stable/pod-gateway/README.md
@@ -1,6 +1,6 @@
 # pod-gateway
 
-![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
+![Version: 3.2.2](https://img.shields.io/badge/Version-3.2.2-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
 
 Admision controller to change the default gateway and DNS server of PODs
 
@@ -100,17 +100,13 @@ certificates. It does not install it as dependency to avoid conflicts.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | DNS | string | `"172.16.0.1"` | IP address of the DNS server within the vxlan tunnel. All mutated PODs will get this as their DNS server. It must match VXLAN_GATEWAY_IP in settings.sh |
-| addons.vpn.configFileSecret | string | `"openvpn"` |  |
 | addons.vpn.enabled | bool | `false` | Enable the VPN if you want to route through a VPN. You might also want to set VPN_BLOCK_OTHER_TRAFFIC to true for extra safeness in case the VPN does connect |
-| addons.vpn.env | string | `nil` |  |
 | addons.vpn.networkPolicy.egress[0].ports[0].port | int | `443` |  |
 | addons.vpn.networkPolicy.egress[0].ports[0].protocol | string | `"UDP"` |  |
 | addons.vpn.networkPolicy.egress[0].to[0].ipBlock.cidr | string | `"0.0.0.0/0"` |  |
 | addons.vpn.networkPolicy.egress[1].to[0].ipBlock.cidr | string | `"10.0.0.0/8"` |  |
 | addons.vpn.networkPolicy.enabled | bool | `true` |  |
-| addons.vpn.openvpn | string | `nil` |  |
 | addons.vpn.type | string | `"openvpn"` |  |
-| addons.vpn.wireguard | string | `nil` |  |
 | clusterName | string | `"cluster.local"` | cluster name used to derive the gateway full name |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy of the gateway and inserted helper cotainers |
 | image.repository | string | `"ghcr.io/k8s-at-home/pod-gateway"` | image repository of the gateway and inserted helper containers |
@@ -142,6 +138,10 @@ certificates. It does not install it as dependency to avoid conflicts.
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [3.2.2]
+
+- Remove some default values (`addons.vpn.openvpn`, `addons.vpn.wireguard`, `addons.vpn.env`, `addons.vpn.configFileSecret`) which were interfering with user supplied configuration.
 
 ### [3.0.2]
 

--- a/charts/stable/pod-gateway/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/pod-gateway/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,10 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.2.2]
+
+- Remove some default values (`addons.vpn.openvpn`, `addons.vpn.wireguard`, `addons.vpn.env`, `addons.vpn.configFileSecret`) which were interfering with user supplied configuration.
+
 ### [3.0.2]
 
 #### Fixed

--- a/charts/stable/pod-gateway/values.yaml
+++ b/charts/stable/pod-gateway/values.yaml
@@ -76,7 +76,7 @@ addons:
     openvpn:
     wireguard:
     env:
-    configFileSecret: openvpn
+    # configFileSecret: openvpn
     networkPolicy:
       enabled: true
       egress:

--- a/charts/stable/pod-gateway/values.yaml
+++ b/charts/stable/pod-gateway/values.yaml
@@ -73,9 +73,9 @@ addons:
     # for extra safeness in case the VPN does connect
     enabled: false
     type: openvpn
-    openvpn:
-    wireguard:
-    env:
+    # openvpn:
+    # wireguard:
+    # env:
     # configFileSecret: openvpn
     networkPolicy:
       enabled: true


### PR DESCRIPTION


<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Because the default values.yaml file has `configFileSecret` set to `openvpn` by default, it is impossible to use the built in `configFile` with no secret. If you attempt to override `configFileSecret` to `null` the default value takes precedence, and the gateway will not start because of the lack of `openvpn` secret. 

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
