### PR TITLE
joplin-server Bump version of Joplin Server to 2.1.2 (Latest Stable Version)

### DIFF
--- a/charts/stable/joplin-server/Chart.yaml
+++ b/charts/stable/joplin-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.1.2
 description: This server allows you to sync any Joplin client
 name: joplin-server
-version: 3.1.0
+version: 3.2.0
 keywords:
   - joplin
   - notes

--- a/charts/stable/joplin-server/Chart.yaml
+++ b/charts/stable/joplin-server/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.7.2
+appVersion: 2.1.2
 description: This server allows you to sync any Joplin client
 name: joplin-server
 version: 3.1.0

--- a/charts/stable/joplin-server/README.md
+++ b/charts/stable/joplin-server/README.md
@@ -1,6 +1,6 @@
 # joplin-server
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
 
 This server allows you to sync any Joplin client
 
@@ -88,7 +88,7 @@ N/A
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"joplin/server"` | image repository |
-| image.tag | string | `"1.7.2"` | image tag |
+| image.tag | string | `"2.1.2"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | postgresql | object | See values.yaml | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
 | service | object | See values.yaml | Configures service settings for the chart. |
@@ -98,6 +98,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [3.2.0]
+
+#### Changed
+
+- Updated Joplin Server version to 2.1.2, as 2.0 introduces breaking changes between client and server.
 
 ### [3.0.0]
 

--- a/charts/stable/joplin-server/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/joplin-server/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.2.0]
+
+#### Changed
+
+- Updated Joplin Server version to 2.1.2, as 2.0 introduces breaking changes between client and server.
+
 ### [3.0.0]
 
 #### Added

--- a/charts/stable/joplin-server/values.yaml
+++ b/charts/stable/joplin-server/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: joplin/server
     # -- image tag
-  tag: 1.7.2
+  tag: 2.1.2
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

Update version of Joplin Server to 2.1.2 (Latest Stable Version)

**Benefits**

Joplin recently went through a major breaking change post-2.0. Updating the server will ensure users are able to continue to use this chart.

**Possible drawbacks**

No foreseeable drawbacks

**Applicable issues**

None

**Additional information**

None

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
