### PR TITLE
[ser2sock] Fix wrong device path

### DIFF
--- a/charts/stable/ser2sock/values.yaml
+++ b/charts/stable/ser2sock/values.yaml
@@ -21,7 +21,7 @@ env:
   # -- Port where ser2sock listens
   LISTENER_PORT: "{{ .Values.service.main.ports.server.port }}"
   # -- Path to the serial device
-  SERIAL_DEVICE: "{{ .Values.persistence.usb.hostPath }}"
+  SERIAL_DEVICE: "{{ .Values.persistence.usb.mountPath }}"
   # -- Serial device baud rate
   BAUD_RATE: 115200
 
@@ -51,7 +51,7 @@ persistence:
   usb:
     enabled: false
     type: hostPath
-    hostPath: /dev/ttyUSB0
+    mountPath: /dev/ttyUSB0
 
 securityContext:
   # -- (bool) Privileged securityContext may be required if USB controller is accessed directly through the host machine


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
Currently the env var references the host path instead of the path inside the container.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
n/a
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
n/a
<!-- Describe any known limitations with your change -->

**Applicable issues**
n/a
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
