### PR TITLE
[ser2sock] Fix wrong device path

### DIFF
--- a/charts/stable/ser2sock/Chart.yaml
+++ b/charts/stable/ser2sock/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: Serial to Socket Redirector
 name: ser2sock
-version: 4.0.0
+version: 4.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - ser2sock

--- a/charts/stable/ser2sock/README.md
+++ b/charts/stable/ser2sock/README.md
@@ -1,6 +1,6 @@
 # ser2sock
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Serial to Socket Redirector
 
@@ -109,7 +109,7 @@ affinity:
 | env | object | See below | environment variables. See [image docs](https://github.com/tenstartups/ser2sock) for more details. |
 | env.BAUD_RATE | int | `115200` | Serial device baud rate |
 | env.LISTENER_PORT | string | `"{{ .Values.service.main.ports.server.port }}"` | Port where ser2sock listens |
-| env.SERIAL_DEVICE | string | `"{{ .Values.persistence.usb.hostPath }}"` | Path to the serial device |
+| env.SERIAL_DEVICE | string | `"{{ .Values.persistence.usb.mountPath }}"` | Path to the serial device |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"Always"` | image pull policy |
 | image.repository | string | `"tenstartups/ser2sock"` | image repository |
@@ -125,6 +125,12 @@ affinity:
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [4.0.1]
+
+#### Fixed
+
+- Default device path used by ser2sock now points to the device inside the container.
 
 ### [4.0.0]
 
@@ -161,6 +167,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[4.0.1]: #401
 [4.0.0]: #400
 [3.0.0]: #300
 [1.0.0]: #100

--- a/charts/stable/ser2sock/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/ser2sock/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.1]
+
+#### Fixed
+
+- Default device path used by ser2sock now points to the device inside the container.
+
 ### [4.0.0]
 
 #### Changed
@@ -44,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[4.0.1]: #401
 [4.0.0]: #400
 [3.0.0]: #300
 [1.0.0]: #100

--- a/charts/stable/ser2sock/values.yaml
+++ b/charts/stable/ser2sock/values.yaml
@@ -21,7 +21,7 @@ env:
   # -- Port where ser2sock listens
   LISTENER_PORT: "{{ .Values.service.main.ports.server.port }}"
   # -- Path to the serial device
-  SERIAL_DEVICE: "{{ .Values.persistence.usb.hostPath }}"
+  SERIAL_DEVICE: "{{ .Values.persistence.usb.mountPath }}"
   # -- Serial device baud rate
   BAUD_RATE: 115200
 
@@ -51,7 +51,7 @@ persistence:
   usb:
     enabled: false
     type: hostPath
-    hostPath: /dev/ttyUSB0
+    mountPath: /dev/ttyUSB0
 
 securityContext:
   # -- (bool) Privileged securityContext may be required if USB controller is accessed directly through the host machine


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
Currently the env var references the host path instead of the path inside the container.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
n/a
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
n/a
<!-- Describe any known limitations with your change -->

**Applicable issues**
n/a
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
