### PR TITLE
[oauth2-proxy] bump oauth2-proxy to 7.1.3

### DIFF
--- a/charts/stable/oauth2-proxy/Chart.yaml
+++ b/charts/stable/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 5.0.5
+version: 5.0.6
 apiVersion: v1
-appVersion: 7.0.1
+appVersion: 7.1.3
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/oauth2-proxy
 description: A reverse proxy that provides authentication with Google, Github or other providers
 icon: https://avatars.githubusercontent.com/u/62798169?s=200&v=4

--- a/charts/stable/oauth2-proxy/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/oauth2-proxy/README_CHANGELOG.md.gotmpl
@@ -75,6 +75,20 @@ Due to [this issue](https://github.com/helm/helm/issues/6583) there may be error
 
 - Update oauth2-proxy website URLs.
 
+### [5.0.6]
+
+#### Added
+
+- N/A
+
+#### Changed
+
+- This version upgrade oauth2-proxy to 7.1.3. Please see the [changelog](https://github.com/oauth2-proxy/oauth2-proxy/blob/v7.1.3/CHANGELOG.md) in order to upgrade.
+
+#### Removed
+
+- N/A
+
 [5.0.4]: #5.0.4
 [5.0.1]: #5.0.1
 {{- end -}}

--- a/charts/stable/oauth2-proxy/values.yaml
+++ b/charts/stable/oauth2-proxy/values.yaml
@@ -32,7 +32,7 @@ image:
   # -- Image repository
   repository: "quay.io/oauth2-proxy/oauth2-proxy"
   # -- Image tag
-  tag: "v7.0.1"
+  tag: "v7.1.3"
   # -- Image pull policy
   pullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
Signed-off-by: Jan-Otto Kröpke <joe@adorsys.de>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

oauth2-proxy to 7.1.3

**Benefits**

An up2date oauth2-proxy 

**Possible drawbacks**

Unknown incompatibilities in oauth2-proxy 

**Applicable issues**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
