### PR TITLE
[icinga2] image comes with MariaDB enabled & hardcoded

### DIFF
--- a/charts/stable/icinga2/Chart.yaml
+++ b/charts/stable/icinga2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: latest
 description: A monitoring system which checks the availability of your network resources, notifies users of outages, and generates performance data for reporting.
 name: icinga2
-version: 1.0.0
+version: 1.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - icinga2
@@ -19,7 +19,3 @@ dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com
   version: 3.2.0
-- name: mariadb
-  version: 9.3.14
-  repository: https://charts.bitnami.com/bitnami
-  condition: mariadb.enabled

--- a/charts/stable/icinga2/README.md
+++ b/charts/stable/icinga2/README.md
@@ -1,6 +1,6 @@
 # icinga2
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A monitoring system which checks the availability of your network resources, notifies users of outages, and generates performance data for reporting.
 
@@ -19,7 +19,6 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mariadb | 9.3.14 |
 | https://library-charts.k8s-at-home.com | common | 3.2.0 |
 
 ## TL;DR
@@ -83,10 +82,10 @@ N/A
 | image.repository | string | `"jordan/icinga2"` | image repository |
 | image.tag | string | `"latest"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
-| mariadb | object | See values.yaml | Enable and configure mariadb database subchart under this key.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | persistence.config | object | `{"enabled":false,"mountPath":"/etc/icinga2"}` | Icinga2 configuration folder |
 | persistence.data | object | `{"enabled":false,"mountPath":"/var/lib/icinga2"}` | Icinga2 Data |
+| persistence.mariadb | object | `{"enabled":false,"mountPath":"/var/lib/mysql"}` | MariaDb data directory |
 | persistence.ssmtp | object | `{"enabled":false,"mountPath":"/etc/ssmtp"}` | ssmtp folder |
 | persistence.web | object | `{"enabled":false,"mountPath":"/etc/icingaweb2"}` | Icingaweb2 configuration folder |
 | service | object | See values.yaml | Configures service settings for the chart. |
@@ -96,6 +95,20 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [1.1.0]
+
+#### Added
+
+- Persistence for MariaDB data folder
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- optional external mariadb configuration and dependency
 
 ### [1.0.0]
 
@@ -111,6 +124,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[1.1.0]: N/A
 [1.0.0]: #100
 
 ## Support

--- a/charts/stable/icinga2/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/icinga2/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,20 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.1.0]
+
+#### Added
+
+- Persistence for MariaDB data folder
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- optional external mariadb configuration and dependency
+
 ### [1.0.0]
 
 #### Added
@@ -23,5 +37,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
+[1.1.0]: N/A
 [1.0.0]: #100
 {{- end -}}

--- a/charts/stable/icinga2/values.yaml
+++ b/charts/stable/icinga2/values.yaml
@@ -68,3 +68,4 @@ persistence:
   mariadb:
     enabled: false
     mountPath: /var/lib/mysql
+

--- a/charts/stable/icinga2/values.yaml
+++ b/charts/stable/icinga2/values.yaml
@@ -63,20 +63,8 @@ persistence:
   ssmtp:
     enabled: false
     mountPath: /etc/ssmtp
-
-# -- Enable and configure mariadb database subchart under this key.
-#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
-# @default -- See values.yaml
-mariadb:
-  enabled: false
-  architecture: standalone
-  auth:
-    database: icinga2
-    username: icinga2
-    password: icinga2-pass
-    rootPassword: icinga2rootpass
-  primary:
-    persistence:
-      enabled: false
-      # storageClass: ""
-  fullnameOverride: icinga2-db
+  # -- MariaDb data directory
+  # @default -- Disabled
+  mariadb:
+    enabled: false
+    mountPath: /var/lib/mysql


### PR DESCRIPTION
**Description of the change**

Removing external (optional) MariaDB dependency and making data directory of MariaDB coming with the Docker image persistable.

**Benefits**

Preventing accidental misconfiguration and possible resulting dataloss.

**Possible drawbacks**

It's not possible to disable the MariaDB server coming with the `icinga2` image, and using an external MariaDB server has to be done separately and explicitly.

**Applicable issues**

- none open

**Additional information**

Should allow a properly persisting Icinga2 this way now.

More documentation of configuration (Graphite etc) probably recommended for another PR.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)