### PR TITLE
[unifi] Add extra env vars for unifi deployment

### DIFF
--- a/charts/stable/unifi/templates/deployment.yaml
+++ b/charts/stable/unifi/templates/deployment.yaml
@@ -151,6 +151,7 @@ spec:
             - name: CERT_PRIVATE_NAME
               value: "{{ .Values.customCert.keyName }}"
             {{- end }}
+            {{- if .Values.extraEnvVars }}{{ toYaml .Values.extraEnvVars | trim | nindent 12 }}{{ end }}
           volumeMounts:
             - mountPath: /unifi/data
               name: unifi-data


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Add extra env vars for unifi deployment

**Benefits**

We can override any env var of the Docker image

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
