### PR TITLE
[blocky] Move replicas under controller definition in values.yaml

### DIFF
--- a/charts/stable/blocky/Chart.yaml
+++ b/charts/stable/blocky/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.14
 description: DNS proxy as ad-blocker for local network
 name: blocky
-version: 7.1.0
+version: 7.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - blocky

--- a/charts/stable/blocky/README.md
+++ b/charts/stable/blocky/README.md
@@ -1,6 +1,6 @@
 # blocky
 
-![Version: 7.1.0](https://img.shields.io/badge/Version-7.1.0-informational?style=flat-square) ![AppVersion: v0.14](https://img.shields.io/badge/AppVersion-v0.14-informational?style=flat-square)
+![Version: 7.1.1](https://img.shields.io/badge/Version-7.1.1-informational?style=flat-square) ![AppVersion: v0.14](https://img.shields.io/badge/AppVersion-v0.14-informational?style=flat-square)
 
 DNS proxy as ad-blocker for local network
 
@@ -76,6 +76,7 @@ N/A
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config | string | see URL to default config | Full list of options https://github.com/0xERR0R/blocky/blob/master/docs/config.yml |
+| controller.replicas | int | `1` | (int) Number of pods to load balance between |
 | controller.strategy | string | `"RollingUpdate"` | Set the controller upgrade strategy |
 | env | object | See below | environment variables. See [image docs](https://0xerr0r.github.io/blocky/installation/#run-with-docker) for more details. |
 | env.TZ | string | `"UTC"` | Set the container timezone |
@@ -84,7 +85,6 @@ N/A
 | image.tag | string | `"v0.14"` | image tag |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | prometheus.serviceMonitor | object | See values.yaml | Enable and configure a Prometheus serviceMonitor for the chart under this key. See also the notes under `additionalContainers`. |
-| replicas | int | `1` | (int) Number of pods to load balance between |
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog

--- a/charts/stable/blocky/values.yaml
+++ b/charts/stable/blocky/values.yaml
@@ -16,15 +16,14 @@ image:
 controller:
   # -- Set the controller upgrade strategy
   strategy: RollingUpdate
+  # -- (int) Number of pods to load balance between
+  replicas: 1
 
 # -- environment variables. See [image docs](https://0xerr0r.github.io/blocky/installation/#run-with-docker) for more details.
 # @default -- See below
 env:
   # -- Set the container timezone
   TZ: UTC
-
-# -- (int) Number of pods to load balance between
-replicas: 1
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml


### PR DESCRIPTION
Signed-off-by: Brandon Clifford <brandon@clifford.sh>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This moves the `replicas` underneath `controller` as the move to the current common chart expects it here.

**Benefits**

Update's self-documentation mentioned in the values.yaml to indicate where replicas should be defined.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)
