### PR TITLE
[pod-gateway] Fix for allowing custom namespace selectors without dict merges

### DIFF
--- a/charts/stable/pod-gateway/Chart.yaml
+++ b/charts/stable/pod-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.6
 description: Admision controller to change the default gateway and DNS server of PODs
 name: pod-gateway
-version: 3.3.0
+version: 4.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - pod-gateway

--- a/charts/stable/pod-gateway/README.md
+++ b/charts/stable/pod-gateway/README.md
@@ -1,6 +1,6 @@
 # pod-gateway
 
-![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
 
 Admision controller to change the default gateway and DNS server of PODs
 

--- a/charts/stable/pod-gateway/README.md
+++ b/charts/stable/pod-gateway/README.md
@@ -1,6 +1,6 @@
 # pod-gateway
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
+![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
 
 Admision controller to change the default gateway and DNS server of PODs
 
@@ -129,7 +129,7 @@ certificates. It does not install it as dependency to avoid conflicts.
 | webhook.image.pullPolicy | string | `"IfNotPresent"` | image pullPolicy of the webhook |
 | webhook.image.repository | string | `"ghcr.io/k8s-at-home/gateway-admision-controller"` | image repository of the webhook |
 | webhook.image.tag | string | `"v3.3.2"` | image tag of the webhook |
-| webhook.namespaceSelector | object | `{"matchLabels":{"routed-gateway":"true"}}` | Selector for namespace. All pods in this namespace will get evaluated by the webhook. **IMPORTANT**: Do not select the namespace where the webhook is deployed to or you will get locking issues. |
+| webhook.namespaceSelector | object | `{"custom":{},"label":"routed-gateway","type":"label"}` | Selector for namespace. All pods in this namespace will get evaluated by the webhook. **IMPORTANT**: Do not select the namespace where the webhook is deployed to or you will get locking issues. |
 | webhook.replicas | int | `1` | number of webhook instances to deploy |
 | webhook.strategy | object | `{"type":"RollingUpdate"}` | strategy for updates |
 
@@ -138,6 +138,10 @@ certificates. It does not install it as dependency to avoid conflicts.
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [4.0.0]
+
+- Fixed `namespaceSelector` to allow replacing the default label value.
 
 ### [3.2.2]
 

--- a/charts/stable/pod-gateway/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/pod-gateway/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,10 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.0]
+
+- Fixed `namespaceSelector` to allow replacing the default label value.
+
 ### [3.2.2]
 
 - Remove some default values (`addons.vpn.openvpn`, `addons.vpn.wireguard`, `addons.vpn.env`, `addons.vpn.configFileSecret`) which were interfering with user supplied configuration.

--- a/charts/stable/pod-gateway/templates/webhook-admissionregistration.yaml
+++ b/charts/stable/pod-gateway/templates/webhook-admissionregistration.yaml
@@ -10,7 +10,12 @@ webhooks:
 - name: "{{ include "common.names.fullname" . }}.svc.cluster.local"
   namespaceSelector:
   {{- with .Values.webhook.namespaceSelector }}
-    {{ toYaml . | nindent 4 }}
+  {{- if eq .type "label" }}
+    matchLabels:
+      {{ .label }}: "true"
+  {{- else if eq .type "custom" }}
+    {{- toYaml .custom | nindent 4 }}
+  {{- end }}
   {{- end }}
   rules:
   - apiGroups:   [""]

--- a/charts/stable/pod-gateway/values.yaml
+++ b/charts/stable/pod-gateway/values.yaml
@@ -119,12 +119,13 @@ webhook:
   # **IMPORTANT**: Do not select the namespace where the webhook
   # is deployed to or you will get locking issues.
   namespaceSelector:
-    matchLabels:
-      routed-gateway: "true"
-    # matchExpressions:
-    # - key: notTouch
-    #   operator: NotIn
-    #   values: ["1"]
+    type: label
+    label: "routed-gateway"
+    custom: {}
+      # matchExpressions:
+      # - key: notTouch
+      #   operator: NotIn
+      #   values: ["1"]
 
   # -- default behviour for new PODs in the evaluated namespace
   gatewayDefault: true


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Currently `namespaceSelector` is defined as a dict to match k8s format, however this causes an issue if one wants to set a custom namespace label as Helm merges the values ending up with multiple labels.

This change allows setting custom labels that won't be merged, while still allowing complex custom selectors if needed.

**Benefits**

Fixes implementation to work as originally intended.

**Possible drawbacks**

Breaking change for users that have already attempted to use custom `namespaceSelector`s (probably just me :) )

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
