### PR TITLE
[youtubedl-material] Fix incorrect mount paths

### DIFF
--- a/charts/stable/youtubedl-material/Chart.yaml
+++ b/charts/stable/youtubedl-material/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.2"
 description: Self-hosted YouTube downloader built on Material Design
 name: youtubedl-material
-version: 3.1.0
+version: 3.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - youtubedl-material

--- a/charts/stable/youtubedl-material/README.md
+++ b/charts/stable/youtubedl-material/README.md
@@ -1,6 +1,6 @@
 # youtubedl-material
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![AppVersion: 4.2](https://img.shields.io/badge/AppVersion-4.2-informational?style=flat-square)
+![Version: 3.1.1](https://img.shields.io/badge/Version-3.1.1-informational?style=flat-square) ![AppVersion: 4.2](https://img.shields.io/badge/AppVersion-4.2-informational?style=flat-square)
 
 Self-hosted YouTube downloader built on Material Design
 
@@ -92,6 +92,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [3.1.1]
+
+#### Changed
+
+- Fix `persistence.<volume>.mountPath` for `audio` and `subscriptions` volumes
 
 ### [3.0.0]
 

--- a/charts/stable/youtubedl-material/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/youtubedl-material/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.1.1]
+
+#### Changed
+
+- Fix `persistence.<volume>.mountPath` for `audio` and `subscriptions` volumes
+
 ### [3.0.0]
 
 #### Changed

--- a/charts/stable/youtubedl-material/values.yaml
+++ b/charts/stable/youtubedl-material/values.yaml
@@ -48,10 +48,10 @@ persistence:
     mountPath: /app/audio
   subscriptions:
     enabled: false
-    mountPath: /subscriptions
+    mountPath: /app/subscriptions
   users:
     enabled: false
     mountPath: /users
   video:
     enabled: false
-    mountPath: /video
+    mountPath: /app/video


### PR DESCRIPTION
**Description of the change**

The change updates the pv mount paths to what I believe to be the correct paths. The app reads subscriptions from `/app/subscriptions`, videos from `/app/videos`, audio from `/app/audio` and config from `/app/appdata`. The way that the mount paths are written in the values.yaml, the volumes for subscriptions and video mount at the root directory instead of under /app.

I noticed there was a discrepancy with the mount paths when my videos were gone due to a pod eviction. The eviction was due to an exceeded ephemeral storage limit which makes sense because I was unknowingly storing videos within the container. 

As a workaround, I'm currently passing the mountPaths as values to my installation and I'm able to persist videos and audio as expected. 

**Benefits**

The installation will store videos and audio into the volumes that one would expect when enabling them.

**Possible drawbacks**

API change, although if the values don't work as expected then it might be a welcomed change

**Applicable issues**

None, but I can open one if necessary

**Additional information**

There is a volume for `users` at the mount path `/users`, but it doesn't seem like it should exist. Users are stored at `/app/appdata/users.json` which would be under the `config` volume.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)

