### PR TITLE
[octoprint] new images, configmap, init container & much more [WIP]

### DIFF
--- a/charts/stable/octoprint/templates/common.yaml
+++ b/charts/stable/octoprint/templates/common.yaml
@@ -1,1 +1,34 @@
+{{/* Make sure all variables are set properly */}}
+{{- include "common.values.setup" . }}
+
+{{/* Append the configMap volume to the volumes */}}
+{{- define "octoprint.init" -}}
+enabled: "true"
+mountPath: "/init.sh"
+subPath: "init.sh"
+type: "custom"
+volumeSpec:
+  configMap:
+    name: {{ include "common.names.fullname" . }}-init
+    defaultMode: 0755
+{{- end -}}
+{{- define "octoprint.initContainer" -}}
+name: init-octoprint
+image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+imagePullPolicy: {{ .Values.image.pullPolicy }}
+volumeMounts:
+- name: data
+  mountPath: /octoprint
+- name: octoprint-init
+  mountPath: /init.sh
+  subPath: init.sh
+command:
+  - sh
+  - -c
+  - /init.sh
+{{- end -}}
+{{- $_ := set .Values.persistence "octoprint-init" (include "octoprint.init" . | fromYaml) -}}
+{{- $_ := set .Values.initContainers "octoprint-init" (include "octoprint.initContainer" . | fromYaml) -}}
+
+{{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/stable/octoprint/templates/init_config.yaml
+++ b/charts/stable/octoprint/templates/init_config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "common.names.fullname" . }}-init
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+data:
+  init.sh: |
+    #!/bin/bash
+    if ! octoprint --version 2>/dev/null ; then
+      cd; mkdir tmp; tar xzf ${octoprint_ref}.tar.gz --strip-components 1 -C tmp ; cd tmp; pip install .
+    fi
+{{- if .Values.octoprint.plugins.install }}
+  {{- range .Values.octoprint.plugins.plugins }}
+    pip install{{if $.Values.octoprint.plugins.upgrade }}--upgrade{{ end }} {{.}}
+  {{- end }}
+{{- end }}

--- a/charts/stable/octoprint/templates/webcam-streamer.yaml
+++ b/charts/stable/octoprint/templates/webcam-streamer.yaml
@@ -1,0 +1,55 @@
+{{- include "common.values.setup" . }}
+{{- define "octoprint.streamer" -}}
+name: webcam-streamer
+{{- if .Values.mjpg_streamer.enabled }}
+image: {{ .Values.mjpg_streamer.image | default "badsmoke/mjpg-streamer" }}:{{ .Values.mjpg_streamer.tag | default "latest" }}
+imagePullPolicy: {{ .Values.mjpg_streamer.imagePullPolicy | default "IfNotPresent" }}
+{{- else }}
+image: {{ .Values.ustreamer.image | default "lib42/ustreamer" }}:{{ .Values.ustreamer.tag | default "latest" }}
+imagePullPolicy: {{ .Values.ustreamer.imagePullPolicy | default "IfNotPresent" }}
+{{- end }}
+securityContext:
+  privileged: true
+ports:
+  - name: http-stream
+    containerPort: 8080
+    protocol: TCP
+command:
+{{- if .Values.mjpg_streamer.enabled }}
+  - /mjpg-streamer/mjpg-streamer-experimental/docker-start.sh
+  - -i
+  - '"./input_uvc.so -u -d {{ .Values.streamer.device | default "/dev/video0"}} -r {{ .Values.streamer.resolution | default "640x480" }} -f {{.Values.mjpg_streamer.framerate | default 15}}"'
+  - -o
+  - '"./output_http.so -p {{ .Values.streamer.port | default 8080 }}"'
+{{- else }}
+  - ./ustreamer
+  - --host=0.0.0.0
+  - --slowdown
+  - --drop-same-frames=30
+  - --device={{ .Values.streamer.device | default "/dev/video0" }}
+  - --encoder={{ .Values.streamer.encoder | default "CPU" }}
+  - --quality={{ .Values.streamer.quality | default 80 }}
+  - --port={{ .Values.streamer.port | default 8080 }}
+  - --desired-fps={{ .Values.streamer.fps | default 15 }}
+  - --format={{ .Values.streamer.format | default "YUYV" }}
+  - --resolution={{ .Values.streamer.resolution | default "640x480" }}
+{{- end }}
+livenessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 10
+  failureThreshold: 3
+  timeoutSeconds: 1
+  periodSeconds: 10
+readinessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 10
+  failureThreshold: 3
+  timeoutSeconds: 1
+  periodSeconds: 10
+{{- end -}}
+
+{{- if or .Values.mjpg_streamer.enabled .Values.ustreamer.enabled -}}
+{{- $_ := set .Values.additionalContainers "webcam-streamer" (include "octoprint.streamer" . | fromYaml) -}}
+{{- end -}}

--- a/charts/stable/octoprint/values.yaml
+++ b/charts/stable/octoprint/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: octoprint/octoprint
   # -- image tag
-  tag: 1.6.1
+  tag: 1.6.1-minimal
   # -- image pull policy
   pullPolicy: IfNotPresent
 
@@ -18,27 +18,88 @@ image:
 env:
   # -- Set the container timezone
   TZ: UTC
-  # -- Enable MJPG Streamer
-  # Enable this to ensure camera streaming is enabled you add a video device.
-  ENABLE_MJPG_STREAMER: "true"
-  # -- MJPG Streamer input parameters
-  MJPG_STREAMER_INPUT:  # "-y -n -r 640x480"
-  # -- MJPG Streamer camera device
-  CAMERA_DEV:  # /dev/video0
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml
 service:
   main:
+    enabled: true
     ports:
       http:
         port: 80
+        targetPort: 5000
+
+  # Webcam Stream
+  stream:
+    enabled: false
+    ports:
+      http-stream:
+        enabled: true
+        port: 80
+        targetPort: 8080
+
+# Octoprint settings
+octoprint:
+ 
+  # Octoprint Plugins
+  plugins:
+    # Install plugins before starting octoprint?
+    install: false
+
+    # Upgrade installed plugins?
+    upgrade: false
+
+    ## List of plugins to install/upgrade
+    #plugins:
+    #- https://github.com/tg44/OctoPrint-Prometheus-Exporter/archive/master.zip
+    #- https://github.com/LazeMSS/OctoPrint-UICustomizer/archive/main.zip
+    #- https://github.com/NilsRo/OctoPrint-SlicerEstimator/archive/master.zip
+
+# Webcam Streamer config for mjpg & ustreamer
+# Requires to enable one of mjpg_streamer and ustreamer
+streamer:
+  device: /dev/video0
+  resolution: 640x480
+  framerate: 15
+  port: 8080
+  resolution: 640x480
+
+  # ustreamer-only - YUYV, UYVY, RGB565, RGB24, MJPEG, JPEG; default: YUYV
+  format: YUYV
+  encoder: CPU
+  quality: 70
+
+## Choose on of these if you want to stream a webcam feed:
+# mjpg-streamer the old classic
+mjpg_streamer:
+  enabled: false
+
+  image: badsmoke/mjpg-streamer
+  tag: latest
+  imagePullPolicy: IfNotPresent
+
+# ustreamer - new, written in go
+ustreamer:
+  enabled: false
+
+  image: lib42/ustreamer
+  tag: latest
+  imagePullPolicy: IfNotPresent
+
+## Pod annotations e.g. for octoprint prometheus exporter
+#podAnnotations:
+#  prometheus.io/scrape: "true"
+#  prometheus.io/port: "5000"
+#  prometheus.io/path: "/plugin/prometheus_exporter/metrics"
 
 ingress:
   # -- Enable and configure ingress settings for the chart under this key.
   # @default -- See values.yaml
   main:
     enabled: false
+    #annotations:
+    #  # Increased body-size lets you upload bigger gcode
+    #  nginx.ingress.kubernetes.io/proxy-body-size: 100m
 
 securityContext:
   # -- (bool) Privileged securityContext may be required if USB devics are accessed directly through the host machine
@@ -50,9 +111,18 @@ persistence:
   data:
     enabled: false
     mountPath: /octoprint
+    accessMode: ReadWriteOnce
+    size: 1Gi
+
   # -- Configure a hostPathMount to mount a USB device in the container.
   # @default -- See values.yaml
   printer:
     enabled: false
     type: hostPath
     hostPath: /dev/ttyACM0
+
+  # Device path of webcam
+  camera:
+    enabled: false
+    type: hostPath
+    hostPath: /dev/video0


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

The current octoprint chart uses a image the contains multiple services e.g. `haproxy`, `octoprint` and `mjpg-streamer`. This change brakes up the monolithic image into multiple containers inside a pod, using a `minimalistic` upstream image.

Also I added a few configuration options directly to the `values.yaml` making it easy to use. Besides `mjpg-streamer` it's also possible to use `ustreamer` by simply enabling it in the `values.yaml`

Furthermore I had to create a initContainer which installes octoprint, since octoprint gets installed into `/octoprint` during the creation of the image & will be empty if a persistent volume is being used. While at it I also implemented an automatic installation & upgrade of octoprint plugins during init phase.


<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
 - Better practice by separating services in multiple containers
 - ustreamer support
 - less overhead by using ingress instead of haproxy
 - more & simple configuration options for [webcam streamers](https://github.com/Nold360/k8s-at-home-charts/blob/d88c7eb3828527aa04dac5732957ddc2d2453fa2/charts/stable/octoprint/values.yaml#L59) / octoprint /...
 - [easy automatic install of octoprint plugins](https://github.com/Nold360/k8s-at-home-charts/blob/d88c7eb3828527aa04dac5732957ddc2d2453fa2/charts/stable/octoprint/values.yaml#L45) via init-container & array in `values.yaml`
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
 - Ingress is needed to use a the webcam streamer [well i guess you could also use a NodePort...]
 - octoprint installation of first start might require internet access, due to pip. [But all dependencies should already be installed anyways & i'm using the original .tar.gz which is still inside the container image]
 - Probably breaks current deployments 
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1118

**Additional information**

I marked this PR as "WIP" since 
  1. I want your feedback 
  2. I need a better way to implement the second path on the ingress. Since the name of the streamer-service is dynamic ( Release.Name-Chart.Name-myService ). I tried adding it to the paths-array like i do with the `additionalContainers`. But since it's an array (in an array) i wasn't able to make it work. [See this](https://github.com/Nold360/k8s-at-home-charts/blob/d88c7eb3828527aa04dac5732957ddc2d2453fa2/charts/stable/octoprint/values.yaml#L110)

I guess the easiest way would be to create a Service-template with a fixed name & keep the ingress path in `values.yaml`

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
