### PR TITLE
Fix URL to joplin-server chart homepage

### DIFF
--- a/charts/stable/joplin-server/Chart.yaml
+++ b/charts/stable/joplin-server/Chart.yaml
@@ -6,7 +6,7 @@ version: 4.0.0
 keywords:
   - joplin
   - notes
-home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/jopplin-server
+home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/joplin-server
 icon: https://raw.githubusercontent.com/laurent22/joplin/master/Assets/LinuxIcons/256x256.png?raw=true
 sources:
   - https://github.com/laurent22/joplin/tree/dev/packages/server


### PR DESCRIPTION
Fixes a typo in the homepage URL for `joplin-server` so that those redirecting from [artifacthub](https://artifacthub.io/packages/helm/k8s-at-home/joplin-server) don't get a 404 :smile: 
