### PR TITLE
[smarter-device-manager] use /var/log for termination.messagePath (fixes #1092)

### DIFF
--- a/charts/stable/smarter-device-manager/Chart.yaml
+++ b/charts/stable/smarter-device-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.20.7
 description: Manage hardware resource allocation without a need for privileged containers
 name: smarter-device-manager
-version: 6.0.0
+version: 6.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - kubernetes

--- a/charts/stable/smarter-device-manager/README.md
+++ b/charts/stable/smarter-device-manager/README.md
@@ -1,6 +1,6 @@
 # smarter-device-manager
 
-![Version: 6.0.0](https://img.shields.io/badge/Version-6.0.0-informational?style=flat-square) ![AppVersion: 1.20.7](https://img.shields.io/badge/AppVersion-1.20.7-informational?style=flat-square)
+![Version: 6.1.0](https://img.shields.io/badge/Version-6.1.0-informational?style=flat-square) ![AppVersion: 1.20.7](https://img.shields.io/badge/AppVersion-1.20.7-informational?style=flat-square)
 
 Manage hardware resource allocation without a need for privileged containers
 
@@ -124,12 +124,21 @@ In this case host device `/dev/ttyUSB-Conbee-2` will be given at the same path, 
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | priorityClassName | string | `"system-node-critical"` | Custom priority class for different treatment by the scheduler Setting this is not necessary, but it is recommended. [[ref]](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) |
 | securityContext | object | See values.yaml | Configure the securityContext for this pod [[ref]](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) |
+| termination.messagePath | string | `"/var/log/termination-log"` | Configure the path at which the file to which the main container's termination message will be written. Overrides the default of `/dev/termination-log` to allow read-only `persistence.devfs` at `/dev`. [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
+| termination.messagePolicy | string | `"FallbackToLogsOnError"` | Indicate how the main container's termination message should be populated. Valid options are `File` and `FallbackToLogsOnError`. smarter-device-manager does not support a termination-log, so use the container's log. [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
 
 ## Changelog
 
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [6.1.0]
+
+#### Changed
+
+- Override the default container `terminationMessagePath` to allow mounting `/dev` as read-only. The path is now `/var/log/termination-log`. Fixes #1092.
+- Use the container's error log to populate the container termination message, since smarter-device-manager does not support a k8s `termination-log`.
 
 ### [6.0.0]
 
@@ -164,6 +173,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial version
 
+[6.1.0]: #610
 [6.0.0]: #600
 [5.0.0]: #500
 [4.0.0]: #400

--- a/charts/stable/smarter-device-manager/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/smarter-device-manager/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,13 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [6.1.0]
+
+#### Changed
+
+- Override the default container `terminationMessagePath` to allow mounting `/dev` as read-only. The path is now `/var/log/termination-log`. Fixes #1092.
+- Use the container's error log to populate the container termination message, since smarter-device-manager does not support a k8s `termination-log`.
+
 ### [6.0.0]
 
 #### Changed
@@ -42,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial version
 
+[6.1.0]: #610
 [6.0.0]: #600
 [5.0.0]: #500
 [4.0.0]: #400

--- a/charts/stable/smarter-device-manager/values.yaml
+++ b/charts/stable/smarter-device-manager/values.yaml
@@ -25,6 +25,18 @@ hostNetwork: true
 # -- Defaults to "ClusterFirst" if hostNetwork is false and "ClusterFirstWithHostNet" if hostNetwork is true.
 dnsPolicy:  # ClusterFirstWithHostNet
 
+termination:
+  # -- Configure the path at which the file to which the main container's termination message will be written.
+  # Overrides the default of `/dev/termination-log` to allow read-only `persistence.devfs` at `/dev`.
+  # [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)]
+  messagePath: /var/log/termination-log
+
+  # -- Indicate how the main container's termination message should be populated.
+  # Valid options are `File` and `FallbackToLogsOnError`.
+  # smarter-device-manager does not support a termination-log, so use the container's log.
+  # [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)]
+  messagePolicy: FallbackToLogsOnError
+
 # -- Configure persistence settings for the chart under this key.
 # @default -- See values.yaml
 persistence:


### PR DESCRIPTION
Signed-off-by: Andrew Zammit <zammit.andrew@gmail.com>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

- Override the default container `terminationMessagePath` to allow mounting `/dev` as read-only. The path is now `/var/log/termination-log`. Fixes #1092.
- Use the container's error log to populate the container termination message, since smarter-device-manager does not support a k8s `termination-log`.

**Benefits**

The default `values.yaml` for this chart now work out-of-the-box.

**Possible drawbacks**

This chart's `common` dependency was bumped on 8/12 to v4.0.0, which added support for the `termination` section. The default values added here may conflict with the consumer's expectation of behavior, albeit it never worked to begin with. If set by the consumer, these default values will have no effect.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1092 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
