### PR TITLE
[searx] Update to latest version

### DIFF
--- a/charts/stable/searx/Chart.yaml
+++ b/charts/stable/searx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: Searx is a privacy-respecting, hackable metasearch engine
 name: searx
-version: 5.0.0
+version: 5.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - searx

--- a/charts/stable/searx/README.md
+++ b/charts/stable/searx/README.md
@@ -94,9 +94,6 @@ N/A
 | searx.baseUrl | string | `"https://searx.DOMAIN"` | External URL where the application is reachable |
 | searx.existingSecret | string | `nil` | Specify an existing secret that contains the environment variables required for the application configuration. |
 | searx.mortyKey | string | `"changeme"` | Generate a random key used by Morty (Privacy aware web content sanitizer proxy as a service). Example : `openssl rand -base64 24` |
-| searxChecker.pullPolicy | string | `"Always"` | searx-checker sidecar image pull policy |
-| searxChecker.repository | string | `"searx/searx-checker"` | searx-checker sidecar image repository |
-| searxChecker.tag | string | `"latest"` | searx-checker sidecar image tag |
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog

--- a/charts/stable/searx/README.md
+++ b/charts/stable/searx/README.md
@@ -103,6 +103,14 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [5.1.0]
+
+#### Changed
+
+- Removed searx-checker container from Helm chart because it's integrated into Searx.
+- Added the `caddy.noTls` option to disable automatic Let's Encrypt certificates for situations where Searx is running behind another Ingress controller that handles certificates.
+- Changed image tag to `1.0.0-211-968b2899`.
+
 ### [5.0.0]
 
 #### Changed

--- a/charts/stable/searx/README.md
+++ b/charts/stable/searx/README.md
@@ -1,6 +1,6 @@
 # searx
 
-![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Searx is a privacy-respecting, hackable metasearch engine
 
@@ -77,6 +77,7 @@ N/A
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| caddy.noTls | bool | `false` | caddy sidecar disable auto tls if behind another loadbalancer or ingress |
 | caddy.pullPolicy | string | `"IfNotPresent"` | caddy sidecar image pull policy |
 | caddy.repository | string | `"caddy"` | caddy sidecar image repository |
 | caddy.tag | string | `"2.2.0-alpine"` | caddy sidecar image tag |
@@ -85,7 +86,7 @@ N/A
 | filtron.tag | string | `"latest"` | filtron sidecar image tag |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"searx/searx"` | image repository |
-| image.tag | string | `"1.0.0"` | image tag |
+| image.tag | string | `"1.0.0-211-968b2899"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | morty.pullPolicy | string | `"Always"` | morty sidecar image pull policy |
 | morty.repository | string | `"dalf/morty"` | morty sidecar image repository |

--- a/charts/stable/searx/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/searx/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,15 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [5.1.0]
+
+#### Changed
+
+- Removed searx-checker container from Helm chart because it's integrated into Searx.
+- Added the `caddy.noTls` option to disable automatic Let's Encrypt certificates for situations where Searx is running behind another Ingress controller that handles certificates.
+- Changed image tag to `1.0.0-211-968b2899`.
+
+
 ### [5.0.0]
 
 #### Changed

--- a/charts/stable/searx/templates/common.yaml
+++ b/charts/stable/searx/templates/common.yaml
@@ -19,11 +19,6 @@ persistence:
       configMap:
         name: {{ printf "%v-config" (include "common.names.fullname" .) }}
 
-  searx-checker:
-    enabled: true
-    type: emptyDir
-    mountPath: "-"
-
 additionalContainers:
   caddy:
     name: caddy
@@ -36,18 +31,6 @@ additionalContainers:
     - name: searx-config
       mountPath: /etc/caddy/Caddyfile
       subPath: Caddyfile
-    - name: searx-checker
-      mountPath: /srv/searx-checker
-
-  searx-checker:
-    name: searx-checker
-    image: "{{ .Values.searxChecker.repository }}:{{ .Values.searxChecker.tag }}"
-    imagePullPolicy: {{ .Values.searxChecker.pullPolicy }}
-    args:
-      ["-cron", "-o", "html/data/status.json", "http://localhost:8080"]
-    volumeMounts:
-    - name: searx-checker
-      mountPath: /usr/local/searx-checker/html/data
 
   filtron:
     name: filtron

--- a/charts/stable/searx/templates/configmap.yaml
+++ b/charts/stable/searx/templates/configmap.yaml
@@ -10,7 +10,9 @@ data:
   Caddyfile: |-
     {
       admin off
+    {{- if .Values.caddy.noTls }}
       auto_https off
+    {{- end }}
     }
 
     :80 {

--- a/charts/stable/searx/templates/configmap.yaml
+++ b/charts/stable/searx/templates/configmap.yaml
@@ -10,35 +10,36 @@ data:
   Caddyfile: |-
     {
       admin off
+      auto_https off
     }
 
     :80 {
-      log {
+        log {
             output discard
-      }
+        }
 
-      @api {
+        @api {
             path /config
-        path /status
-      }
+            path /status
+        }
 
-      @static {
+        @static {
             path /static/*
-      }
+        }
 
-      @notstatic {
+        @notstatic {
             not path /static/*
-      }
+        }
 
-      @morty {
+        @morty {
             path /morty/*
-      }
+        }
 
-      @notmorty {
+        @notmorty {
             not path /morty/*
-      }
+        }
 
-      header {
+        header {
             # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
             Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
 
@@ -52,6 +53,9 @@ data:
             X-Frame-Options "SAMEORIGIN"
 
             # Disable some features
+            Permissions-Policy "accelerometer=();ambient-light-sensor=(); autoplay=();camera=();encrypted-media=();focus-without-user-activation=(); geolocation=();gyroscope=();magnetometer=();microphone=();midi=();payment=();picture-in-picture=(); speaker=();sync-xhr=();usb=();vr=()"
+
+            # Disable some features (legacy)
             Feature-Policy "accelerometer 'none';ambient-light-sensor 'none'; autoplay 'none';camera 'none';encrypted-media 'none';focus-without-user-activation 'none'; geolocation 'none';gyroscope 'none';magnetometer 'none';microphone 'none';midi 'none';payment 'none';picture-in-picture 'none'; speaker 'none';sync-xhr 'none';usb 'none';vr 'none'"
 
             # Referer
@@ -62,53 +66,52 @@ data:
 
             # Remove Server header
             -Server
-      }
+        }
 
-      header @api {
+        header @api {
             Access-Control-Allow-Methods "GET, OPTIONS"
             Access-Control-Allow-Origin  "*"
-      }
+        }
 
-      # Cache
-      header @static {
+        # Cache
+        header @static {
             # Cache
-        Cache-Control "public, max-age=31536000"
-        defer
-      }
+            Cache-Control "public, max-age=31536000"
+            defer
+        }
 
-      header @notstatic {
+        header @notstatic {
             # No Cache
             Cache-Control "no-cache, no-store"
             Pragma "no-cache"
-      }
+        }
 
-      # CSP (see http://content-security-policy.com/ )
-      header @morty {
-        Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; form-action 'self'; frame-ancestors 'self'; base-uri 'self'; img-src 'self' data:; font-src 'self'; frame-src 'self'"
-      }
+        # CSP (see http://content-security-policy.com/ )
+        header @morty {
+            Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; form-action 'self'; frame-ancestors 'self'; base-uri 'self'; img-src 'self' data:; font-src 'self'; frame-src 'self'"
+        }
 
-      header @notmorty {
+        header @notmorty {
             Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self' https://overpass-api.de; img-src 'self' data: https://*.tile.openstreetmap.org; frame-src https://www.youtube-nocookie.com https://player.vimeo.com https://www.dailymotion.com https://www.deezer.com https://www.mixcloud.com https://w.soundcloud.com https://embed.spotify.com"
         }
 
-      # Morty
-      handle @morty {
+        # Morty
+        handle @morty {
             reverse_proxy localhost:3000
-      }
+        }
 
-      # Filtron
-      handle {
+        # Filtron
+        handle {
             encode zstd gzip
 
             reverse_proxy localhost:4040 {
-                   header_up X-Forwarded-Port {http.request.port}
-                   header_up X-Forwarded-Proto {http.request.scheme}
-                   header_up X-Forwarded-TlsProto {tls_protocol}
-                   header_up X-Forwarded-TlsCipher {tls_cipher}
-                   header_up X-Forwarded-HttpsProto {proto}
+                header_up X-Forwarded-Port {http.request.port}
+                header_up X-Forwarded-Proto {http.request.scheme}
+                header_up X-Forwarded-TlsProto {tls_protocol}
+                header_up X-Forwarded-TlsCipher {tls_cipher}
+                header_up X-Forwarded-HttpsProto {proto}
             }
-      }
-
+        }
     }
   rules.json: |-
     [
@@ -231,7 +234,7 @@ data:
                     "aggregations": ["Header:X-Forwarded-For"],
                     "actions": [
                         {"name": "block",
-            "params": {"message": "Rate limit exceeded, try again later."}}
+                        "params": {"message": "Rate limit exceeded, try again later."}}
                     ]
                 },
                 {
@@ -253,7 +256,7 @@ data:
                     "actions": [
                         {"name": "block",
                         "params": {"message": "Rate limit exceeded, try again later."}}
-        ]
+                    ]
                 }
             ]
         }

--- a/charts/stable/searx/templates/configmap.yaml
+++ b/charts/stable/searx/templates/configmap.yaml
@@ -89,14 +89,7 @@ data:
 
       header @notmorty {
             Content-Security-Policy "upgrade-insecure-requests; default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; connect-src 'self' https://overpass-api.de; img-src 'self' data: https://*.tile.openstreetmap.org; frame-src https://www.youtube-nocookie.com https://player.vimeo.com https://www.dailymotion.com https://www.deezer.com https://www.mixcloud.com https://w.soundcloud.com https://embed.spotify.com"
-      }
-
-      # Searx-Checker
-      uri replace /status /searx-checker/status.json
-      handle /searx-checker/status.json {
-            root * /srv
-            file_server
-      }
+        }
 
       # Morty
       handle @morty {

--- a/charts/stable/searx/values.yaml
+++ b/charts/stable/searx/values.yaml
@@ -46,6 +46,8 @@ caddy:
   tag: 2.2.0-alpine
   # -- caddy sidecar image pull policy
   pullPolicy: IfNotPresent
+  # -- caddy sidecar disable auto tls if behind another loadbalancer or ingress
+  noTls: false
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml

--- a/charts/stable/searx/values.yaml
+++ b/charts/stable/searx/values.yaml
@@ -23,14 +23,6 @@ searx:
   # Example : `openssl rand -base64 24`
   mortyKey: "changeme"
 
-searxChecker:
-  # -- searx-checker sidecar image repository
-  repository: searx/searx-checker
-  # -- searx-checker sidecar image tag
-  tag: latest
-  # -- searx-checker sidecar image pull policy
-  pullPolicy: Always
-
 filtron:
   # -- filtron sidecar image repository
   repository: dalf/filtron

--- a/charts/stable/searx/values.yaml
+++ b/charts/stable/searx/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: searx/searx
   # -- image tag
-  tag: 1.0.0
+  tag: 1.0.0-211-968b2899
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Modify Helm chart to support the latest version of Searx.

**Benefits**

* Latest version support, should allow for easier updating.
* Reindented Caddyfile
* Added option to disable automatic TLS in Caddy when using another Ingress in front of Caddy (like Traefik)

**Possible drawbacks**

No real drawbacks.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
