### PR TITLE
[lidarr] refactor of exportarr sidecar and podmonitor

### DIFF
--- a/charts/stable/lidarr/Chart.yaml
+++ b/charts/stable/lidarr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.0.0.2226
+appVersion: v1.0.0.2255
 description: Looks and smells like Sonarr but made for music
 name: lidarr
-version: 11.0.0
+version: 12.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - lidarr

--- a/charts/stable/lidarr/README.md
+++ b/charts/stable/lidarr/README.md
@@ -78,16 +78,16 @@ N/A
 |-----|------|---------|-------------|
 | env | object | See below | environment variables. |
 | env.TZ | string | `"UTC"` | Set the container timezone |
-| exportarr.enabled | bool | See values.yaml | Enable and configure Exportarr sidecar and Prometheus podMonitor. |
-| exportarr.env.addMetrics | bool | `false` | Set to true to enable gathering of additional metrics (slow) |
-| exportarr.env.port | int | `32123` | metrics port |
-| exportarr.env.unknownItems | bool | `false` | Set to true to enable gathering unknown queue items |
-| exportarr.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
-| exportarr.image.repository | string | `"ghcr.io/onedr0p/exportarr"` | image repository |
-| exportarr.image.tag | string | `"v0.6.1"` | image tag |
-| exportarr.podMonitor.interval | string | `"3m"` |  |
-| exportarr.podMonitor.labels | object | `{}` |  |
-| exportarr.podMonitor.scrapeTimeout | string | `"1m"` |  |
+| exporter.enabled | bool | See values.yaml | Enable and configure Exportarr sidecar and Prometheus podMonitor. |
+| exporter.env.addMetrics | bool | `false` | Set to true to enable gathering of additional metrics (slow) |
+| exporter.env.port | int | `32123` | metrics port |
+| exporter.env.unknownItems | bool | `false` | Set to true to enable gathering unknown queue items |
+| exporter.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
+| exporter.image.repository | string | `"ghcr.io/onedr0p/exportarr"` | image repository |
+| exporter.image.tag | string | `"v0.6.1"` | image tag |
+| exporter.podMonitor.interval | string | `"3m"` |  |
+| exporter.podMonitor.labels | object | `{}` |  |
+| exporter.podMonitor.scrapeTimeout | string | `"1m"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"ghcr.io/k8s-at-home/lidarr"` | image repository |
 | image.tag | string | `"v1.0.0.2255"` | image tag |

--- a/charts/stable/lidarr/README.md
+++ b/charts/stable/lidarr/README.md
@@ -81,6 +81,7 @@ N/A
 | exportarr.enabled | bool | See values.yaml | Enable and configure Exportarr sidecar and Prometheus podMonitor. |
 | exportarr.env.addMetrics | bool | `false` | Set to true to enable gathering of additional metrics (slow) |
 | exportarr.env.port | int | `32123` | metrics port |
+| exportarr.env.unknownItems | bool | `false` | Set to true to enable gathering unknown queue items |
 | exportarr.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | exportarr.image.repository | string | `"ghcr.io/onedr0p/exportarr"` | image repository |
 | exportarr.image.tag | string | `"v0.6.1"` | image tag |

--- a/charts/stable/lidarr/README.md
+++ b/charts/stable/lidarr/README.md
@@ -79,9 +79,9 @@ N/A
 | env | object | See below | environment variables. |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | exporter.enabled | bool | See values.yaml | Enable and configure Exportarr sidecar and Prometheus podMonitor. |
-| exporter.env.addMetrics | bool | `false` | Set to true to enable gathering of additional metrics (slow) |
+| exporter.env.additionalMetrics | bool | `false` | Set to true to enable gathering of additional metrics (slow) |
 | exporter.env.port | int | `32123` | metrics port |
-| exporter.env.unknownItems | bool | `false` | Set to true to enable gathering unknown queue items |
+| exporter.env.unknownQueueItems | bool | `false` | Set to true to enable gathering unknown queue items |
 | exporter.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | exporter.image.repository | string | `"ghcr.io/onedr0p/exportarr"` | image repository |
 | exporter.image.tag | string | `"v0.6.1"` | image tag |

--- a/charts/stable/lidarr/README.md
+++ b/charts/stable/lidarr/README.md
@@ -1,6 +1,6 @@
 # lidarr
 
-![Version: 11.0.0](https://img.shields.io/badge/Version-11.0.0-informational?style=flat-square) ![AppVersion: v1.0.0.2226](https://img.shields.io/badge/AppVersion-v1.0.0.2226-informational?style=flat-square)
+![Version: 12.0.0](https://img.shields.io/badge/Version-12.0.0-informational?style=flat-square) ![AppVersion: v1.0.0.2255](https://img.shields.io/badge/AppVersion-v1.0.0.2255-informational?style=flat-square)
 
 Looks and smells like Sonarr but made for music
 
@@ -78,13 +78,21 @@ N/A
 |-----|------|---------|-------------|
 | env | object | See below | environment variables. |
 | env.TZ | string | `"UTC"` | Set the container timezone |
+| exportarr.enabled | bool | See values.yaml | Enable and configure Exportarr sidecar and Prometheus podMonitor. |
+| exportarr.env.addMetrics | bool | `false` | Set to true to enable gathering of additional metrics (slow) |
+| exportarr.env.port | int | `32123` | metrics port |
+| exportarr.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
+| exportarr.image.repository | string | `"ghcr.io/onedr0p/exportarr"` | image repository |
+| exportarr.image.tag | string | `"v0.6.1"` | image tag |
+| exportarr.podMonitor.interval | string | `"3m"` |  |
+| exportarr.podMonitor.labels | object | `{}` |  |
+| exportarr.podMonitor.scrapeTimeout | string | `"1m"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"ghcr.io/k8s-at-home/lidarr"` | image repository |
-| image.tag | string | `"v1.0.0.2226"` | image tag |
+| image.tag | string | `"v1.0.0.2255"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | probes | object | See values.yaml | Configures the probes for the main Pod. |
-| prometheus.podMonitor | object | See values.yaml | Enable and configure a Prometheus podMonitor for the chart under this key. See also the notes under `additionalContainers`. |
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog
@@ -92,6 +100,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [12.0.0]
+
+#### Changed
+
+- Refactoring of the Exportarr sidecar and Prometheus podMonitor. This is a breaking change if it was enabled previously.
 
 ### [11.0.0]
 
@@ -119,6 +133,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial version
 
+[12.0.0]: #1200
 [11.0.0]: #1100
 [10.0.0]: #1000
 [9.0.0]: #900

--- a/charts/stable/lidarr/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/lidarr/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [12.0.0]
+
+#### Changed
+
+- Refactoring of the Exportarr sidecar and Prometheus podMonitor. This is a breaking change if it was enabled previously.
+
 ### [11.0.0]
 
 #### Changed
@@ -35,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial version
 
+[12.0.0]: #1200
 [11.0.0]: #1100
 [10.0.0]: #1000
 [9.0.0]: #900

--- a/charts/stable/lidarr/ci/ct-exportarr-values.yaml
+++ b/charts/stable/lidarr/ci/ct-exportarr-values.yaml
@@ -7,7 +7,7 @@ persistence:
 additionalContainers:
   exportarr:
     name: exportarr
-    image: ghcr.io/onedr0p/exportarr:v0.6.0
+    image: ghcr.io/onedr0p/exportarr:v0.6.1
     imagePullPolicy: IfNotPresent
     args: ["exportarr", "lidarr"]
     env:

--- a/charts/stable/lidarr/templates/common.yaml
+++ b/charts/stable/lidarr/templates/common.yaml
@@ -25,9 +25,11 @@ additionalContainers:
       - name: metrics
         containerPort: {{ .Values.exporter.env.port }}
     volumeMounts:
+      {{ if .Values.persistence.config.enabled }}
       - name: config
         mountPath: /config
         readOnly: true
+      {{ end }}
 {{ end }}
 {{- end -}}
 {{- $_ := mergeOverwrite .Values (include "lidarr.harcodedValues" . | fromYaml) -}}

--- a/charts/stable/lidarr/templates/common.yaml
+++ b/charts/stable/lidarr/templates/common.yaml
@@ -1,1 +1,34 @@
+{{/* Make sure all variables are set properly */}}
+{{- include "common.values.setup" . }}
+
+{{/* Append the hardcoded settings */}}
+{{- define "exportarr.harcodedValues" -}}
+{{ if .Values.exportarr.enabled }}
+additionalContainers:
+  exportarr:
+    name: exportarr
+    image: "{{ .Values.exportarr.image.repository }}:{{ .Values.exportarr.image.tag }}"
+    imagePullPolicy: {{ .Values.exportarr.image.pullPolicy }}
+    args: ["exportarr", "lidarr"]
+    env:
+      - name: URL
+        value: "http://localhost"
+      - name: CONFIG
+        value: "/config/config.xml"
+      - name: PORT
+        value: "{{ .Values.exportarr.env.port }}"
+      - name: ENABLE_ADDITIONAL_METRICS
+        value: "{{ .Values.exportarr.env.addMetrics }}"
+    ports:
+      - name: metrics
+        containerPort: {{ .Values.exportarr.env.port }}
+    volumeMounts:
+      - name: config
+        mountPath: /config
+        readOnly: true
+{{ end }}
+{{- end -}}
+{{- $_ := mergeOverwrite .Values (include "exportarr.harcodedValues" . | fromYaml) -}}
+
+{{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/stable/lidarr/templates/common.yaml
+++ b/charts/stable/lidarr/templates/common.yaml
@@ -18,9 +18,9 @@ additionalContainers:
       - name: PORT
         value: "{{ .Values.exporter.env.port }}"
       - name: ENABLE_ADDITIONAL_METRICS
-        value: "{{ .Values.exporter.env.addMetrics }}"
+        value: "{{ .Values.exporter.env.additionalMetrics }}"
       - name: ENABLE_UNKNOWN_QUEUE_ITEMS
-        value: "{{ .Values.exporter.env.unknownItems }}"
+        value: "{{ .Values.exporter.env.unknownQueueItems }}"
     ports:
       - name: metrics
         containerPort: {{ .Values.exporter.env.port }}

--- a/charts/stable/lidarr/templates/common.yaml
+++ b/charts/stable/lidarr/templates/common.yaml
@@ -2,13 +2,13 @@
 {{- include "common.values.setup" . }}
 
 {{/* Append the hardcoded settings */}}
-{{- define "exportarr.harcodedValues" -}}
-{{ if .Values.exportarr.enabled }}
+{{- define "lidarr.harcodedValues" -}}
+{{ if .Values.exporter.enabled }}
 additionalContainers:
-  exportarr:
-    name: exportarr
-    image: "{{ .Values.exportarr.image.repository }}:{{ .Values.exportarr.image.tag }}"
-    imagePullPolicy: {{ .Values.exportarr.image.pullPolicy }}
+  exporter:
+    name: exporter
+    image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
+    imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
     args: ["exportarr", "lidarr"]
     env:
       - name: URL
@@ -16,21 +16,21 @@ additionalContainers:
       - name: CONFIG
         value: "/config/config.xml"
       - name: PORT
-        value: "{{ .Values.exportarr.env.port }}"
+        value: "{{ .Values.exporter.env.port }}"
       - name: ENABLE_ADDITIONAL_METRICS
-        value: "{{ .Values.exportarr.env.addMetrics }}"
+        value: "{{ .Values.exporter.env.addMetrics }}"
       - name: ENABLE_UNKNOWN_QUEUE_ITEMS
-        value: "{{ .Values.exportarr.env.unknownItems }}"
+        value: "{{ .Values.exporter.env.unknownItems }}"
     ports:
       - name: metrics
-        containerPort: {{ .Values.exportarr.env.port }}
+        containerPort: {{ .Values.exporter.env.port }}
     volumeMounts:
       - name: config
         mountPath: /config
         readOnly: true
 {{ end }}
 {{- end -}}
-{{- $_ := mergeOverwrite .Values (include "exportarr.harcodedValues" . | fromYaml) -}}
+{{- $_ := mergeOverwrite .Values (include "lidarr.harcodedValues" . | fromYaml) -}}
 
 {{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/stable/lidarr/templates/common.yaml
+++ b/charts/stable/lidarr/templates/common.yaml
@@ -19,6 +19,8 @@ additionalContainers:
         value: "{{ .Values.exportarr.env.port }}"
       - name: ENABLE_ADDITIONAL_METRICS
         value: "{{ .Values.exportarr.env.addMetrics }}"
+      - name: ENABLE_UNKNOWN_QUEUE_ITEMS
+        value: "{{ .Values.exportarr.env.unknownItems }}"
     ports:
       - name: metrics
         containerPort: {{ .Values.exportarr.env.port }}

--- a/charts/stable/lidarr/templates/podmonitor.yaml
+++ b/charts/stable/lidarr/templates/podmonitor.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.prometheus.podMonitor.enabled }}
+{{- if .Values.exportarr.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
-    {{- with .Values.prometheus.podMonitor.additionalLabels }}
+    {{- with .Values.exportarr.podMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -13,12 +13,17 @@ spec:
     matchLabels:
       {{- include "common.labels.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
-  - port: exportarr
-    {{- with .Values.prometheus.podMonitor.interval }}
-    interval: {{ . }}
-    {{- end }}
-    {{- with .Values.prometheus.podMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ . }}
-    {{- end }}
-    path: /metrics
+    - port: metrics
+      {{- with .Values.exportarr.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.exportarr.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics
+      relabelings:
+        - sourceLabels: ['namespace', 'job']
+          regex: ".+/(.*)"
+          targetLabel: "job"
+          replacement: "$1"
 {{- end }}

--- a/charts/stable/lidarr/templates/podmonitor.yaml
+++ b/charts/stable/lidarr/templates/podmonitor.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.exportarr.enabled }}
+{{- if .Values.exporter.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
-    {{- with .Values.exportarr.podMonitor.labels }}
+    {{- with .Values.exporter.podMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -14,10 +14,10 @@ spec:
       {{- include "common.labels.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
     - port: metrics
-      {{- with .Values.exportarr.podMonitor.interval }}
+      {{- with .Values.exporter.podMonitor.interval }}
       interval: {{ . }}
       {{- end }}
-      {{- with .Values.exportarr.podMonitor.scrapeTimeout }}
+      {{- with .Values.exporter.podMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
       path: /metrics

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/k8s-at-home/lidarr
   # -- image tag
-  tag: v1.0.0.2226
+  tag: v1.0.0.2255
   # -- image pull policy
   pullPolicy: IfNotPresent
 
@@ -66,35 +66,23 @@ persistence:
     enabled: false
     mountPath: /media
 
-prometheus:
-  # -- Enable and configure a Prometheus podMonitor for the chart under this key.
-  # See also the notes under `additionalContainers`.
+exportarr:
+  # -- Enable and configure Exportarr sidecar and Prometheus podMonitor.
   # @default -- See values.yaml
+  enabled: false
   podMonitor:
-    enabled: false
     interval: 3m
     scrapeTimeout: 1m
-    additionalLabels: {}
-
-# # When using the prometheus.podMonitor the following
-# # container is required
-# additionalContainers:
-#   exportarr:
-#     name: exportarr
-#     image: ghcr.io/onedr0p/exportarr:v0.6.0
-#     imagePullPolicy: IfNotPresent
-#     args: ["exportarr", "lidarr"]
-#     env:
-#     - name: PORT
-#       value: "32123"
-#     - name: URL
-#       value: "http://localhost"
-#     - name: CONFIG
-#       value: "/config/config.xml"
-#     ports:
-#     - name: exportarr
-#       containerPort: 32123
-#     volumeMounts:
-#     - name: config
-#       mountPath: /config
-#       readOnly: true
+    labels: {}
+  image:
+    # -- image repository
+    repository: ghcr.io/onedr0p/exportarr
+    # -- image tag
+    tag: v0.6.1
+    # -- image pull policy
+    pullPolicy: IfNotPresent
+  env:
+    # -- metrics port
+    port: 32123
+    # -- Set to true to enable gathering of additional metrics (slow)
+    addMetrics: false

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -85,6 +85,6 @@ exporter:
     # -- metrics port
     port: 32123
     # -- Set to true to enable gathering of additional metrics (slow)
-    addMetrics: false
+    additionalMetrics: false
     # -- Set to true to enable gathering unknown queue items
-    unknownItems: false
+    unknownQueueItems: false

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -86,3 +86,5 @@ exportarr:
     port: 32123
     # -- Set to true to enable gathering of additional metrics (slow)
     addMetrics: false
+    # -- Set to true to enable gathering unknown queue items
+    unknownItems: false

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -66,7 +66,7 @@ persistence:
     enabled: false
     mountPath: /media
 
-exportarr:
+exporter:
   # -- Enable and configure Exportarr sidecar and Prometheus podMonitor.
   # @default -- See values.yaml
   enabled: false


### PR DESCRIPTION
If these changes look good I'll update sonarr and radarr as well.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
