### PR TITLE
[lidarr] version bump

### DIFF
--- a/charts/stable/lidarr/Chart.yaml
+++ b/charts/stable/lidarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.0.0.2255
 description: Looks and smells like Sonarr but made for music
 name: lidarr
-version: 12.0.0
+version: 12.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - lidarr

--- a/charts/stable/lidarr/README.md
+++ b/charts/stable/lidarr/README.md
@@ -1,6 +1,6 @@
 # lidarr
 
-![Version: 12.0.0](https://img.shields.io/badge/Version-12.0.0-informational?style=flat-square) ![AppVersion: v1.0.0.2255](https://img.shields.io/badge/AppVersion-v1.0.0.2255-informational?style=flat-square)
+![Version: 12.0.1](https://img.shields.io/badge/Version-12.0.1-informational?style=flat-square) ![AppVersion: v1.0.0.2255](https://img.shields.io/badge/AppVersion-v1.0.0.2255-informational?style=flat-square)
 
 Looks and smells like Sonarr but made for music
 


### PR DESCRIPTION
Just a version to give it a little kickstart. The GitHub release was generated for 12.0.0, but never landed in the index.yaml. 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
