### PR TITLE
[speedtest-exporter] metrics consistency

### DIFF
--- a/charts/stable/network-ups-tools/Chart.yaml
+++ b/charts/stable/network-ups-tools/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.7.4-2474-gb4a58380
+appVersion: v2.7.4-2479-g86a32237
 description: Network UPS Tools is a collection of programs which provide a common interface for monitoring and administering UPS, PDU and SCD hardware.
 name: network-ups-tools
-version: 5.0.0
+version: 5.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - nut

--- a/charts/stable/network-ups-tools/README.md
+++ b/charts/stable/network-ups-tools/README.md
@@ -1,6 +1,6 @@
 # network-ups-tools
 
-![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![AppVersion: v2.7.4-2474-gb4a58380](https://img.shields.io/badge/AppVersion-v2.7.4--2474--gb4a58380-informational?style=flat-square)
+![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![AppVersion: v2.7.4-2479-g86a32237](https://img.shields.io/badge/AppVersion-v2.7.4--2479--g86a32237-informational?style=flat-square)
 
 Network UPS Tools is a collection of programs which provide a common interface for monitoring and administering UPS, PDU and SCD hardware.
 
@@ -79,10 +79,23 @@ N/A
 | config.mode | string | `"values"` | If set to 'values', the configuration will be read from these values. Otherwise you have to mount a volume to /etc/nut containing the configuration files. |
 | env | object | See below | environment variables. |
 | env.TZ | string | `"UTC"` | Set the container timezone |
+| exporter.enabled | bool | See values.yaml | Enable and configure prometheus-nut-exporter sidecar and Prometheus serviceMonitor. |
+| exporter.env.logLevel | string | `"info"` | log level [info|debug|trace] |
+| exporter.env.port | int | `9995` | metrics port |
+| exporter.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
+| exporter.image.repository | string | `"hon95/prometheus-nut-exporter"` | image repository |
+| exporter.image.tag | string | `"1.1.1"` | image tag |
+| exporter.serviceMonitor.interval | string | `"30s"` |  |
+| exporter.serviceMonitor.labels | object | `{}` |  |
+| exporter.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"ghcr.io/k8s-at-home/network-ups-tools"` | image repository |
-| image.tag | string | `"v2.7.4-2474-gb4a58380"` | image tag |
+| image.tag | string | `"v2.7.4-2479-g86a32237"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
+| persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
+| persistence.ups.hostPath | string | `"/dev/bus/usb/001/001"` | The path of the usb ups on the host.  |
+| persistence.ups.mountPath | string | `"/dev/bus/usb/001/001"` | Optional path for ups to mount in the container.  |
+| securityContext | object | See values.yaml | Set to true if using ups connected by usb to the host |
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog
@@ -90,6 +103,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [5.1.0]
+
+### Added
+
+- Added podMonitor and the ability to use [prometheus-nut-exporter](https://github.com/HON95/prometheus-nut-exporter) as a sidecar container.
 
 ### [5.0.0]
 
@@ -112,6 +131,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial version
 
+[5.1.0]: #510
 [5.0.0]: #500
 [4.0.0]: #400
 [1.0.0]: #100

--- a/charts/stable/network-ups-tools/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/network-ups-tools/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [5.1.0]
+
+### Added
+
+- Added podMonitor and the ability to use [prometheus-nut-exporter](https://github.com/HON95/prometheus-nut-exporter) as a sidecar container.
+
 ### [5.0.0]
 
 #### Changed
@@ -30,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Initial version
 
+[5.1.0]: #510
 [5.0.0]: #500
 [4.0.0]: #400
 [1.0.0]: #100

--- a/charts/stable/network-ups-tools/templates/common.yaml
+++ b/charts/stable/network-ups-tools/templates/common.yaml
@@ -14,10 +14,35 @@ persistence:
         name: {{ printf "%v-config" (include "common.names.fullname" .) }}
         defaultMode: 256
         optional: true
+
+{{ if .Values.exporter.enabled }}
+additionalContainers:
+  exporter:
+    name: exporter
+    image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
+    imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
+    env:
+      - name: HTTP_PORT
+        value: "{{ .Values.exporter.env.port }}"
+      - name: HTTP_PATH
+        value: "/metrics"
+      - name: RUST_LOG
+        value: "{{ .Values.exporter.env.logLevel }}"
+    ports:
+      - name: metrics
+        containerPort: {{ .Values.exporter.env.port }}
+
+service:
+  metrics:
+    enabled: true
+    ports:
+      metrics:
+        enabled: true
+        protocol: TCP
+        port: {{ .Values.exporter.env.port }}
+{{ end }}
 {{- end -}}
-{{- if eq .Values.config.mode "values" -}}
-  {{- $_ := mergeOverwrite .Values (include "network-ups-tools.harcodedValues" . | fromYaml) -}}
-{{- end -}}
+{{- $_ := mergeOverwrite .Values (include "network-ups-tools.harcodedValues" . | fromYaml) -}}
 
 {{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/stable/network-ups-tools/templates/servicemonitor.yaml
+++ b/charts/stable/network-ups-tools/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.exporter.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.exporter.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "common.labels.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      {{- with .Values.exporter.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.exporter.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics
+      params:
+        target:
+          - "localhost:{{ .Values.service.main.ports.server.port }}"
+      relabelings:
+        - sourceLabels: [__param_target]
+          targetLabel: target
+{{- end }}

--- a/charts/stable/network-ups-tools/values.yaml
+++ b/charts/stable/network-ups-tools/values.yaml
@@ -43,9 +43,9 @@ persistence:
   ups:
     enabled: false
     type: hostPath
-    # -- The path of the usb ups on the host. 
+    # -- The path of the usb ups on the host.
     hostPath: /dev/bus/usb/001/001
-    # -- Optional path for ups to mount in the container. 
+    # -- Optional path for ups to mount in the container.
     mountPath: /dev/bus/usb/001/001
     readOnly: false
 

--- a/charts/stable/network-ups-tools/values.yaml
+++ b/charts/stable/network-ups-tools/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/k8s-at-home/network-ups-tools
   # -- image tag
-  tag: v2.7.4-2474-gb4a58380
+  tag: v2.7.4-2479-g86a32237
   # -- image pull policy
   pullPolicy: IfNotPresent
 
@@ -37,6 +37,23 @@ ingress:
   main:
     enabled: false
 
+# -- Configure persistence settings for the chart under this key.
+# @default -- See values.yaml
+persistence:
+  ups:
+    enabled: false
+    type: hostPath
+    # -- The path of the usb ups on the host. 
+    hostPath: /dev/bus/usb/001/001
+    # -- Optional path for ups to mount in the container. 
+    mountPath: /dev/bus/usb/001/001
+    readOnly: false
+
+# -- Set to true if using ups connected by usb to the host
+# @default -- See values.yaml
+securityContext:
+  privileged: false
+
 config:
   # -- If set to 'values', the configuration will be read from these values.
   # Otherwise you have to mount a volume to /etc/nut containing the configuration files.
@@ -56,3 +73,24 @@ config:
         driver = dummy-ups
         port = dummy-ups.dev
         desc = "dummy-ups in dummy mode"
+
+exporter:
+  # -- Enable and configure prometheus-nut-exporter sidecar and Prometheus serviceMonitor.
+  # @default -- See values.yaml
+  enabled: false
+  serviceMonitor:
+    interval: 30s
+    scrapeTimeout: 10s
+    labels: {}
+  image:
+    # -- image repository
+    repository: hon95/prometheus-nut-exporter
+    # -- image tag
+    tag: 1.1.1
+    # -- image pull policy
+    pullPolicy: IfNotPresent
+  env:
+    # -- metrics port
+    port: 9995
+    # -- log level [info|debug|trace]
+    logLevel: info

--- a/charts/stable/prometheus-nut-exporter/Chart.yaml
+++ b/charts/stable/prometheus-nut-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.1
 description: Prometheus NUT Exporter a service monitor to send NUT server metrics to a Prometheus instance.
 name: prometheus-nut-exporter
-version: 4.0.0
+version: 4.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - nut

--- a/charts/stable/prometheus-nut-exporter/README.md
+++ b/charts/stable/prometheus-nut-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-nut-exporter
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 
 Prometheus NUT Exporter a service monitor to send NUT server metrics to a Prometheus instance.
 
@@ -76,6 +76,7 @@ N/A
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | env | object | See below | environment variables. See [application docs](https://github.com/HON95/prometheus-nut-exporter#environment-variables) for more details. |
+| env.RUST_LOG | string | `"info"` | log level [info|debug|trace]  |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"hon95/prometheus-nut-exporter"` | image repository |

--- a/charts/stable/prometheus-nut-exporter/templates/common.yaml
+++ b/charts/stable/prometheus-nut-exporter/templates/common.yaml
@@ -1,1 +1,13 @@
+{{/* Make sure all variables are set properly */}}
+{{- include "common.values.setup" . }}
+
+{{/* Append the hardcoded settings */}}
+{{- define "prometheus-nut-exporter.harcodedValues" -}}
+env:
+  HTTP_PATH: "/metrics"
+  HTTP_PORT: "{{ .Values.service.main.ports.metrics.port }}"
+{{- end -}}
+{{- $_ := mergeOverwrite .Values (include "prometheus-nut-exporter.harcodedValues" . | fromYaml) -}}
+
+{{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/stable/prometheus-nut-exporter/templates/servicemonitor.yaml
+++ b/charts/stable/prometheus-nut-exporter/templates/servicemonitor.yaml
@@ -14,10 +14,10 @@ spec:
       {{- include "common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
   {{- range .Values.prometheus.serviceMonitor.targets }}
-  - port: http
+  - port: metrics
     interval: {{ .interval }}
     scrapeTimeout: {{ .scrapeTimeout }}
-    path: /nut
+    path: /metrics
     params:
       target:
       - "{{ .hostname }}:{{ .port }}"

--- a/charts/stable/prometheus-nut-exporter/values.yaml
+++ b/charts/stable/prometheus-nut-exporter/values.yaml
@@ -18,6 +18,8 @@ image:
 env:
   # -- Set the container timezone
   TZ: UTC
+  # -- log level [info|debug|trace] 
+  RUST_LOG: info
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml
@@ -25,6 +27,10 @@ service:
   main:
     ports:
       http:
+        enabled: false
+      metrics:
+        enabled: true
+        protocol: TCP
         port: 9995
 
 prometheus:

--- a/charts/stable/speedtest-exporter/Chart.yaml
+++ b/charts/stable/speedtest-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v3.2.2
 description: Speedtest Exporter made in python using the official speedtest bin
 name: speedtest-exporter
-version: 4.0.0
+version: 4.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - speedtest-exporter

--- a/charts/stable/speedtest-exporter/README.md
+++ b/charts/stable/speedtest-exporter/README.md
@@ -1,6 +1,6 @@
 # speedtest-exporter
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: v3.2.2](https://img.shields.io/badge/AppVersion-v3.2.2-informational?style=flat-square)
+![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![AppVersion: v3.2.2](https://img.shields.io/badge/AppVersion-v3.2.2-informational?style=flat-square)
 
 Speedtest Exporter made in python using the official speedtest bin
 

--- a/charts/stable/speedtest-exporter/templates/servicemonitor.yaml
+++ b/charts/stable/speedtest-exporter/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       {{- include "common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
-    - port: http
+    - port: metrics
       {{- with .Values.prometheus.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/charts/stable/speedtest-exporter/values.yaml
+++ b/charts/stable/speedtest-exporter/values.yaml
@@ -25,6 +25,10 @@ service:
   main:
     ports:
       http:
+        enabled: false
+      metrics:
+        enabled: true
+        protocol: TCP
         port: 9798
 
 prometheus:


### PR DESCRIPTION
Just bringing some consistency here with metrics port names

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
