### PR TITLE
[speedtest-exporter] metrics consistency

### DIFF
--- a/charts/stable/speedtest-exporter/Chart.yaml
+++ b/charts/stable/speedtest-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v3.2.2
 description: Speedtest Exporter made in python using the official speedtest bin
 name: speedtest-exporter
-version: 4.0.0
+version: 4.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - speedtest-exporter

--- a/charts/stable/speedtest-exporter/README.md
+++ b/charts/stable/speedtest-exporter/README.md
@@ -1,6 +1,6 @@
 # speedtest-exporter
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: v3.2.2](https://img.shields.io/badge/AppVersion-v3.2.2-informational?style=flat-square)
+![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![AppVersion: v3.2.2](https://img.shields.io/badge/AppVersion-v3.2.2-informational?style=flat-square)
 
 Speedtest Exporter made in python using the official speedtest bin
 

--- a/charts/stable/speedtest-exporter/templates/servicemonitor.yaml
+++ b/charts/stable/speedtest-exporter/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       {{- include "common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
-    - port: http
+    - port: metrics
       {{- with .Values.prometheus.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/charts/stable/speedtest-exporter/values.yaml
+++ b/charts/stable/speedtest-exporter/values.yaml
@@ -25,6 +25,10 @@ service:
   main:
     ports:
       http:
+        enabled: false
+      metrics:
+        enabled: true
+        protocol: TCP
         port: 9798
 
 prometheus:


### PR DESCRIPTION
Just bringing some consistency with metrics ports

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
