### PR TITLE
[home-assistant] update hass documentation for running behind a reverse proxy

### DIFF
--- a/charts/stable/home-assistant/Chart.yaml
+++ b/charts/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2021.6.3
 description: Home Assistant
 name: home-assistant
-version: 10.1.0
+version: 10.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - home-assistant

--- a/charts/stable/home-assistant/README.md
+++ b/charts/stable/home-assistant/README.md
@@ -1,6 +1,6 @@
 # home-assistant
 
-![Version: 10.1.0](https://img.shields.io/badge/Version-10.1.0-informational?style=flat-square) ![AppVersion: 2021.6.3](https://img.shields.io/badge/AppVersion-2021.6.3-informational?style=flat-square)
+![Version: 10.1.1](https://img.shields.io/badge/Version-10.1.1-informational?style=flat-square) ![AppVersion: 2021.6.3](https://img.shields.io/badge/AppVersion-2021.6.3-informational?style=flat-square)
 
 Home Assistant
 
@@ -71,6 +71,25 @@ helm install home-assistant k8s-at-home/home-assistant -f values.yaml
 ```
 
 ## Custom configuration
+
+### HTTP 400 bad request while accessing from your browser
+
+When configuring Home Assistant behind a reverse proxy make sure you configure the [http](https://www.home-assistant.io/integrations/http) component and set `trusted_proxies` correctly and `use_x_forwarded_for` to `true`.
+
+For example:
+
+```yaml
+http:
+  server_host: 0.0.0.0
+  ip_ban_enabled: true
+  login_attempts_threshold: 5
+  use_x_forwarded_for: true
+  trusted_proxies:
+  # Pod CIDR
+  - 10.69.0.0/16
+  # Node CIDR
+  - 192.168.42.0/24
+```
 
 ### Z-Wave / Zigbee
 

--- a/charts/stable/home-assistant/README_CONFIG.md.gotmpl
+++ b/charts/stable/home-assistant/README_CONFIG.md.gotmpl
@@ -5,6 +5,25 @@
 {{- define "custom.custom.configuration" -}}
 {{ template "custom.custom.configuration.header" . }}
 
+### HTTP 400 bad request while accessing from your browser
+
+When configuring Home Assistant behind a reverse proxy make sure you configure the [http](https://www.home-assistant.io/integrations/http) component and set `trusted_proxies` correctly and `use_x_forwarded_for` to `true`.
+
+For example:
+
+```yaml
+http:
+  server_host: 0.0.0.0
+  ip_ban_enabled: true
+  login_attempts_threshold: 5
+  use_x_forwarded_for: true
+  trusted_proxies:
+  # Pod CIDR
+  - 10.69.0.0/16
+  # Node CIDR
+  - 192.168.42.0/24
+```
+
 ### Z-Wave / Zigbee
 
 A Z-Wave and/or Zigbee controller device could be used with Home Assistant if passed through from the host to the pod. Skip this section if you are using zwave2mqtt and/or zigbee2mqtt or plan to.


### PR DESCRIPTION

**Description of the change**

update hass documentation for running behind a reverse proxy

**Benefits**

explain to ppl how to make hass work behind a reverse proxy

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1146

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
