### PR TITLE
[speedtest-exporter] fix rules

### DIFF
--- a/charts/stable/speedtest-exporter/Chart.yaml
+++ b/charts/stable/speedtest-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v3.2.2
 description: Speedtest Exporter made in python using the official speedtest bin
 name: speedtest-exporter
-version: 5.0.0
+version: 5.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - speedtest-exporter

--- a/charts/stable/speedtest-exporter/README.md
+++ b/charts/stable/speedtest-exporter/README.md
@@ -84,10 +84,10 @@ N/A
 | metrics.prometheusRule | object | See values.yaml | Enable and configure Prometheus Rules for the chart under this key. |
 | metrics.prometheusRule.downloadLimit | int | `400` | Download speed you want alerts to be triggered in Mbps |
 | metrics.prometheusRule.jitterLimit | int | `30` | Jitter latency you want alerts to be triggered in ms |
-| metrics.prometheusRule.pingLimit | int | `15` | Ping latency you want alerts to be triggered in ms |
+| metrics.prometheusRule.pingLimit | int | `10` | Ping latency you want alerts to be triggered in ms |
 | metrics.prometheusRule.rules | list | See prometheusrules.yaml | Configure additionial rules for the chart under this key. |
 | metrics.prometheusRule.uploadLimit | int | `400` | Upload speed you want alerts to be triggered in Mbps |
-| metrics.serviceMonitor.interval | string | `"60m"` | The interval field must use minutes for the padding to calculate properly.  |
+| metrics.serviceMonitor.interval | string | `"60m"` | The interval field must use minutes for the padding to calculate properly. |
 | metrics.serviceMonitor.labels | object | `{}` |  |
 | metrics.serviceMonitor.scrapeTimeout | string | `"1m"` |  |
 | service | object | See values.yaml | Configures service settings for the chart. |

--- a/charts/stable/speedtest-exporter/README.md
+++ b/charts/stable/speedtest-exporter/README.md
@@ -1,6 +1,6 @@
 # speedtest-exporter
 
-![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![AppVersion: v3.2.2](https://img.shields.io/badge/AppVersion-v3.2.2-informational?style=flat-square)
+![Version: 5.0.1](https://img.shields.io/badge/Version-5.0.1-informational?style=flat-square) ![AppVersion: v3.2.2](https://img.shields.io/badge/AppVersion-v3.2.2-informational?style=flat-square)
 
 Speedtest Exporter made in python using the official speedtest bin
 
@@ -84,10 +84,10 @@ N/A
 | metrics.prometheusRule | object | See values.yaml | Enable and configure Prometheus Rules for the chart under this key. |
 | metrics.prometheusRule.downloadLimit | int | `400` | Download speed you want alerts to be triggered in Mbps |
 | metrics.prometheusRule.jitterLimit | int | `30` | Jitter latency you want alerts to be triggered in ms |
-| metrics.prometheusRule.pingLimit | int | `10` | Ping latency you want alerts to be triggered in ms |
+| metrics.prometheusRule.pingLimit | int | `15` | Ping latency you want alerts to be triggered in ms |
 | metrics.prometheusRule.rules | list | See prometheusrules.yaml | Configure additionial rules for the chart under this key. |
 | metrics.prometheusRule.uploadLimit | int | `400` | Upload speed you want alerts to be triggered in Mbps |
-| metrics.serviceMonitor.interval | string | `"1h"` |  |
+| metrics.serviceMonitor.interval | string | `"60m"` | The interval field must use minutes for the padding to calculate properly.  |
 | metrics.serviceMonitor.labels | object | `{}` |  |
 | metrics.serviceMonitor.scrapeTimeout | string | `"1m"` |  |
 | service | object | See values.yaml | Configures service settings for the chart. |

--- a/charts/stable/speedtest-exporter/templates/prometheusrules.yaml
+++ b/charts/stable/speedtest-exporter/templates/prometheusrules.yaml
@@ -18,7 +18,7 @@ spec:
             summary: Speedtest Exporter is down.
           expr: |
             absent(up{job=~".*{{ include "common.names.fullname" . }}.*"} == 1)
-          for: {{ .Values.metrics.serviceMonitor.interval }}
+          for: {{ trimAll "m" .Values.metrics.serviceMonitor.interval | add 15 }}m
           labels:
             severity: critical
         - alert: SpeedtestSlowInternetDownload
@@ -26,7 +26,7 @@ spec:
             description: Internet download speed is averaging {{ "{{ humanize $value }}" }} Mbps.
             summary: SpeedTest slow internet download.
           expr: |
-            avg_over_time(speedtest_download{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
+            avg_over_time(speedtest_download_bits_per_second{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
               < {{ .Values.metrics.prometheusRule.downloadLimit }}
           for: 0m
           labels:
@@ -36,7 +36,7 @@ spec:
             description: Internet upload speed is averaging {{ "{{ humanize $value }}" }} Mbps.
             summary: SpeedTest slow internet upload.
           expr: |
-            avg_over_time(speedtest_upload{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
+            avg_over_time(speedtest_upload_bits_per_second{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
               < {{ .Values.metrics.prometheusRule.uploadLimit }}
           for: 0m
           labels:
@@ -46,7 +46,7 @@ spec:
             description: Internet ping latency is averaging {{ "{{ humanize $value }}" }} ms.
             summary: SpeedTest high ping latency.
           expr: |
-            avg_over_time(speedtest_ping_latency_milliseconds{job=~".*{{ include "common.names.fullname" . }}.*"}[2h])
+            avg_over_time(speedtest_ping_latency_milliseconds{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
               > {{ .Values.metrics.prometheusRule.pingLimit }}
           for: 0m
           labels:
@@ -56,7 +56,7 @@ spec:
             description: Internet jitter latency is averaging {{ "{{ humanize $value }}" }} ms.
             summary: SpeedTest high jitter latency.
           expr: |
-            avg_over_time(speedtest_jitter_latency_milliseconds{job=~".*{{ include "common.names.fullname" . }}.*"}[2h])
+            avg_over_time(speedtest_jitter_latency_milliseconds{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
               > {{ .Values.metrics.prometheusRule.jitterLimit }}
           for: 0m
           labels:

--- a/charts/stable/speedtest-exporter/values.yaml
+++ b/charts/stable/speedtest-exporter/values.yaml
@@ -34,7 +34,7 @@ service:
 metrics:
   # -- Enable and configure a Prometheus serviceMonitor for the chart under this key.
   # @default -- See values.yaml
-  enabled: true
+  enabled: false
   serviceMonitor:
     # -- The interval field must use minutes for the padding to calculate properly.
     interval: 60m
@@ -43,13 +43,13 @@ metrics:
   # -- Enable and configure Prometheus Rules for the chart under this key.
   # @default -- See values.yaml
   prometheusRule:
-    enabled: true
+    enabled: false
     # -- Download speed you want alerts to be triggered in Mbps
     downloadLimit: 400
     # -- Upload speed you want alerts to be triggered in Mbps
     uploadLimit: 400
     # -- Ping latency you want alerts to be triggered in ms
-    pingLimit: 15
+    pingLimit: 10
     # -- Jitter latency you want alerts to be triggered in ms
     jitterLimit: 30
     labels: {}

--- a/charts/stable/speedtest-exporter/values.yaml
+++ b/charts/stable/speedtest-exporter/values.yaml
@@ -34,21 +34,22 @@ service:
 metrics:
   # -- Enable and configure a Prometheus serviceMonitor for the chart under this key.
   # @default -- See values.yaml
-  enabled: false
+  enabled: true
   serviceMonitor:
-    interval: 1h
+    # -- The interval field must use minutes for the padding to calculate properly.
+    interval: 60m
     scrapeTimeout: 1m
     labels: {}
   # -- Enable and configure Prometheus Rules for the chart under this key.
   # @default -- See values.yaml
   prometheusRule:
-    enabled: false
+    enabled: true
     # -- Download speed you want alerts to be triggered in Mbps
     downloadLimit: 400
     # -- Upload speed you want alerts to be triggered in Mbps
     uploadLimit: 400
     # -- Ping latency you want alerts to be triggered in ms
-    pingLimit: 10
+    pingLimit: 15
     # -- Jitter latency you want alerts to be triggered in ms
     jitterLimit: 30
     labels: {}
@@ -57,11 +58,11 @@ metrics:
     rules: []
       # - alert: SpeedtestSlowInternetDownload
       #   annotations:
-      #     description: Internet download speed is averaging {{ humanize $value }} Mbps.
+      #     description: Internet download speed is averaging {{ "{{ humanize $value }}" }} Mbps.
       #     summary: SpeedTest slow internet download.
       #   expr: |
-      #     avg_over_time(speedtest_download[4h])
-      #       < 420
+      #     avg_over_time(speedtest_download_bits_per_second{job=~".*{{ include "common.names.fullname" . }}.*"}[4h])
+      #       < {{ .Values.metrics.prometheusRule.downloadLimit }}
       #   for: 0m
       #   labels:
       #     severity: warning


### PR DESCRIPTION
this should be the last

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
