### PR TITLE
[onedrive] Move to v2.0.1 of custom docker image

### DIFF
--- a/charts/stable/onedrive/Chart.yaml
+++ b/charts/stable/onedrive/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.12
 description: A free Microsoft OneDrive Client which supports OneDrive Personal, OneDrive for Business, OneDrive for Office365, and SharePoint
 name: onedrive
-version: 1.1.0
+version: 2.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - onedrive

--- a/charts/stable/onedrive/README.md
+++ b/charts/stable/onedrive/README.md
@@ -1,6 +1,6 @@
 # onedrive
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: v2.4.12](https://img.shields.io/badge/AppVersion-v2.4.12-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: v2.4.12](https://img.shields.io/badge/AppVersion-v2.4.12-informational?style=flat-square)
 
 A free Microsoft OneDrive Client which supports OneDrive Personal, OneDrive for Business, OneDrive for Office365, and SharePoint
 
@@ -67,13 +67,13 @@ helm install onedrive k8s-at-home/onedrive -f values.yaml
 
 ## Custom configuration
 
-To use this chart, you will need to set an application_id in the `config` section as well as a secret (called `onedrive-auth` by default) with a field called `auth-response` that has the value derrived from the process below.
+To use this chart you will need to provide an authentication response from Microsoft for the client to use. This is provided as an environment variable like the claim token is for the plex chart.
 
-In order to generate an auth-response value you must do the following:
+In order to generate an authentication response value you must do the following:
 
-1. Visit the following URL: `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=d50ca740-c83f-4d1b-b616-12c519384f0c&scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.ReadWrite.All%20offline_access&response_type=code&redirect_uri=https://login.microsoftonline.com/common/oauth2/nativeclient`
-2. Authenticate with your OneDrive account.
-3. Copy the URL when you arrive at the blank page (should look like this: `https://login.microsoftonline.com/common/oauth2/nativeclient?code=<redacted>`) and use that as the `auth-reponse` value in the previously mentioned secret `onedrive-auth`.
+1. Visit the following URL: [Authenticate for OneDrive](https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=d50ca740-c83f-4d1b-b616-12c519384f0c&scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.ReadWrite.All%20offline_access&response_type=code&redirect_uri=https://login.microsoftonline.com/common/oauth2/nativeclient)
+2. Follow the prompts to login and get your token URL.
+3. Copy the URL when you arrive at the blank page (should look like this: `https://login.microsoftonline.com/common/oauth2/nativeclient?code=<redacted>`) and provide it to the chart through the `ONEDRIVE_AUTHRESPONSE` environment variable, preferrably secured through some secret.
 
 ## Values
 
@@ -81,17 +81,15 @@ In order to generate an auth-response value you must do the following:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| auth | object | See values.yaml | Configure auth secret for onedrive to initialize with |
 | config | string | `"# Configuration for OneDrive Linux Client\n# This file contains the list of supported configuration fields\n# with their default values.\n# All values need to be enclosed in quotes\n# When changing a config option below, remove the '#' from the start of the line\n# For explanations of all config options below see docs/USAGE.md or the man page.\n#\n# sync_dir = \"/onedrive/data\"\n# skip_file = \"~*|.~*|*.tmp\"\n# monitor_interval = \"300\"\n# skip_dir = \"\"\n# log_dir = \"/var/log/onedrive/\"\n# drive_id = \"\"\n# upload_only = \"false\"\n# check_nomount = \"false\"\n# check_nosync = \"false\"\n# download_only = \"false\"\n# disable_notifications = \"false\"\n# disable_upload_validation = \"false\"\n# enable_logging = \"false\"\n# force_http_2 = \"false\"\n# local_first = \"false\"\n# no_remote_delete = \"false\"\n# skip_symlinks = \"false\"\n# debug_https = \"false\"\n# skip_dotfiles = \"false\"\n# dry_run = \"false\"\n# min_notify_changes = \"5\"\n# monitor_log_frequency = \"5\"\n# monitor_fullscan_frequency = \"10\"\n# sync_root_files = \"false\"\n# classify_as_big_delete = \"1000\"\n# user_agent = \"\"\n# remove_source_files = \"false\"\n# skip_dir_strict_match = \"false\"\napplication_id = \"d50ca740-c83f-4d1b-b616-12c519384f0c\"\n# resync = \"false\"\n# bypass_data_preservation = \"false\"\n# azure_ad_endpoint = \"\"\n# azure_tenant_id = \"common\"\n# sync_business_shared_folders = \"false\"\n# sync_dir_permissions = \"700\"\n# sync_file_permissions = \"600\"\n# rate_limit = \"131072\"\n"` |  |
 | env | object | See below and commented variables in values.yaml | environment variables. |
-| env.KAH_HELM_INSTALL | int | `1` | Indicate to container to run K8s specific setup |
-| env.ONEDRIVE_AUTHFILES | string | `"/onedrive/conf/auth-request:/onedrive/conf/auth-response"` | Set the auth request and response file locations for OneDrive |
+| env.ONEDRIVE_AUTHRESPONSE | string | `""` | Set the One Drive Authentication Response |
 | env.ONEDRIVE_GID | int | `1000` | Set the One Drive Group ID |
 | env.ONEDRIVE_UID | int | `1000` | Set the OneDrive User ID |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"ghcr.io/wrmilling/onedrive-docker"` | image repository |
-| image.tag | string | `"v1.0.0"` | image tag |
+| image.tag | string | `"v2.0.1"` | image tag |
 | persistence | object | See values.yaml for full listing | Configure persistence settings for the chart under this key. |
 | persistence.config | object | `{"accessMode":"ReadWriteOnce","enabled":true,"mountPath":"/onedrive/conf"}` | OneDrive config storage |
 | persistence.config.enabled | bool | `true` | If config storage should be enabled |
@@ -103,6 +101,15 @@ In order to generate an auth-response value you must do the following:
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [2.0.0]
+
+This release moves away from the auth-files approach and uses a custom docker image that allows the responseUrl to be passed directly as an environment variable, similar to how Plex does claim tokens.
+
+#### Removed
+
+* Removed requirement for `onedrive-auth` secret, you can now provide the `ONEDRIVE_AUTHRESPONSE` however you wish to do so
+* Remove `KAH_HELM_INSTALL` environment variable
 
 ### [1.1.0]
 

--- a/charts/stable/onedrive/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/onedrive/README_CHANGELOG.md.gotmpl
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### [2.0.0]
 
-This release moves away from the auth-files approach and uses a custom docker image that allows the responseUrl to be passed directly as an environment variable, similar to how Plex does claim tokens. 
+This release moves away from the auth-files approach and uses a custom docker image that allows the responseUrl to be passed directly as an environment variable, similar to how Plex does claim tokens.
 
 #### Removed
 

--- a/charts/stable/onedrive/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/onedrive/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,15 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.0.0]
+
+This release moves away from the auth-files approach and uses a custom docker image that allows the responseUrl to be passed directly as an environment variable, similar to how Plex does claim tokens. 
+
+#### Removed
+
+* Removed requirement for `onedrive-auth` secret, you can now provide the `ONEDRIVE_AUTHRESPONSE` however you wish to do so
+* Remove `KAH_HELM_INSTALL` environment variable
+
 ### [1.1.0]
 
 #### Added

--- a/charts/stable/onedrive/README_CONFIG.md.gotmpl
+++ b/charts/stable/onedrive/README_CONFIG.md.gotmpl
@@ -5,12 +5,12 @@
 {{- define "custom.custom.configuration" -}}
 {{ template "custom.custom.configuration.header" . }}
 
-To use this chart, you will need to set an application_id in the `config` section as well as a secret (called `onedrive-auth` by default) with a field called `auth-response` that has the value derrived from the process below.
+To use this chart you will need to provide an authentication response from Microsoft for the client to use. This is provided as an environment variable like the claim token is for the plex chart.
 
-In order to generate an auth-response value you must do the following:
+In order to generate an authentication response value you must do the following:
 
-1. Visit the following URL: `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=d50ca740-c83f-4d1b-b616-12c519384f0c&scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.ReadWrite.All%20offline_access&response_type=code&redirect_uri=https://login.microsoftonline.com/common/oauth2/nativeclient`
-2. Authenticate with your OneDrive account.
-3. Copy the URL when you arrive at the blank page (should look like this: `https://login.microsoftonline.com/common/oauth2/nativeclient?code=<redacted>`) and use that as the `auth-reponse` value in the previously mentioned secret `onedrive-auth`.
+1. Visit the following URL: [Authenticate for OneDrive](https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=d50ca740-c83f-4d1b-b616-12c519384f0c&scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.ReadWrite.All%20offline_access&response_type=code&redirect_uri=https://login.microsoftonline.com/common/oauth2/nativeclient)
+2. Follow the prompts to login and get your token URL.
+3. Copy the URL when you arrive at the blank page (should look like this: `https://login.microsoftonline.com/common/oauth2/nativeclient?code=<redacted>`) and provide it to the chart through the `ONEDRIVE_AUTHRESPONSE` environment variable, preferrably secured through some secret. 
 
 {{- end -}}

--- a/charts/stable/onedrive/README_CONFIG.md.gotmpl
+++ b/charts/stable/onedrive/README_CONFIG.md.gotmpl
@@ -11,6 +11,6 @@ In order to generate an authentication response value you must do the following:
 
 1. Visit the following URL: [Authenticate for OneDrive](https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=d50ca740-c83f-4d1b-b616-12c519384f0c&scope=Files.ReadWrite%20Files.ReadWrite.all%20Sites.ReadWrite.All%20offline_access&response_type=code&redirect_uri=https://login.microsoftonline.com/common/oauth2/nativeclient)
 2. Follow the prompts to login and get your token URL.
-3. Copy the URL when you arrive at the blank page (should look like this: `https://login.microsoftonline.com/common/oauth2/nativeclient?code=<redacted>`) and provide it to the chart through the `ONEDRIVE_AUTHRESPONSE` environment variable, preferrably secured through some secret. 
+3. Copy the URL when you arrive at the blank page (should look like this: `https://login.microsoftonline.com/common/oauth2/nativeclient?code=<redacted>`) and provide it to the chart through the `ONEDRIVE_AUTHRESPONSE` environment variable, preferrably secured through some secret.
 
 {{- end -}}

--- a/charts/stable/onedrive/ci/ct-values.yaml
+++ b/charts/stable/onedrive/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+env:
+  ONEDRIVE_AUTHFILES: "/onedrive/conf/auth-request:/onedrive/conf/auth-response"

--- a/charts/stable/onedrive/ci/ct-values.yaml
+++ b/charts/stable/onedrive/ci/ct-values.yaml
@@ -1,4 +1,0 @@
-auth:
-  existingSecret: ""
-env:
-  KAH_HELM_INSTALL: 0

--- a/charts/stable/onedrive/templates/common.yaml
+++ b/charts/stable/onedrive/templates/common.yaml
@@ -16,17 +16,6 @@ probes:
     enabled: false
 
 persistence:
-{{- if .Values.auth.existingSecret }}
-  onedrive-auth:
-    enabled: "true"
-    mountPath: "/onedrive/auth-response"
-    subPath: "auth-response"
-    type: "custom"
-    volumeSpec:
-      secret:
-        secretName: {{ .Values.auth.existingSecret }}
-{{- end }}
-
   onedrive-settings:
     enabled: "true"
     mountPath: "/onedrive/conf/config"

--- a/charts/stable/onedrive/values.yaml
+++ b/charts/stable/onedrive/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/wrmilling/onedrive-docker
   # -- image tag
-  tag: v1.0.0
+  tag: v2.0.1
   # -- image pull policy
   pullPolicy: IfNotPresent
 
@@ -18,25 +18,18 @@ image:
 env:
   # -- Set the container timezone
   TZ: UTC
-  # -- Set the auth request and response file locations for OneDrive
-  ONEDRIVE_AUTHFILES: "/onedrive/conf/auth-request:/onedrive/conf/auth-response"
   # -- Set the OneDrive User ID
   ONEDRIVE_UID: 1000
   # -- Set the One Drive Group ID
   ONEDRIVE_GID: 1000
-  # -- Indicate to container to run K8s specific setup
-  KAH_HELM_INSTALL: 1
+  # -- Set the One Drive Authentication Response
+  ONEDRIVE_AUTHRESPONSE: ""
   # ONEDRIVE_VERBOSE: 0
   # ONEDRIVE_DEBUG: 0
   # ONEDRIVE_DEBUG_HTTPS: 0
   # ONEDRIVE_RESYNC: 0
   # ONEDRIVE_DOWNLOADONLY: 0
   # ONEDRIVE_LOGOUT: 0
-
-# -- Configure auth secret for onedrive to initialize with
-# @default -- See values.yaml
-auth:
-  existingSecret: "onedrive-auth"
 
 # -- Configure persistence settings for the chart under this key.
 # @default -- See values.yaml for full listing
@@ -59,7 +52,7 @@ persistence:
     readOnly: false
     retain: false
 
-# @default -- Default config with application_id set. If you update, please be sure to set the application_id
+# @default -- Default config with application_id set.
 config: |
   # Configuration for OneDrive Linux Client
   # This file contains the list of supported configuration fields

--- a/charts/stable/onedrive/values.yaml
+++ b/charts/stable/onedrive/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/wrmilling/onedrive-docker
   # -- image tag
-  tag: v2.0.1
+  tag: v2.0.2
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

This update does the following: 

* Update chart documentation for env style authentication
* Now supports multi-arch (amd64 and arm64)
* Cleaned up depricated secrets

**Benefits**

Simpler install process which does not force a specific way of storing the secret which mean more flexibility to the end user. 

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)