### PR TITLE
[valheim] Update to use ghcr for image

### DIFF
--- a/charts/stable/valheim/Chart.yaml
+++ b/charts/stable/valheim/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: latest
 description: Valheim dedicated gameserver with automatic update and world backup support
 name: valheim
-version: 4.0.1
+version: 4.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - valheim

--- a/charts/stable/valheim/README.md
+++ b/charts/stable/valheim/README.md
@@ -1,6 +1,6 @@
 # valheim
 
-![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Valheim dedicated gameserver with automatic update and world backup support
 
@@ -79,7 +79,7 @@ N/A
 | env | object | See below | environment variables. See [image docs](https://github.com/lloesche/valheim-server-docker#environment-variables) for more details. |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
-| image.repository | string | `"lloesche/valheim-server"` | image repository |
+| image.repository | string | `"ghcr.io/lloesche/valheim-server"` | image repository |
 | image.tag | string | `"latest"` | image tag |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | service | object | See values.yaml | Configures service settings for the chart. |

--- a/charts/stable/valheim/values.yaml
+++ b/charts/stable/valheim/values.yaml
@@ -7,7 +7,7 @@
 
 image:
   # -- image repository
-  repository: lloesche/valheim-server
+  repository: ghcr.io/lloesche/valheim-server
   # -- image tag
   tag: latest
   # -- image pull policy


### PR DESCRIPTION
**Description of the change**

Moving to ghcr.io for the valheim-docker image, based on maintainers recommendation in [README.md](https://github.com/lloesche/valheim-server-docker).

**Benefits**

Will follow up to date images.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)