### PR TITLE
[unifi] Move traefik serversscheme annotations to service

### DIFF
--- a/charts/stable/unifi/Chart.yaml
+++ b/charts/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v6.2.26
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 4.2.1
+version: 4.2.2
 keywords:
   - ubiquiti
   - unifi

--- a/charts/stable/unifi/README.md
+++ b/charts/stable/unifi/README.md
@@ -1,6 +1,6 @@
 # unifi
 
-![Version: 4.2.1](https://img.shields.io/badge/Version-4.2.1-informational?style=flat-square) ![AppVersion: v6.2.26](https://img.shields.io/badge/AppVersion-v6.2.26-informational?style=flat-square)
+![Version: 4.2.2](https://img.shields.io/badge/Version-4.2.2-informational?style=flat-square) ![AppVersion: v6.2.26](https://img.shields.io/badge/AppVersion-v6.2.26-informational?style=flat-square)
 
 Ubiquiti Network's Unifi Controller
 
@@ -148,6 +148,12 @@ service:
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [4.2.2]
+
+### Fixed
+
+- Move HTTPS protocol declaration for default web UI port from ingress annotations to service port attribute.
 
 ### [4.0.0]
 

--- a/charts/stable/unifi/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/unifi/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.2.2]
+
+### Fixed
+
+- Move HTTPS protocol declaration for default web UI port from ingress annotations to service port attribute.
+
 ### [4.0.0]
 
 #### Changed

--- a/charts/stable/unifi/values.yaml
+++ b/charts/stable/unifi/values.yaml
@@ -40,6 +40,8 @@ env:
 # @default -- See values.yaml
 service:
   main:
+    annotations:
+      traefik.ingress.kubernetes.io/service.serversscheme: https
     ports:
       # -- Configure Web interface + API port
       # @default -- See values.yaml
@@ -95,7 +97,6 @@ ingress:
     enabled: false
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-      traefik.ingress.kubernetes.io/service.serversscheme: https
 
   # -- Enable and configure settings for the captive portal ingress under this key.
   # @default -- See values.yaml
@@ -103,7 +104,6 @@ ingress:
     enabled: false
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-      traefik.ingress.kubernetes.io/service.serversscheme: https
 
     ingressClassName:  # "nginx"
 

--- a/charts/stable/unifi/values.yaml
+++ b/charts/stable/unifi/values.yaml
@@ -40,13 +40,12 @@ env:
 # @default -- See values.yaml
 service:
   main:
-    annotations:
-      traefik.ingress.kubernetes.io/service.serversscheme: https
     ports:
       # -- Configure Web interface + API port
       # @default -- See values.yaml
       http:
         port: 8443
+        protocol: HTTPS
       # -- Configure Controller port used for device command/control
       # @default -- See values.yaml
       controller:


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Moves the Traefik `serversscheme` annotations from the ingresses to the service.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Makes the Unifi controller web portal available.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None that I'm aware of.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Tested locally, confirmed that controller UI was not available prior to the change and is available afterwards.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
