### PR TITLE
[zwavejs2mqtt] Add websocket service

### DIFF
--- a/charts/stable/zwavejs2mqtt/Chart.yaml
+++ b/charts/stable/zwavejs2mqtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 5.0.2
 description: Fully configurable Zwave to MQTT Gateway and Control Panel
 name: zwavejs2mqtt
-version: 5.0.1
+version: 5.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - zwave

--- a/charts/stable/zwavejs2mqtt/README.md
+++ b/charts/stable/zwavejs2mqtt/README.md
@@ -1,6 +1,6 @@
 # zwavejs2mqtt
 
-![Version: 5.0.1](https://img.shields.io/badge/Version-5.0.1-informational?style=flat-square) ![AppVersion: 5.0.2](https://img.shields.io/badge/AppVersion-5.0.2-informational?style=flat-square)
+![Version: 5.0.2](https://img.shields.io/badge/Version-5.0.2-informational?style=flat-square) ![AppVersion: 5.0.2](https://img.shields.io/badge/AppVersion-5.0.2-informational?style=flat-square)
 
 Fully configurable Zwave to MQTT Gateway and Control Panel
 
@@ -123,6 +123,12 @@ affinity:
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [5.0.2]
+
+#### Added
+
+- Support for websocket service
 
 ### [5.0.0]
 

--- a/charts/stable/zwavejs2mqtt/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/zwavejs2mqtt/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [5.0.2]
+
+#### Added
+
+- Support for websocket service
+
 ### [5.0.0]
 
 #### Changed

--- a/charts/stable/zwavejs2mqtt/values.yaml
+++ b/charts/stable/zwavejs2mqtt/values.yaml
@@ -28,6 +28,9 @@ service:
     ports:
       http:
         port: 8091
+      websocket:
+        enabled: false
+        port: 3000
 
 ingress:
   # -- Enable and configure ingress settings for the chart under this key.


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Zwavejs2mqtt supports a [websocket server](https://zwave-js.github.io/zwavejs2mqtt/#/guide/homeassistant-official) for a dedicated [hass integration](https://www.home-assistant.io/integrations/zwave_js) that does not use mqtt.

**Benefits**

Use zwavejs2mqtt as websocket gateway

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
