### PR TITLE
[radarr] add apikey option

### DIFF
--- a/charts/stable/radarr/Chart.yaml
+++ b/charts/stable/radarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v3.2.2.5080
 description: A fork of Sonarr to work with movies à la Couchpotato
 name: radarr
-version: 15.0.3
+version: 15.0.4
 kubeVersion: ">=1.16.0-0"
 keywords:
 - radarr

--- a/charts/stable/radarr/README.md
+++ b/charts/stable/radarr/README.md
@@ -1,6 +1,6 @@
 # radarr
 
-![Version: 15.0.3](https://img.shields.io/badge/Version-15.0.3-informational?style=flat-square) ![AppVersion: v3.2.2.5080](https://img.shields.io/badge/AppVersion-v3.2.2.5080-informational?style=flat-square)
+![Version: 15.0.4](https://img.shields.io/badge/Version-15.0.4-informational?style=flat-square) ![AppVersion: v3.2.2.5080](https://img.shields.io/badge/AppVersion-v3.2.2.5080-informational?style=flat-square)
 
 A fork of Sonarr to work with movies à la Couchpotato
 
@@ -84,6 +84,7 @@ N/A
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | metrics.enabled | bool | See values.yaml | Enable and configure Exportarr sidecar and Prometheus serviceMonitor. |
 | metrics.exporter.env.additionalMetrics | bool | `false` | Set to true to enable gathering of additional metrics (slow) |
+| metrics.exporter.env.apiKey | string | `""` | Set the api key to connect to radarr |
 | metrics.exporter.env.port | int | `9793` | metrics port |
 | metrics.exporter.env.unknownQueueItems | bool | `false` | Set to true to enable gathering unknown queue items |
 | metrics.exporter.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |

--- a/charts/stable/radarr/templates/common.yaml
+++ b/charts/stable/radarr/templates/common.yaml
@@ -21,6 +21,10 @@ additionalContainers:
         value: "{{ .Values.metrics.exporter.env.additionalMetrics }}"
       - name: ENABLE_UNKNOWN_QUEUE_ITEMS
         value: "{{ .Values.metrics.exporter.env.unknownQueueItems }}"
+      {{ if .Values.metrics.exporter.env.apiKey }}
+      - name: APIKEY
+        value: "{{ .Values.metrics.exporter.env.apiKey }}"
+      {{ end }}
     ports:
       - name: metrics
         containerPort: {{ .Values.metrics.exporter.env.port }}

--- a/charts/stable/radarr/values.yaml
+++ b/charts/stable/radarr/values.yaml
@@ -107,3 +107,5 @@ metrics:
       additionalMetrics: false
       # -- Set to true to enable gathering unknown queue items
       unknownQueueItems: false
+      # -- Set the api key to connect to radarr
+      apiKey: ""


### PR DESCRIPTION
Adding the apikey option. This should address this https://github.com/k8s-at-home/charts/issues/1213#issue-1007370695. Not sure if there would be any benefit to add the ability to change the url using this as a sidecar.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
