### PR TITLE
[vaultwarden] Bumped vaultwarden/server to 1.22.2

### DIFF
--- a/charts/stable/vaultwarden/Chart.yaml
+++ b/charts/stable/vaultwarden/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.20.0
+appVersion: 1.22.2
 description: Vaultwarden is a Bitwarden compatable server in Rust
 name: vaultwarden
-version: 3.1.2
+version: 3.1.3
 kubeVersion: ">=1.16.0-0"
 keywords:
 - Vaultwarden

--- a/charts/stable/vaultwarden/README.md
+++ b/charts/stable/vaultwarden/README.md
@@ -1,6 +1,6 @@
 # vaultwarden
 
-![Version: 3.1.2](https://img.shields.io/badge/Version-3.1.2-informational?style=flat-square) ![AppVersion: 1.20.0](https://img.shields.io/badge/AppVersion-1.20.0-informational?style=flat-square)
+![Version: 3.1.3](https://img.shields.io/badge/Version-3.1.3-informational?style=flat-square) ![AppVersion: 1.22.2](https://img.shields.io/badge/AppVersion-1.22.2-informational?style=flat-square)
 
 Vaultwarden is a Bitwarden compatable server in Rust
 
@@ -81,7 +81,7 @@ N/A
 | env.DATA_FOLDER | string | `"config"` | Config dir |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"vaultwarden/server"` | image repository |
-| image.tag | string | `"1.21.0"` | image tag |
+| image.tag | string | `"1.22.2"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | mariadb.enabled | bool | `false` |  |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |

--- a/charts/stable/vaultwarden/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/vaultwarden/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.1.3]
+
+#### Changed
+
+- Bump version to 1.22.2
+
 ### [3.0.0]
 
 #### Changed

--- a/charts/stable/vaultwarden/values.yaml
+++ b/charts/stable/vaultwarden/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: 1.21.0
+  tag: 1.22.2
 
 strategy:
   type: Recreate


### PR DESCRIPTION
Signed-off-by: Simon Caron <simon.caron@protonmail.com>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Bump vaultwarden/server to 1.22.2

**Benefits**

Update to the [latest release](https://github.com/dani-garcia/vaultwarden/releases/tag/1.22.2) to get security/bug fixes

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
