### PR TITLE
[home-assistant] Fix home-assistant ingress example

### DIFF
--- a/charts/stable/home-assistant/Chart.yaml
+++ b/charts/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2021.6.3
 description: Home Assistant
 name: home-assistant
-version: 11.0.5
+version: 11.0.6
 kubeVersion: ">=1.16.0-0"
 keywords:
 - home-assistant

--- a/charts/stable/home-assistant/README.md
+++ b/charts/stable/home-assistant/README.md
@@ -1,6 +1,6 @@
 # home-assistant
 
-![Version: 11.0.5](https://img.shields.io/badge/Version-11.0.5-informational?style=flat-square) ![AppVersion: 2021.6.3](https://img.shields.io/badge/AppVersion-2021.6.3-informational?style=flat-square)
+![Version: 11.0.6](https://img.shields.io/badge/Version-11.0.6-informational?style=flat-square) ![AppVersion: 2021.6.3](https://img.shields.io/badge/AppVersion-2021.6.3-informational?style=flat-square)
 
 Home Assistant
 
@@ -129,9 +129,14 @@ Using NGINX as an example the following will need to be added to your values:
 
 ```yaml
 ingress:
-  enabled: true
-  annotations:
-    nginx.org/websocket-services: home-assistant
+  main:
+    enabled: true
+    annotations:
+      nginx.org/websocket-services: home-assistant
+    hosts:
+      - host: home-assistant.example.org
+        paths:
+          - path: /
 ```
 
 The value derived is the name of the kubernetes service object for home-assistant
@@ -174,6 +179,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [11.0.6]
+
+#### Changed
+
+- Fix home-assistant ingress example
 
 ### [11.0.5]
 

--- a/charts/stable/home-assistant/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/home-assistant/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [11.0.6]
+
+#### Changed
+
+- Fix home-assistant ingress example
+
 ### [11.0.5]
 
 #### Fixed

--- a/charts/stable/home-assistant/README_CONFIG.md.gotmpl
+++ b/charts/stable/home-assistant/README_CONFIG.md.gotmpl
@@ -62,9 +62,14 @@ Using NGINX as an example the following will need to be added to your values:
 
 ```yaml
 ingress:
-  enabled: true
-  annotations:
-    nginx.org/websocket-services: home-assistant
+  main:
+    enabled: true
+    annotations:
+      nginx.org/websocket-services: home-assistant
+    hosts:
+      - host: home-assistant.example.org
+        paths:
+          - path: /
 ```
 
 The value derived is the name of the kubernetes service object for home-assistant


### PR DESCRIPTION
**Description of the change**

Simple README.md change to fix the home-assistant ingress example.

**Benefits**

It provides a working ingress example which users can copy&paste with minimal changes needed (host name).

**Possible drawbacks**

-

**Applicable issues**

-

**Additional information**


**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [-] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)
