### PR TITLE
mealie: add mealie chart

### DIFF
--- a/charts/incubator/mealie/.helmignore
+++ b/charts/incubator/mealie/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS file for Kubernetes
+OWNERS
+# helm-docs templates
+*.gotmpl

--- a/charts/incubator/mealie/Chart.yaml
+++ b/charts/incubator/mealie/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+appVersion: v0.5.3
+description: mealie helm package
+name: mealie
+version: 0.1.0
+kubeVersion: ">=1.16.0-0"
+keywords:
+- mealie
+home: https://hay-kot.github.io/mealie/
+sources:
+- https://github.com/hay-kot/mealie
+maintainers:
+- name: roobre
+  email: roobre@roobre.es
+dependencies:
+- name: common
+  repository: https://library-charts.k8s-at-home.com
+  version: 4.0.1

--- a/charts/incubator/mealie/README.md
+++ b/charts/incubator/mealie/README.md
@@ -1,0 +1,67 @@
+# mealie
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: v0.5.3](https://img.shields.io/badge/AppVersion-v0.5.3-informational?style=flat-square)
+
+mealie helm package
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
+## Source Code
+
+* <https://github.com/hay-kot/mealie>
+
+## Requirements
+
+Kubernetes: `>=1.16.0-0`
+
+## Dependencies
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://library-charts.k8s-at-home.com | common | 4.0.1 |
+
+## TL;DR
+
+```console
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm repo update
+helm install mealie k8s-at-home/mealie
+```
+
+## Installing the Chart
+
+To install the chart with the release name `mealie`
+
+```console
+helm install mealie k8s-at-home/mealie
+```
+
+## Uninstalling the Chart
+
+To uninstall the `mealie` deployment
+
+```console
+helm uninstall mealie
+```
+
+The command removes all the Kubernetes components associated with the chart **including persistent volumes** and deletes the release.
+
+## Configuration
+
+Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
+Other values may be used from the [values.yaml](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml) from the [common library](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common).
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```console
+helm install mealie \
+  --set env.TZ="America/New York" \
+    k8s-at-home/mealie
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart.
+
+```console
+helm install mealie k8s-at-home/mealie -f values.yaml
+```
+

--- a/charts/incubator/mealie/README.md.gotmpl
+++ b/charts/incubator/mealie/README.md.gotmpl
@@ -1,0 +1,146 @@
+{{- define "custom.repository.organization" -}}
+k8s-at-home
+{{- end -}}
+
+{{- define "custom.repository.url" -}}
+https://github.com/k8s-at-home/charts
+{{- end -}}
+
+{{- define "custom.helm.url" -}}
+https://k8s-at-home.com/charts/
+{{- end -}}
+
+{{- define "custom.helm.path" -}}
+{{ template "custom.repository.organization" . }}/{{ template "chart.name" . }}
+{{- end -}}
+
+{{- define "custom.notes" -}}
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+{{- end -}}
+
+{{- define "custom.requirements" -}}
+## Requirements
+
+{{ template "chart.kubeVersionLine" . }}
+{{- end -}}
+
+{{- define "custom.dependencies" -}}
+## Dependencies
+
+{{ template "chart.requirementsTable" . }}
+{{- end -}}
+
+{{- define "custom.install.tldr" -}}
+## TL;DR
+
+```console
+helm repo add {{ template "custom.repository.organization" . }} {{ template "custom.helm.url" . }}
+helm repo update
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.install" -}}
+## Installing the Chart
+
+To install the chart with the release name `{{ template "chart.name" . }}`
+
+```console
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.uninstall" -}}
+## Uninstalling the Chart
+
+To uninstall the `{{ template "chart.name" . }}` deployment
+
+```console
+helm uninstall {{ template "chart.name" . }}
+```
+
+The command removes all the Kubernetes components associated with the chart **including persistent volumes** and deletes the release.
+{{- end -}}
+
+{{- define "custom.configuration.header" -}}
+## Configuration
+{{- end -}}
+
+{{- define "custom.configuration.readValues" -}}
+Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
+Other values may be used from the [values.yaml](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml) from the [common library](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common).
+{{- end -}}
+
+{{- define "custom.configuration.example.set" -}}
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```console
+helm install {{ template "chart.name" . }} \
+  --set env.TZ="America/New York" \
+    {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.configuration.example.file" -}}
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart.
+
+```console
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }} -f values.yaml
+```
+{{- end -}}
+
+{{- define "custom.valuesSection" -}}
+## Values
+
+**Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
+
+{{ template "chart.valuesTable" . }}
+{{- end -}}
+
+{{- define "custom.support" -}}
+## Support
+
+- See the [Docs](https://docs.k8s-at-home.com/our-helm-charts/getting-started/)
+- Open an [issue](https://github.com/k8s-at-home/charts/issues/new/choose)
+- Ask a [question](https://github.com/k8s-at-home/organization/discussions)
+- Join our [Discord](https://discord.gg/sTMX7Vh) community
+{{- end -}}
+
+{{ template "chart.header" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "custom.notes" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "custom.requirements" . }}
+
+{{ template "custom.dependencies" . }}
+
+{{ template "custom.install.tldr" . }}
+
+{{ template "custom.install" . }}
+
+{{ template "custom.uninstall" . }}
+
+{{ template "custom.configuration.header" . }}
+
+{{ template "custom.configuration.readValues" . }}
+
+{{ template "custom.configuration.example.set" . }}
+
+{{ template "custom.configuration.example.file" . }}
+
+{{ template "custom.custom.configuration" . }}
+
+{{ template "custom.valuesSection" . }}
+
+{{ template "custom.changelog" . }}
+
+{{ template "custom.support" . }}
+
+{{ template "helm-docs.versionFooter" . }}
+{{ "" }}

--- a/charts/incubator/mealie/README_CHANGELOG.md.gotmpl
+++ b/charts/incubator/mealie/README_CHANGELOG.md.gotmpl
@@ -1,0 +1,27 @@
+{{- define "custom.changelog.header" -}}
+## Changelog
+{{- end -}}
+
+{{- define "custom.changelog" -}}
+{{ template "custom.changelog.header" . }}
+
+All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [1.0.0]
+
+#### Added
+
+- Initial version
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
+
+[1.0.0]: #100
+{{- end -}}

--- a/charts/incubator/mealie/README_CONFIG.md.gotmpl
+++ b/charts/incubator/mealie/README_CONFIG.md.gotmpl
@@ -1,0 +1,9 @@
+{{- define "custom.custom.configuration.header" -}}
+## Custom configuration
+{{- end -}}
+
+{{- define "custom.custom.configuration" -}}
+{{ template "custom.custom.configuration.header" . }}
+
+N/A
+{{- end -}}

--- a/charts/incubator/mealie/templates/NOTES.txt
+++ b/charts/incubator/mealie/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/incubator/mealie/templates/common.yaml
+++ b/charts/incubator/mealie/templates/common.yaml
@@ -1,0 +1,1 @@
+{{ include "common.all" . }}

--- a/charts/incubator/mealie/values.yaml
+++ b/charts/incubator/mealie/values.yaml
@@ -1,0 +1,49 @@
+#
+# IMPORTANT NOTE
+#
+# This chart inherits from our common library chart. You can check the default values/options here:
+# https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml
+#
+
+image:
+  # -- image repository
+  repository: hkotel/mealie
+  # -- image tag
+  tag: ""
+  # -- image pull policy
+  pullPolicy: IfNotPresent
+
+# -- environment variables. See more environment variables in https://hay-kot.github.io/mealie/documentation/getting-started/install/#env-variables.
+# @default -- See below
+env:
+  # -- Set the container timezone
+  TZ: UTC
+#  RECIPE_PUBLIC: 'true'
+#  RECIPE_SHOW_NUTRITION: 'true'
+#  RECIPE_SHOW_ASSETS: 'true'
+#  RECIPE_LANDSCAPE_VIEW: 'true'
+#  RECIPE_DISABLE_COMMENTS: 'false'
+#  RECIPE_DISABLE_AMOUNT: 'false'
+
+# -- Configures service settings for the chart.
+# @default -- See values.yaml
+service:
+  main:
+    ports:
+      http:
+        port: 80
+
+ingress:
+  # -- Enable and configure ingress settings for the chart under this key.
+  # @default -- See values.yaml
+  main:
+    enabled: false
+    primary: true
+
+# -- Configure persistence settings for the chart under this key.
+# @default -- See values.yaml
+persistence:
+  # Mealie will store the SQLite database here
+  data:
+    enabled: false
+    mountPath: /app/data


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This commit adds a simple chart for Mealie, a self hosted recipe manager and meal planner.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
