### PR TITLE
[changedetection-io] Image version bump and fixes

### DIFF
--- a/charts/incubator/changedetection-io/Chart.yaml
+++ b/charts/incubator/changedetection-io/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.93"
+appVersion: "0.39"
 description: changedetection-io helm package
 name: changedetection-io
 version: 1.1.0

--- a/charts/incubator/changedetection-io/Chart.yaml
+++ b/charts/incubator/changedetection-io/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.39"
+appVersion: "0.39.3"
 description: changedetection-io helm package
 name: changedetection-io
 version: 1.1.0

--- a/charts/incubator/changedetection-io/Chart.yaml
+++ b/charts/incubator/changedetection-io/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.39.3"
 description: changedetection-io helm package
 name: changedetection-io
-version: 1.1.0
+version: 1.2.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - changedetection.io

--- a/charts/incubator/changedetection-io/README.md
+++ b/charts/incubator/changedetection-io/README.md
@@ -1,6 +1,6 @@
 # changedetection-io
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 0.93](https://img.shields.io/badge/AppVersion-0.93-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 0.39.3](https://img.shields.io/badge/AppVersion-0.39.3-informational?style=flat-square)
 
 changedetection-io helm package
 
@@ -79,8 +79,8 @@ N/A
 | env | object | See below | environment variables. See more environment variables in the [changedetection-io documentation](https://changedetection-io.org/docs). |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
-| image.repository | string | `"dgtlmoon/changedetection.io"` | image repository |
-| image.tag | string | `"0.39"` | image tag |
+| image.repository | string | `"ghcr.io/dgtlmoon/changedetection.io"` | image repository |
+| image.tag | string | `"0.39.3"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | service | object | See values.yaml | Configures service settings for the chart. |
@@ -91,7 +91,17 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [1.0.0]
+### [1.2.0]
+
+#### Changed
+
+- Updated the image tag to v0.39.3
+- Switched to GHCR
+- Fixed `appVersion`
+- Fixed changelog
+- Updated readme
+
+### [1.1.0]
 
 #### Added
 
@@ -104,8 +114,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Removed
 
 - N/A
-
-[1.0.0]: #100
 
 ## Support
 

--- a/charts/incubator/changedetection-io/README_CHANGELOG.md.gotmpl
+++ b/charts/incubator/changedetection-io/README_CHANGELOG.md.gotmpl
@@ -9,7 +9,17 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [1.0.0]
+### [1.2.0]
+
+#### Changed
+
+- Updated the image tag to v0.39.3
+- Switched to GHCR
+- Fixed `appVersion`
+- Fixed changelog
+- Updated readme
+
+### [1.1.0]
 
 #### Added
 
@@ -23,5 +33,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - N/A
 
-[1.0.0]: #100
 {{- end -}}

--- a/charts/incubator/changedetection-io/values.yaml
+++ b/charts/incubator/changedetection-io/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: dgtlmoon/changedetection.io
   # -- image tag
-  tag: "0.39"
+  tag: "0.39.3"
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/incubator/changedetection-io/values.yaml
+++ b/charts/incubator/changedetection-io/values.yaml
@@ -7,7 +7,7 @@
 
 image:
   # -- image repository
-  repository: dgtlmoon/changedetection.io
+  repository: ghcr.io/dgtlmoon/changedetection.io
   # -- image tag
   tag: "0.39.3"
   # -- image pull policy


### PR DESCRIPTION
**Description of the change**

- Updated the image tag to v0.39.3
- Switched to GHCR
- Fixed `appVersion`
- Fixed changelog
- Updated readme

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
