### PR TITLE
[tautuli] Image version bump 

### DIFF
--- a/charts/stable/tautulli/Chart.yaml
+++ b/charts/stable/tautulli/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.7.4
+appVersion: v2.7.7
 description: A Python based monitoring and tracking tool for Plex Media Server
 name: tautulli
-version: 11.1.0
+version: 11.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - tautulli

--- a/charts/stable/tautulli/README.md
+++ b/charts/stable/tautulli/README.md
@@ -1,6 +1,6 @@
 # tautulli
 
-![Version: 11.1.0](https://img.shields.io/badge/Version-11.1.0-informational?style=flat-square) ![AppVersion: v2.7.4](https://img.shields.io/badge/AppVersion-v2.7.4-informational?style=flat-square)
+![Version: 11.1.1](https://img.shields.io/badge/Version-11.1.1-informational?style=flat-square) ![AppVersion: v2.7.7](https://img.shields.io/badge/AppVersion-v2.7.7-informational?style=flat-square)
 
 A Python based monitoring and tracking tool for Plex Media Server
 
@@ -80,7 +80,7 @@ N/A
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"ghcr.io/k8s-at-home/tautulli"` | image repository |
-| image.tag | string | `"v2.7.4"` | image tag |
+| image.tag | string | `"v2.7.7"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | service | object | See values.yaml | Configures service settings for the chart. |
@@ -90,6 +90,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [11.1.1]
+
+#### Changed
+
+- Bumped image version to v2.7.7
 
 ### [11.0.0]
 

--- a/charts/stable/tautulli/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/tautulli/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [11.1.1]
+
+#### Changed
+
+- Bumped image version to v2.7.7
+
 ### [11.0.0]
 
 #### Changed

--- a/charts/stable/tautulli/values.yaml
+++ b/charts/stable/tautulli/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/k8s-at-home/tautulli
   # -- image tag
-  tag: v2.7.4
+  tag: v2.7.7
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

Bumped image version to 2.7.7

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)
