### PR TITLE
[mealie] - Support Postgres

### DIFF
--- a/charts/stable/mealie/Chart.yaml
+++ b/charts/stable/mealie/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.5.1
 description: Mealie is a self hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in Vue for a pleasant user experience for the whole family.
 name: mealie
-version: 3.1.0
+version: 3.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - grocy
@@ -17,3 +17,7 @@ dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com
   version: 4.2.0
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.13.11
+  condition: postgresql.enabled

--- a/charts/stable/mealie/Chart.yaml
+++ b/charts/stable/mealie/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.5.1
 description: Mealie is a self hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in Vue for a pleasant user experience for the whole family.
 name: mealie
-version: 3.1.1
+version: 3.2.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - grocy

--- a/charts/stable/mealie/README.md
+++ b/charts/stable/mealie/README.md
@@ -93,6 +93,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.2.0]
+
+### Changed
+
+- Add dependency for postgres database as the application now supports it. [Postgres - Mealie](https://hay-kot.github.io/mealie/documentation/getting-started/install/#docker-compose-with-postgres-beta)
+
 ### [3.0.0]
 
 #### Changed

--- a/charts/stable/mealie/README.md
+++ b/charts/stable/mealie/README.md
@@ -1,6 +1,6 @@
 # mealie
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
 
 Mealie is a self hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in Vue for a pleasant user experience for the whole family.
 
@@ -18,8 +18,8 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 4.2.0 |
 | https://charts.bitnami.com/bitnami | postgresql | 10.13.11 |
+| https://library-charts.k8s-at-home.com | common | 4.2.0 |
 
 ## TL;DR
 
@@ -84,6 +84,7 @@ N/A
 | image.tag | string | `"v0.5.1"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
+| postgres | object | See values.yaml | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog

--- a/charts/stable/mealie/README.md
+++ b/charts/stable/mealie/README.md
@@ -19,6 +19,7 @@ Kubernetes: `>=1.16.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://library-charts.k8s-at-home.com | common | 4.2.0 |
+| https://charts.bitnami.com/bitnami | postgresql | 10.13.11 |
 
 ## TL;DR
 

--- a/charts/stable/mealie/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/mealie/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.2.0]
+
+### Changed
+
+- Add dependency for postgres database as the application now supports it. [Postgres - Mealie](https://hay-kot.github.io/mealie/documentation/getting-started/install/#docker-compose-with-postgres-beta)
+
 ### [3.0.0]
 
 #### Changed

--- a/charts/stable/mealie/values.yaml
+++ b/charts/stable/mealie/values.yaml
@@ -41,3 +41,15 @@ persistence:
   config:
     enabled: false
     mountPath: /app/data/
+
+# -- Enable and configure postgresql database subchart under this key.
+#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+# @default -- See values.yaml
+postgres:
+  enabled: false
+  postgresqlUsername: mealie
+  postgresqlPassword: mealie-pass
+  postgresqlDatabase: mealie
+  persistence:
+    enabled: false
+    # storageClass: ""


### PR DESCRIPTION
**Description of the change**

Add Postgres DB to mealie -> https://hay-kot.github.io/mealie/documentation/getting-started/install/#docker-compose-with-postgres-beta

**Benefits**
Postgres instead of sqlite, having the benefit of not having it on each node.
<!-- What benefits will be realized by the code change? -->

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)
