### PR TITLE
[tdarr] Add shared persistence to tdarr node sidecar

### DIFF
--- a/charts/stable/tdarr/Chart.yaml
+++ b/charts/stable/tdarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.00.10
 description: Tdarr is a self hosted web-app for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers etc.
 name: tdarr
-version: 4.1.0
+version: 4.1.1
 keywords:
   - transcoding
   - remux

--- a/charts/stable/tdarr/README.md
+++ b/charts/stable/tdarr/README.md
@@ -93,6 +93,7 @@ N/A
 | persistence.config | object | See values.yaml | Volume used for configuration |
 | persistence.data | object | See values.yaml | Volume used for tdarr server database |
 | persistence.media | object | See values.yaml | Volume used for media libraries |
+| persistence.shared | object | See values.yaml | Volume used for shared storage |
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog

--- a/charts/stable/tdarr/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/tdarr/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,14 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.1.1]
+
+#### Changed
+
+- Add shared persistence option to the tdarr node sidecar in order to
+have a local (emptydir) alternative for transcodes between the server
+and node containers.
+
 ### [4.0.0]
 
 #### Changed

--- a/charts/stable/tdarr/templates/common.yaml
+++ b/charts/stable/tdarr/templates/common.yaml
@@ -26,6 +26,10 @@ additionalContainers:
       - name: media
         mountPath: /media
       {{ end }}
+      {{ if .Values.persistence.shared.enabled }}
+      - name: shared
+        mountPath: /shared
+      {{ end }}
 {{ end }}
 {{- end -}}
 {{- $_ := mergeOverwrite .Values (include "tdarr.harcodedValues" . | fromYaml) -}}

--- a/charts/stable/tdarr/values.yaml
+++ b/charts/stable/tdarr/values.yaml
@@ -76,3 +76,9 @@ persistence:
   media:
     enabled: false
     mountpath: /media
+
+  # -- Volume used for shared storage. e.g. emptydir transcode
+  # @default -- See values.yaml
+  shared:
+    enabled: false
+    mountpath: /shared


### PR DESCRIPTION
Adding a shared persistence option to the tdarr node sidecar in order to
have a local (emptydir) alternative for transcodes between the server and node
containers.

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Add option for shared directory between the tdarr server and node sidecar.

**Benefits**

Allow the option of a local emptydir transcode location 

**Possible drawbacks**

n/a

**Applicable issues**

n/a

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
