### PR TITLE
[onedrive] Bump image tag to 2.0.5

### DIFF
--- a/charts/stable/onedrive/Chart.yaml
+++ b/charts/stable/onedrive/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.4.13
+appVersion: v2.4.14
 description: A free Microsoft OneDrive Client which supports OneDrive Personal, OneDrive for Business, OneDrive for Office365, and SharePoint
 name: onedrive
-version: 2.1.0
+version: 2.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - onedrive

--- a/charts/stable/onedrive/README.md
+++ b/charts/stable/onedrive/README.md
@@ -1,6 +1,6 @@
 # onedrive
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![AppVersion: v2.4.13](https://img.shields.io/badge/AppVersion-v2.4.13-informational?style=flat-square)
+![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![AppVersion: v2.4.14](https://img.shields.io/badge/AppVersion-v2.4.14-informational?style=flat-square)
 
 A free Microsoft OneDrive Client which supports OneDrive Personal, OneDrive for Business, OneDrive for Office365, and SharePoint
 
@@ -89,7 +89,7 @@ In order to generate an authentication response value you must do the following:
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"ghcr.io/wrmilling/onedrive-docker"` | image repository |
-| image.tag | string | `"v2.0.2"` | image tag |
+| image.tag | string | `"v2.0.5"` | image tag |
 | persistence | object | See values.yaml for full listing | Configure persistence settings for the chart under this key. |
 | persistence.config | object | `{"accessMode":"ReadWriteOnce","enabled":true,"mountPath":"/onedrive/conf"}` | OneDrive config storage |
 | persistence.config.enabled | bool | `true` | If config storage should be enabled |
@@ -126,6 +126,8 @@ This release moves away from the auth-files approach and uses a custom docker im
 
 - Ability to run a abraunegg/onedrive instance
 
+[2.0.0]: #2.0.0
+[1.1.0]: #1.1.0
 [1.0.0]: #1.0.0
 
 ## Support

--- a/charts/stable/onedrive/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/onedrive/README_CHANGELOG.md.gotmpl
@@ -33,5 +33,7 @@ This release moves away from the auth-files approach and uses a custom docker im
 
 - Ability to run a abraunegg/onedrive instance
 
+[2.0.0]: #2.0.0
+[1.1.0]: #1.1.0
 [1.0.0]: #1.0.0
 {{- end -}}

--- a/charts/stable/onedrive/values.yaml
+++ b/charts/stable/onedrive/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/wrmilling/onedrive-docker
   # -- image tag
-  tag: v2.0.2
+  tag: v2.0.5
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

Bump docker image to 2.0.5, which removes the patch being applied to source but retains a multi-arch image. Next release of onedrive may remove the custom image as there is a PR for multi-arch pending upstream. 

**Benefits**

Removed patch step on source code. 

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)
