### PR TITLE
[unifi] Update AppVersion to v6.5.54

### DIFF
--- a/charts/stable/unifi/Chart.yaml
+++ b/charts/stable/unifi/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v6.2.26
+appVersion: v6.5.54
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 4.4.0
+version: 4.5.0
 keywords:
   - ubiquiti
   - unifi

--- a/charts/stable/unifi/README.md
+++ b/charts/stable/unifi/README.md
@@ -1,6 +1,6 @@
 # unifi
 
-![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square) ![AppVersion: v6.2.26](https://img.shields.io/badge/AppVersion-v6.2.26-informational?style=flat-square)
+![Version: 4.5.0](https://img.shields.io/badge/Version-4.5.0-informational?style=flat-square) ![AppVersion: v6.5.54](https://img.shields.io/badge/AppVersion-v6.5.54-informational?style=flat-square)
 
 Ubiquiti Network's Unifi Controller
 
@@ -128,7 +128,7 @@ service:
 | env.UNIFI_UID | string | `"999"` | Specify the user ID the application will run as |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"jacobalberty/unifi"` | image repository |
-| image.tag | string | `"v6.2.26"` | image tag |
+| image.tag | string | `"v6.5.54"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | ingress.portal | object | See values.yaml | Enable and configure settings for the captive portal ingress under this key. |
 | mongodb | object | See values.yaml | Enable and configure mongodb database subchart under this key.    For more options see [mongodb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mongodb) |
@@ -149,9 +149,15 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.5.0]
+
+#### Changed
+
+- Bump controller version to 6.5.54
+
 ### [4.2.2]
 
-### Fixed
+#### Fixed
 
 - Move HTTPS protocol declaration for default web UI port from ingress annotations to service port attribute.
 

--- a/charts/stable/unifi/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/unifi/README_CHANGELOG.md.gotmpl
@@ -9,9 +9,15 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.5.0]
+
+#### Changed
+
+- Bump controller version to 6.5.54
+
 ### [4.2.2]
 
-### Fixed
+#### Fixed
 
 - Move HTTPS protocol declaration for default web UI port from ingress annotations to service port attribute.
 

--- a/charts/stable/unifi/values.yaml
+++ b/charts/stable/unifi/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: jacobalberty/unifi
   # -- image tag
-  tag: v6.2.26
+  tag: v6.5.54
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

- Bump unifi version to 6.5.54

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
