### PR TITLE
[frigate] update frigate version to 0.9.4

### DIFF
--- a/charts/stable/frigate/Chart.yaml
+++ b/charts/stable/frigate/Chart.yaml
@@ -1,24 +1,26 @@
 apiVersion: v2
-appVersion: v0.8.0
+appVersion: v0.9.4
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 6.2.0
+version: 7.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
-- frigate
-- nvr
-- tensorflow
-- coral
-- ml
-- machine-learning
+  - frigate
+  - nvr
+  - tensorflow
+  - coral
+  - ml
+  - machine-learning
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/frigate
 icon: https://github.com/blakeblackshear/frigate/blob/master/docs/static/img/frigate.png
 sources:
-- https://github.com/blakeblackshear/frigate
+  - https://github.com/blakeblackshear/frigate
 maintainers:
-- name: billimek
-  email: jeff@billimek.com
+  - name: billimek
+    email: jeff@billimek.com
+  - name: PixelJonas
+    email: 5434875+PixelJonas@users.noreply.github.com
 dependencies:
-- name: common
-  repository: https://library-charts.k8s-at-home.com
-  version: 4.2.0
+  - name: common
+    repository: https://library-charts.k8s-at-home.com
+    version: 4.2.0

--- a/charts/stable/frigate/Chart.yaml
+++ b/charts/stable/frigate/Chart.yaml
@@ -5,22 +5,22 @@ name: frigate
 version: 7.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
-  - frigate
-  - nvr
-  - tensorflow
-  - coral
-  - ml
-  - machine-learning
+- frigate
+- nvr
+- tensorflow
+- coral
+- ml
+- machine-learning
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/frigate
 icon: https://github.com/blakeblackshear/frigate/blob/master/docs/static/img/frigate.png
 sources:
-  - https://github.com/blakeblackshear/frigate
+- https://github.com/blakeblackshear/frigate
 maintainers:
-  - name: billimek
-    email: jeff@billimek.com
-  - name: PixelJonas
-    email: 5434875+PixelJonas@users.noreply.github.com
+- name: billimek
+  email: jeff@billimek.com
+- name: PixelJonas
+  email: 5434875+PixelJonas@users.noreply.github.com
 dependencies:
-  - name: common
-    repository: https://library-charts.k8s-at-home.com
-    version: 4.2.0
+- name: common
+  repository: https://library-charts.k8s-at-home.com
+  version: 4.2.0

--- a/charts/stable/frigate/README.md
+++ b/charts/stable/frigate/README.md
@@ -1,6 +1,6 @@
 # frigate
 
-![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![AppVersion: v0.8.0](https://img.shields.io/badge/AppVersion-v0.8.0-informational?style=flat-square)
+![Version: 7.0.0](https://img.shields.io/badge/Version-7.0.0-informational?style=flat-square) ![AppVersion: v0.9.4](https://img.shields.io/badge/AppVersion-v0.9.4-informational?style=flat-square)
 
 NVR With Realtime Object Detection for IP Cameras
 
@@ -99,7 +99,7 @@ config: |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"blakeblackshear/frigate"` | image repository |
-| image.tag | string | `"0.8.4-amd64"` | image tag |
+| image.tag | string | `"0.9.4-amd64"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | persistence.cache | object | See values.yaml | Configure a temporary cache. See [docs](https://blakeblackshear.github.io/frigate/) for more details.. |
@@ -113,6 +113,10 @@ config: |
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [7.0.0]
+
+- Upgraded frigate version to 0.9.4. This introduces breaking changes regarding frigate configuration. Please check, that your configuration conforms the format described in the [official docs](https://docs.frigate.video/configuration/index/). When starting the container with a wrong configuration you will get a detailed overview which configuration options you need to adjust.
 
 ### [6.0.0]
 

--- a/charts/stable/frigate/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/frigate/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,10 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [7.0.0]
+
+- Upgraded frigate version to 0.9.4. This introduces breaking changes regarding frigate configuration. Please check, that your configuration conforms the format described in the [official docs](https://docs.frigate.video/configuration/index/). When starting the container with a wrong configuration you will get a detailed overview which configuration options you need to adjust.
+
 ### [6.0.0]
 
 #### Changed

--- a/charts/stable/frigate/ci/ct-values.yaml
+++ b/charts/stable/frigate/ci/ct-values.yaml
@@ -3,3 +3,30 @@ persistence:
     enabled: true
     type: emptyDir
     mountPath: /data
+config: |
+  detectors:
+    cpu1:
+      type: cpu
+      num_threads: 1
+  mqtt:
+    host: 192.168.1.2
+    client_id: frigate
+    user: frigate
+    password: frigate
+  database:
+    path: /data/frigate.db
+  detect:
+    fps: 4
+    height: 360
+    width: 640
+  cameras:
+    camera_1:
+      ffmpeg:
+        inputs:
+          - path: rtsp://admin:admin@192.168.1.3:5554//h264Preview_01_sub
+            roles:
+              - detect
+              - rtmp
+      zones:
+        door:
+          coordinates: 481,42,596,48,565,267,469,228

--- a/charts/stable/frigate/values.yaml
+++ b/charts/stable/frigate/values.yaml
@@ -82,8 +82,7 @@ affinity: {}
 #           - coral-tpu
 
 # -- Configure the resource requests and/or limits for the Pod
-resources:
-  {}
+resources: {}
   # requests:
   #   # Hardware acceleration using an Intel iGPU w/ QuickSync and
   #   # using intel-gpu-plugin (https://github.com/intel/intel-device-plugins-for-kubernetes)

--- a/charts/stable/frigate/values.yaml
+++ b/charts/stable/frigate/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: blakeblackshear/frigate
   # -- image tag
-  tag: 0.8.4-amd64
+  tag: 0.9.4-amd64
   # -- image pull policy
   pullPolicy: IfNotPresent
 
@@ -82,7 +82,8 @@ affinity: {}
 #           - coral-tpu
 
 # -- Configure the resource requests and/or limits for the Pod
-resources: {}
+resources:
+  {}
   # requests:
   #   # Hardware acceleration using an Intel iGPU w/ QuickSync and
   #   # using intel-gpu-plugin (https://github.com/intel/intel-device-plugins-for-kubernetes)


### PR DESCRIPTION
**Description of the change**

This PR bumps frigate version to 0.9.4 and the chart-version to 7.0.0 as frigate introduced breaking changes to the config file. README.md is adjusted accordingly

**Benefits**

I just started installing frigate and there was a big mismatch between frigate documentation of configuration and the one needed for the version used in this chart. The new frigate version also includes better error messages for missing configuration, which should make the upgrade easy.

**Additional information**

Most of my configuration errors were based on custom camera configuration.

*v0.8.x*
```
...
camera:
  width: 640
  height: 360
  fps: 4
...
```

*v0.9.x*
```
...
camera:
  detect:
    width: 640
    height: 360
    fps: 4
...
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)