### PR TITLE
[tdarr] Add ffmpegPath environment override

### DIFF
--- a/charts/stable/tdarr/Chart.yaml
+++ b/charts/stable/tdarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.00.10
 description: Tdarr is a self hosted web-app for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers etc.
 name: tdarr
-version: 4.1.3
+version: 4.1.4
 keywords:
   - transcoding
   - remux

--- a/charts/stable/tdarr/Chart.yaml
+++ b/charts/stable/tdarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.00.10
 description: Tdarr is a self hosted web-app for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers etc.
 name: tdarr
-version: 4.1.4
+version: 4.2.0
 keywords:
   - transcoding
   - remux

--- a/charts/stable/tdarr/README.md
+++ b/charts/stable/tdarr/README.md
@@ -80,6 +80,7 @@ N/A
 | env.serverIP | string | `"0.0.0.0"` | tdarr server binding address |
 | env.serverPort | string | `"{{ .Values.service.main.ports.server.port }}"` | tdarr server listening port |
 | env.webUIPort | string | `"{{ .Values.service.main.ports.http.port }}"` | tdarr web UI listening port (same as Service port) |
+| env.ffmpegPath | string | `""` | Override the pre-compiled ffmpeg binary |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"haveagitgat/tdarr"` | image repository |
 | image.tag | string | `"2.00.10"` | image tag |
@@ -102,6 +103,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [4.1.4]
+
+#### Changed
+
+- Add an environment override for `ffmpegPath`. If unset, the tdarr node container will use the default binary that ships with tdarr. Using `""` may cause detection issues with hardware passthrough (i915), but will be backwards backwards compatible with the container default.
 
 ### [4.1.3]
 

--- a/charts/stable/tdarr/README.md
+++ b/charts/stable/tdarr/README.md
@@ -104,7 +104,7 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [4.1.4]
+### [4.2.0]
 
 #### Changed
 

--- a/charts/stable/tdarr/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/tdarr/README_CHANGELOG.md.gotmpl
@@ -9,7 +9,7 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [4.1.4]
+### [4.2.0]
 
 #### Changed
 

--- a/charts/stable/tdarr/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/tdarr/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.1.4]
+
+#### Changed
+
+- Add an environment override for `ffmpegPath`. If unset, the tdarr node container will use the default binary that ships with tdarr. Using `""` may cause detection issues with hardware passthrough (i915), but will be backwards backwards compatible with the container default.
+
 ### [4.1.3]
 
 #### Changed

--- a/charts/stable/tdarr/templates/common.yaml
+++ b/charts/stable/tdarr/templates/common.yaml
@@ -17,6 +17,8 @@ additionalContainers:
         value: "localhost"
       - name: serverPort
         value: "{{ .Values.service.main.ports.server.port }}"
+      - name: ffmpegPath
+        value: {{ default "" .Values.env.ffmpegPath }}
     volumeMounts:
       {{ if .Values.persistence.config.enabled }}
       - name: config

--- a/charts/stable/tdarr/values.yaml
+++ b/charts/stable/tdarr/values.yaml
@@ -24,6 +24,8 @@ env:
   serverIP: 0.0.0.0
   # -- tdarr server listening port
   serverPort: "{{ .Values.service.main.ports.server.port }}"
+  # -- Allow override for the pre-compiled tdarr ffmpeg binary
+  ffmpegPath: ""
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This change adds and environment override for `ffmpegPath`. If unset, the
tdarr node container will use the default binary that ships with tdarr.
Using `""` may cause detection issues with hardware passthrough (`i915`),
but will remain backwards compatible with the container default.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

Allow overriding to the default system ffmpeg binary.

**Possible drawbacks**

None.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
n/a

**Additional information**

This issue was discussed at length with the container maintainer and is the best solution to override the default ffmpeg binary which has vaapi detection problems.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
