### PR TITLE
[lidarr/sonarr/radarr] Updating the exportarr image patch level

### DIFF
--- a/charts/stable/lidarr/Chart.yaml
+++ b/charts/stable/lidarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.0.0.2255
 description: Looks and smells like Sonarr but made for music
 name: lidarr
-version: 13.1.0
+version: 13.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - lidarr

--- a/charts/stable/lidarr/README.md
+++ b/charts/stable/lidarr/README.md
@@ -1,6 +1,6 @@
 # lidarr
 
-![Version: 13.1.0](https://img.shields.io/badge/Version-13.1.0-informational?style=flat-square) ![AppVersion: v1.0.0.2255](https://img.shields.io/badge/AppVersion-v1.0.0.2255-informational?style=flat-square)
+![Version: 13.1.1](https://img.shields.io/badge/Version-13.1.1-informational?style=flat-square) ![AppVersion: v1.0.0.2255](https://img.shields.io/badge/AppVersion-v1.0.0.2255-informational?style=flat-square)
 
 Looks and smells like Sonarr but made for music
 
@@ -88,7 +88,7 @@ N/A
 | metrics.exporter.env.unknownQueueItems | bool | `false` | Set to true to enable gathering unknown queue items |
 | metrics.exporter.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | metrics.exporter.image.repository | string | `"ghcr.io/onedr0p/exportarr"` | image repository |
-| metrics.exporter.image.tag | string | `"v0.6.1"` | image tag |
+| metrics.exporter.image.tag | string | `"v0.6.2"` | image tag |
 | metrics.prometheusRule | object | See values.yaml | Enable and configure Prometheus Rules for the chart under this key. |
 | metrics.prometheusRule.rules | list | See prometheusrules.yaml | Configure additionial rules for the chart under this key. |
 | metrics.serviceMonitor.interval | string | `"3m"` |  |

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -97,7 +97,7 @@ metrics:
       # -- image repository
       repository: ghcr.io/onedr0p/exportarr
       # -- image tag
-      tag: v0.6.1
+      tag: v0.6.2
       # -- image pull policy
       pullPolicy: IfNotPresent
     env:

--- a/charts/stable/radarr/Chart.yaml
+++ b/charts/stable/radarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v3.2.2.5080
 description: A fork of Sonarr to work with movies à la Couchpotato
 name: radarr
-version: 15.1.0
+version: 15.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - radarr

--- a/charts/stable/radarr/README.md
+++ b/charts/stable/radarr/README.md
@@ -1,6 +1,6 @@
 # radarr
 
-![Version: 15.1.0](https://img.shields.io/badge/Version-15.1.0-informational?style=flat-square) ![AppVersion: v3.2.2.5080](https://img.shields.io/badge/AppVersion-v3.2.2.5080-informational?style=flat-square)
+![Version: 15.1.1](https://img.shields.io/badge/Version-15.1.1-informational?style=flat-square) ![AppVersion: v3.2.2.5080](https://img.shields.io/badge/AppVersion-v3.2.2.5080-informational?style=flat-square)
 
 A fork of Sonarr to work with movies à la Couchpotato
 
@@ -88,7 +88,7 @@ N/A
 | metrics.exporter.env.unknownQueueItems | bool | `false` | Set to true to enable gathering unknown queue items |
 | metrics.exporter.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | metrics.exporter.image.repository | string | `"ghcr.io/onedr0p/exportarr"` | image repository |
-| metrics.exporter.image.tag | string | `"v0.6.1"` | image tag |
+| metrics.exporter.image.tag | string | `"v0.6.2"` | image tag |
 | metrics.prometheusRule | object | See values.yaml | Enable and configure Prometheus Rules for the chart under this key. |
 | metrics.prometheusRule.rules | list | See prometheusrules.yaml | Configure additionial rules for the chart under this key. |
 | metrics.serviceMonitor.interval | string | `"3m"` |  |

--- a/charts/stable/radarr/values.yaml
+++ b/charts/stable/radarr/values.yaml
@@ -97,7 +97,7 @@ metrics:
       # -- image repository
       repository: ghcr.io/onedr0p/exportarr
       # -- image tag
-      tag: v0.6.1
+      tag: v0.6.2
       # -- image pull policy
       pullPolicy: IfNotPresent
     env:

--- a/charts/stable/sonarr/Chart.yaml
+++ b/charts/stable/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v3.0.6.1342
 description: Smart PVR for newsgroup and bittorrent users
 name: sonarr
-version: 15.2.0
+version: 15.2.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - sonarr

--- a/charts/stable/sonarr/README.md
+++ b/charts/stable/sonarr/README.md
@@ -1,6 +1,6 @@
 # sonarr
 
-![Version: 15.2.0](https://img.shields.io/badge/Version-15.2.0-informational?style=flat-square) ![AppVersion: v3.0.6.1342](https://img.shields.io/badge/AppVersion-v3.0.6.1342-informational?style=flat-square)
+![Version: 15.2.1](https://img.shields.io/badge/Version-15.2.1-informational?style=flat-square) ![AppVersion: v3.0.6.1342](https://img.shields.io/badge/AppVersion-v3.0.6.1342-informational?style=flat-square)
 
 Smart PVR for newsgroup and bittorrent users
 
@@ -88,7 +88,7 @@ N/A
 | metrics.exporter.env.unknownQueueItems | bool | `false` | Set to true to enable gathering unknown queue items |
 | metrics.exporter.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | metrics.exporter.image.repository | string | `"ghcr.io/onedr0p/exportarr"` | image repository |
-| metrics.exporter.image.tag | string | `"v0.6.1"` | image tag |
+| metrics.exporter.image.tag | string | `"v0.6.2"` | image tag |
 | metrics.prometheusRule | object | See values.yaml | Enable and configure Prometheus Rules for the chart under this key. |
 | metrics.prometheusRule.rules | list | See prometheusrules.yaml | Configure additionial rules for the chart under this key. |
 | metrics.serviceMonitor.interval | string | `"3m"` |  |

--- a/charts/stable/sonarr/values.yaml
+++ b/charts/stable/sonarr/values.yaml
@@ -97,7 +97,7 @@ metrics:
       # -- image repository
       repository: ghcr.io/onedr0p/exportarr
       # -- image tag
-      tag: v0.6.1
+      tag: v0.6.2
       # -- image pull policy
       pullPolicy: IfNotPresent
     env:


### PR DESCRIPTION
Changes Made:
- Update patch level of radarr/sonarr/lidarr chart versions
- Update the exportarr container image from v0.6.1 -> v0.6.2

This patch resolves an issue when exportarr reads config.xml but the UrlBase property is empty.

This is tested and confirmed resolution in my environment.

Previous malformed URL in logs (v0.6.1)
```
exporter time="2021-12-16T18:26:22Z" level=info msg="Sending HTTP request to http://localhost:8989//api/v3/queue?page=1"
```

with the v.0.6.2 patch
```
exporter time="2021-12-16T20:18:12Z" level=info msg="Sending HTTP request to http://localhost:8989/api/v3/queue?page=1"
```

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
