### PR TITLE
[dendrite] Add dendrite helm chart

### DIFF
--- a/charts/incubator/dendrite/.helmignore
+++ b/charts/incubator/dendrite/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS file for Kubernetes
+OWNERS
+# helm-docs templates
+*.gotmpl

--- a/charts/incubator/dendrite/Chart.yaml
+++ b/charts/incubator/dendrite/Chart.yaml
@@ -21,8 +21,8 @@ maintainers:
 dependencies:
   - name: common
     repository: https://library-charts.k8s-at-home.com
-    version: 4.2.0
+    version: 4.3.0
   - name: postgresql
-    version: 10.13.14
+    version: 10.14.2
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled

--- a/charts/incubator/dendrite/Chart.yaml
+++ b/charts/incubator/dendrite/Chart.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v2
+appVersion: 0.5.1
+description: Dendrite Matrix Homeserver
+name: dendrite
+version: 1.0.0
+kubeVersion: ">=1.16.0-0"
+keywords:
+  - dendrite
+  - matrix
+  - homeserver
+  - monolith
+  - federation
+home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/dendrite
+sources:
+  - https://github.com/matrix-org/dendrite
+  - https://github.com/matrix-org/dendrite/tree/master/build/docker
+maintainers:
+  - name: jonnobrow
+    email: jonathan@jonnobrow.co.uk
+dependencies:
+  - name: common
+    repository: https://library-charts.k8s-at-home.com
+    version: 4.2.0
+  - name: postgresql
+    version: 10.13.14
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled

--- a/charts/incubator/dendrite/README.md
+++ b/charts/incubator/dendrite/README.md
@@ -1,0 +1,149 @@
+# dendrite
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 0.5.1](https://img.shields.io/badge/AppVersion-0.5.1-informational?style=flat-square)
+
+Dendrite Matrix Homeserver
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
+## Source Code
+
+* <https://github.com/matrix-org/dendrite>
+* <https://github.com/matrix-org/dendrite/tree/master/build/docker>
+
+## Requirements
+
+Kubernetes: `>=1.16.0-0`
+
+## Dependencies
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | postgresql | 10.13.14 |
+| https://library-charts.k8s-at-home.com | common | 4.2.0 |
+
+## TL;DR
+
+```console
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm repo update
+helm install dendrite k8s-at-home/dendrite
+```
+
+## Installing the Chart
+
+To install the chart with the release name `dendrite`
+
+```console
+helm install dendrite k8s-at-home/dendrite
+```
+
+## Uninstalling the Chart
+
+To uninstall the `dendrite` deployment
+
+```console
+helm uninstall dendrite
+```
+
+The command removes all the Kubernetes components associated with the chart **including persistent volumes** and deletes the release.
+
+## Configuration
+
+Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
+Other values may be used from the [values.yaml](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml) from the [common library](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common).
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```console
+helm install dendrite \
+  --set env.TZ="America/New York" \
+    k8s-at-home/dendrite
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart.
+
+```console
+helm install dendrite k8s-at-home/dendrite -f values.yaml
+```
+
+## Custom configuration
+
+N/A
+
+## Values
+
+**Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| dendrite.components | object | See values.yaml | Configure the dendrite components. |
+| dendrite.components.app_service_api | object | See values.yaml | Configure the App Service API |
+| dendrite.components.client_api | object | `{"captcha":{"enabled":false,"recaptcha_bypass_secret":"","recaptcha_private_key":"","recaptcha_public_key":"","recaptcha_siteverify_api":""},"rate_limiting":{"cooloff_ms":500,"enabled":true,"threshold":5},"registration_disabled":false,"registration_shared_secret":"","turn":{"turn_password":"","turn_shared_secret":"","turn_uris":[],"turn_user_lifetime":"","turn_username":""}}` | Configure the Client API |
+| dendrite.components.client_api.captcha | object | See values.yaml | Configure captcha for registration |
+| dendrite.components.client_api.rate_limiting | object | values.yaml | Configure rate limiting. |
+| dendrite.components.client_api.registration_disabled | bool | See values.yaml | Enable or disable registration for this homeserver. |
+| dendrite.components.client_api.registration_shared_secret | string | See values.yaml | Shared secret that allows registration, despite registration_disabled. |
+| dendrite.components.client_api.turn | object | See values.yaml | Configure TURN |
+| dendrite.components.federation_api | object | values.yaml | Configure the Federation API |
+| dendrite.components.media_api | object | values.yaml | Configure the Media API |
+| dendrite.database | object | See values.yaml | Configure database connection parameters. |
+| dendrite.global | object | See values.yaml | Configure the global settings for dendrite. |
+| dendrite.global.dns_cache | object | See values.yaml | Configure DNS cache. |
+| dendrite.global.dns_cache.enabled | bool | See values.yaml | If enabled, dns cache will be enabled. |
+| dendrite.global.key_validity_period | string | See values.yaml | Configure the key_validity period |
+| dendrite.global.metrics | object | See values.yaml | Configure prometheus metrics collection for dendrite. |
+| dendrite.global.metrics.enabled | bool | See values.yaml | If enabled, metrics collection will be enabled |
+| dendrite.global.server_name | string | See values.yaml | (required) Configure the server name for the dendrite instance. |
+| dendrite.global.trusted_third_party_id_servers | list | See the values.yaml | Configure the list of domains the server will trust as identity servers |
+| dendrite.global.well_known_server_name | string | See values.yaml | Configure the well-known server name and optional port |
+| dendrite.logging | list | See values.yaml | Configure logging. |
+| dendrite.matrix_key_secret | object | See values.yaml | If enabled, use an existing secret for matrix_key.pem. Otherwise a matrix_key.pem must be mounted to `/etc/dendrite`. |
+| dendrite.tls_secret | object | See values.yaml | If enabled, use an existing secrets for the TLS certificate and key. Otherwise, to enable TLS a `server.crt` and `server.key` must be mounted at `/etc/dendrite`. |
+| dendrite.tracing | object | See values.yaml | Configure opentracing. |
+| image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
+| image.repository | string | `"matrixdotorg/dendrite-monolith"` | image repository |
+| image.tag | string | `"v0.5.1"` | image tag |
+| ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
+| persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
+| postgresql.enabled | bool | See value.yaml | Enable and configure postgres as the database for dendrite. |
+| postgresql.persistence.enabled | bool | `false` |  |
+| postgresql.postgresqlDatabase | string | `"dendrite"` |  |
+| postgresql.postgresqlPassword | string | `"changeme"` |  |
+| postgresql.postgresqlUsername | string | `"dendrite"` |  |
+| service | object | See values.yaml | If added dendrite will start a HTTP and HTTPS listener args:   - "--tls-cert=server.crt"   - "--tls-key=server.key" -- Configures service settings for the chart. |
+| service.main.ports.http | object | See values.yaml | Configures the default HTTP listener for dendrite |
+| service.main.ports.https | object | See values.yaml | Configures the HTTPS listener for dendrite |
+
+## Changelog
+
+All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [1.0.0]
+
+#### Added
+
+- Initial version
+- Monolith Only
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
+
+[1.0.0]: #100
+
+## Support
+
+- See the [Docs](https://docs.k8s-at-home.com/our-helm-charts/getting-started/)
+- Open an [issue](https://github.com/k8s-at-home/charts/issues/new/choose)
+- Ask a [question](https://github.com/k8s-at-home/organization/discussions)
+- Join our [Discord](https://discord.gg/sTMX7Vh) community
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/incubator/dendrite/README.md.gotmpl
+++ b/charts/incubator/dendrite/README.md.gotmpl
@@ -1,0 +1,146 @@
+{{- define "custom.repository.organization" -}}
+k8s-at-home
+{{- end -}}
+
+{{- define "custom.repository.url" -}}
+https://github.com/k8s-at-home/charts
+{{- end -}}
+
+{{- define "custom.helm.url" -}}
+https://k8s-at-home.com/charts/
+{{- end -}}
+
+{{- define "custom.helm.path" -}}
+{{ template "custom.repository.organization" . }}/{{ template "chart.name" . }}
+{{- end -}}
+
+{{- define "custom.notes" -}}
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+{{- end -}}
+
+{{- define "custom.requirements" -}}
+## Requirements
+
+{{ template "chart.kubeVersionLine" . }}
+{{- end -}}
+
+{{- define "custom.dependencies" -}}
+## Dependencies
+
+{{ template "chart.requirementsTable" . }}
+{{- end -}}
+
+{{- define "custom.install.tldr" -}}
+## TL;DR
+
+```console
+helm repo add {{ template "custom.repository.organization" . }} {{ template "custom.helm.url" . }}
+helm repo update
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.install" -}}
+## Installing the Chart
+
+To install the chart with the release name `{{ template "chart.name" . }}`
+
+```console
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.uninstall" -}}
+## Uninstalling the Chart
+
+To uninstall the `{{ template "chart.name" . }}` deployment
+
+```console
+helm uninstall {{ template "chart.name" . }}
+```
+
+The command removes all the Kubernetes components associated with the chart **including persistent volumes** and deletes the release.
+{{- end -}}
+
+{{- define "custom.configuration.header" -}}
+## Configuration
+{{- end -}}
+
+{{- define "custom.configuration.readValues" -}}
+Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
+Other values may be used from the [values.yaml](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml) from the [common library](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common).
+{{- end -}}
+
+{{- define "custom.configuration.example.set" -}}
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```console
+helm install {{ template "chart.name" . }} \
+  --set env.TZ="America/New York" \
+    {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.configuration.example.file" -}}
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart.
+
+```console
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }} -f values.yaml
+```
+{{- end -}}
+
+{{- define "custom.valuesSection" -}}
+## Values
+
+**Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
+
+{{ template "chart.valuesTable" . }}
+{{- end -}}
+
+{{- define "custom.support" -}}
+## Support
+
+- See the [Docs](https://docs.k8s-at-home.com/our-helm-charts/getting-started/)
+- Open an [issue](https://github.com/k8s-at-home/charts/issues/new/choose)
+- Ask a [question](https://github.com/k8s-at-home/organization/discussions)
+- Join our [Discord](https://discord.gg/sTMX7Vh) community
+{{- end -}}
+
+{{ template "chart.header" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "custom.notes" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "custom.requirements" . }}
+
+{{ template "custom.dependencies" . }}
+
+{{ template "custom.install.tldr" . }}
+
+{{ template "custom.install" . }}
+
+{{ template "custom.uninstall" . }}
+
+{{ template "custom.configuration.header" . }}
+
+{{ template "custom.configuration.readValues" . }}
+
+{{ template "custom.configuration.example.set" . }}
+
+{{ template "custom.configuration.example.file" . }}
+
+{{ template "custom.custom.configuration" . }}
+
+{{ template "custom.valuesSection" . }}
+
+{{ template "custom.changelog" . }}
+
+{{ template "custom.support" . }}
+
+{{ template "helm-docs.versionFooter" . }}
+{{ "" }}

--- a/charts/incubator/dendrite/README_CHANGELOG.md.gotmpl
+++ b/charts/incubator/dendrite/README_CHANGELOG.md.gotmpl
@@ -1,0 +1,28 @@
+{{- define "custom.changelog.header" -}}
+## Changelog
+{{- end -}}
+
+{{- define "custom.changelog" -}}
+{{ template "custom.changelog.header" . }}
+
+All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [1.0.0]
+
+#### Added
+
+- Initial version
+- Monolith Only
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
+
+[1.0.0]: #100
+{{- end -}}

--- a/charts/incubator/dendrite/README_CONFIG.md.gotmpl
+++ b/charts/incubator/dendrite/README_CONFIG.md.gotmpl
@@ -1,0 +1,9 @@
+{{- define "custom.custom.configuration.header" -}}
+## Custom configuration
+{{- end -}}
+
+{{- define "custom.custom.configuration" -}}
+{{ template "custom.custom.configuration.header" . }}
+
+N/A
+{{- end -}}

--- a/charts/incubator/dendrite/ci/ct-values.yaml
+++ b/charts/incubator/dendrite/ci/ct-values.yaml
@@ -2,7 +2,6 @@
 dendrite:
   matrix_key_secret:
     enabled: true
-    secretName: "dendrite"
 secret:
   matrix_key.pem: |
     -----BEGIN MATRIX PRIVATE KEY-----

--- a/charts/incubator/dendrite/ci/ct-values.yaml
+++ b/charts/incubator/dendrite/ci/ct-values.yaml
@@ -1,0 +1,12 @@
+---
+dendrite:
+  matrix_key_secret:
+    enabled: true
+    secretName: "dendrite"
+secret:
+  matrix_key.pem: |
+    -----BEGIN MATRIX PRIVATE KEY-----
+    Key-ID: ed25519:P8gZqV
+
+    qVzy2Cwokt15RjGy8OzFSq6z0JFmI6QX/1Zw1VP73uU=
+    -----END MATRIX PRIVATE KEY-----

--- a/charts/incubator/dendrite/templates/NOTES.txt
+++ b/charts/incubator/dendrite/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/incubator/dendrite/templates/common.yaml
+++ b/charts/incubator/dendrite/templates/common.yaml
@@ -1,12 +1,12 @@
 {{ include "common.values.setup" . }}
 
 {{- define "dendrite.keyVolume" -}}
-enabled: {{ .Values.dendrite.matrix_key_secret.enabled }}
+enabled: {{ .Values.dendrite.matrix_key_secret.enabled | quote }}
 type: "custom"
 volumeSpec:
   secret:
     defaultMode: 0600
-    secretName: {{ .Values.dendrite.matrix_key_secret.secretName }}
+    secretName: {{ default (include "common.names.fullname" .) .Values.dendrite.matrix_key_secret.secretName }}
 subPath:
   - path: {{ .Values.dendrite.matrix_key_secret.key }}
     mountPath: "/etc/dendrite/matrix_key.pem"

--- a/charts/incubator/dendrite/templates/common.yaml
+++ b/charts/incubator/dendrite/templates/common.yaml
@@ -1,0 +1,50 @@
+{{ include "common.values.setup" . }}
+
+{{- define "dendrite.keyVolume" -}}
+enabled: {{ .Values.dendrite.matrix_key_secret.enabled }}
+type: "custom"
+volumeSpec:
+  secret:
+    defaultMode: 0600
+    secretName: {{ .Values.dendrite.matrix_key_secret.secretName }}
+subPath:
+  - path: {{ .Values.dendrite.matrix_key_secret.key }}
+    mountPath: "/etc/dendrite/matrix_key.pem"
+{{- end -}}
+{{- define "dendrite.tlsVolume" -}}
+enabled: {{ .Values.dendrite.tls_secret.enabled }}
+type: "custom"
+volumeSpec:
+  secret:
+    defaultMode: 0600
+    secretName: {{ .Values.dendrite.tls_secret.secretName }}
+subPath:
+  - path: {{ .Values.dendrite.tls_secret.crtKey }}
+    mountPath: "/etc/dendrite/server.crt"
+  - path: {{ .Values.dendrite.tls_secret.keyKey }}
+    mountPath: "/etc/dendrite/server.key"
+{{- end -}}
+{{- define "dendrite.configVolume" -}}
+enabled: "true"
+type: "custom"
+volumeSpec:
+  secret:
+    defaultMode: 0600
+    secretName: {{ include "common.names.fullname" . }}-config
+subPath:
+  - path: dendrite.yaml
+    mountPath: "/etc/dendrite/dendrite.yaml"
+{{- end -}}
+{{- $_ := set .Values.persistence "dendrite-key" (include "dendrite.keyVolume" . | fromYaml) -}}
+{{- $_ := set .Values.persistence "dendrite-config" (include "dendrite.configVolume" . | fromYaml) -}}
+{{- $_ := set .Values.persistence "dendrite-tls" (include "dendrite.tlsVolume" . | fromYaml) -}}
+{{- define "postgresql.initdbScripts" -}}
+create_db.sh: |
+  #!/bin/sh
+  for db in userapi_accounts userapi_devices mediaapi syncapi roomserver keyserver federationapi appservice naffka; do
+  createdb -U dendrite -O dendrite dendrite_$db
+  done
+{{- end -}}
+{{- $_ := set .Values.postgresql "initdbScripts" (include "postgresql.initdbScripts" . | fromYaml) -}}
+
+{{ include "common.all" . }}

--- a/charts/incubator/dendrite/templates/dendrite-config.yaml
+++ b/charts/incubator/dendrite/templates/dendrite-config.yaml
@@ -1,7 +1,7 @@
 {{- $max_open_conns := default 10 .Values.dendrite.database.max_open_conns }}
 {{- $max_idle_conns := default 2 .Values.dendrite.database.max_idle_conns }}
 {{- $conn_max_lifetime := default -1 .Values.dendrite.database.conn_max_lifetime }}
-{{- $connectionString := "file:dendrite.db" -}}
+{{- $connectionString := "file:" -}}
 {{- if .Values.postgresql.enabled}}
 {{- $connectionString = print "postgresql://" .Values.postgresql.postgresqlUsername ":" .Values.postgresql.postgresqlPassword "@dendrite-postgresql/" -}}
 {{- end}}

--- a/charts/incubator/dendrite/templates/dendrite-config.yaml
+++ b/charts/incubator/dendrite/templates/dendrite-config.yaml
@@ -1,0 +1,179 @@
+{{- $max_open_conns := default 10 .Values.dendrite.database.max_open_conns }}
+{{- $max_idle_conns := default 2 .Values.dendrite.database.max_idle_conns }}
+{{- $conn_max_lifetime := default -1 .Values.dendrite.database.conn_max_lifetime }}
+{{- $connectionString := "file:dendrite.db" -}}
+{{- if .Values.postgresql.enabled}}
+{{- $connectionString = print "postgresql://" .Values.postgresql.postgresqlUsername ":" .Values.postgresql.postgresqlPassword "@dendrite-postgresql/" -}}
+{{- end}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-config
+type: Opaque
+stringData:
+  dendrite.yaml: |
+    version: 1
+    global:
+      server_name: {{ required "A server_name must be provided." .Values.dendrite.global.server_name | quote }}
+      private_key: matrix_key.pem
+      key_validity_period: {{ default "168h0m0s" .Values.dendrite.global.key_validity_period | quote }}
+      well_known_server_name: {{ default "" .Values.dendrite.global.well_known_server_name | quote }}
+      trusted_third_party_id_servers:
+      {{- toYaml .Values.dendrite.global.trusted_third_party_id_servers | nindent 8 }}
+      kafka:
+        topic_prefix: "Dendrite"
+        use_naffka: true
+        naffka_database:
+          connection_string: {{ $connectionString }}dendrite_naffka?sslmode=disable
+          max_open_conns: {{ $max_open_conns }}
+          max_idle_conns: {{ $max_idle_conns }}
+          conn_max_lifetime: {{ $conn_max_lifetime }}
+      metrics:
+        enabled: {{ default false .Values.dendrite.global.metrics.enabled }}
+        basic_auth:
+          username: {{ default "metrics" .Values.dendrite.global.metrics.basic_auth.username | quote }}
+          password: {{ default "metrics" .Values.dendrite.global.metrics.basic_auth.password | quote }}
+      dns_cache:
+        enabled: {{ default false .Values.dendrite.global.dns_cache.enabled }}
+        cache_size: {{ default 256 .Values.dendrite.global.dns_cache.cache_size }}
+        cache_lifetime: {{ default 300 .Values.dendrite.global.dns_cache.cache_lifetime }}
+    # Configuration for the Appservice API.
+    app_service_api:
+      internal_api:
+        listen: http://0.0.0.0:7777
+        connect: http://appservice_api:7777
+      database:
+        connection_string: {{ $connectionString }}dendrite_appservice?sslmode=disable
+        max_open_conns: {{ $max_open_conns }}
+        max_idle_conns: {{ $max_idle_conns }}
+        conn_max_lifetime: {{ $conn_max_lifetime }}
+      config_files:
+{{- toYaml .Values.dendrite.components.app_service_api.config_files | nindent 8 }}
+
+    # Configuration for the Client API.
+    client_api:
+      internal_api:
+        listen: http://0.0.0.0:7771
+        connect: http://client_api:7771
+      external_api:
+        listen: http://0.0.0.0:8071
+
+      registration_disabled: {{ default false .Values.dendrite.components.client_api.registration_disabled }}
+      registration_shared_secret: {{ default "" .Values.dendrite.components.client_api.registration_shared_secret | quote }}
+      enable_registration_captcha: {{ default false .Values.dendrite.components.client_api.captcha.enabled }}
+
+
+      # Settings for ReCAPTCHA.
+      recaptcha_public_key: {{ default "" .Values.dendrite.components.client_api.captcha.recaptcha_public_key | quote }}
+      recaptcha_private_key: {{ default "" .Values.dendrite.components.client_api.captcha.recaptcha_private_key | quote }}
+      recaptcha_bypass_secret: {{ default "" .Values.dendrite.components.client_api.captcha.recaptcha_bypass_secret | quote }}
+      recaptcha_siteverify_api: {{ default "" .Values.dendrite.components.client_api.captcha.recaptcha_siteverify_api | quote }}
+
+      # TURN server information that this homeserver should send to clients.
+      turn:
+{{- toYaml .Values.dendrite.components.client_api.turn | nindent 8 }}
+
+      # Settings for rate-limited endpoints. Rate limiting will kick in after the
+      # threshold number of "slots" have been taken by requests from a specific
+      # host. Each "slot" will be released after the cooloff time in milliseconds.
+      rate_limiting:
+        enabled: {{ default true .Values.dendrite.components.client_api.rate_limiting.enabled }}
+        threshold: {{ default 5 .Values.dendrite.components.client_api.rate_limiting.threshold }}
+        cooloff_ms: {{ default 500 .Values.dendrite.components.client_api.rate_limiting.cooloff_ms }}
+    edu_server:
+      internal_api:
+        listen: http://0.0.0.0:7778
+        connect: http://edu_server:7778
+    federation_api:
+      internal_api:
+        listen: http://0.0.0.0:7772
+        connect: http://federation_api:7772
+      external_api:
+        listen: http://0.0.0.0:8072
+      database:
+        connection_string: {{ $connectionString }}dendrite_federationapi?sslmode=disable
+        max_open_conns: {{ $max_open_conns }}
+        max_idle_conns: {{ $max_idle_conns }}
+        conn_max_lifetime: {{ $conn_max_lifetime }}
+      federation_certificates:
+{{- toYaml .Values.dendrite.components.federation_api.federation_certificates | nindent 8 }}
+      send_max_retries: {{ default 16 .Values.dendrite.components.federation_api.send_max_retries }}
+      disable_tls_validation: {{ default false .Values.dendrite.components.federation_api.disable_tls_validation }}
+      # Use the following proxy server for outbound federation traffic.
+      proxy_outbound:
+        enabled: {{ default false .Values.dendrite.components.federation_api.proxy_outbound.enabled }}
+
+        protocol: {{ default "http" .Values.dendrite.components.federation_api.proxy_outbound.protocol | quote }}
+
+        host: {{ default "localhost" .Values.dendrite.components.federation_api.proxy_outbound.host | quote }}
+        port: {{ default 8080 .Values.dendrite.components.federation_api.proxy_outbound.port }}
+      key_perspectives:
+{{- toYaml .Values.dendrite.components.federation_api.key_perspectives | nindent 8 }}
+      prefer_direct_fetch: {{ default false .Values.dendrite.components.federation_api.prefer_direct_fetch }}
+    key_server:
+      internal_api:
+        listen: http://0.0.0.0:7779
+        connect: http://key_server:7779
+      database:
+        connection_string: {{ $connectionString }}dendrite_keyserver?sslmode=disable
+        max_open_conns: {{ $max_open_conns }}
+        max_idle_conns: {{ $max_idle_conns }}
+        conn_max_lifetime: {{ $conn_max_lifetime }}
+    media_api:
+      internal_api:
+        listen: http://0.0.0.0:7774
+        connect: http://media_api:7774
+      external_api:
+        listen: http://0.0.0.0:8074
+      database:
+        connection_string: {{ $connectionString }}dendrite_mediaapi?sslmode=disable
+        max_open_conns: {{ $max_open_conns }}
+        max_idle_conns: {{ $max_idle_conns }}
+        conn_max_lifetime: {{ $conn_max_lifetime }}
+      base_path: {{ default "/var/dendrite/media" .Values.dendrite.components.media_api.base_path | quote }}
+      max_file_size_bytes: {{ default 10485760 .Values.dendrite.components.media_api.max_file_size_bytes }}
+      dynamic_thumbnails: {{ default false .Values.dendrite.components.media_api.dynamic_thumbnails }}
+      max_thumbnail_generators: {{ default 10 .Values.dendrite.components.media_api.max_thumbnail_generators }}
+      thumbnail_sizes:
+{{- toYaml .Values.dendrite.components.media_api.thumbnail_sizes | nindent 8 }}
+    room_server:
+      internal_api:
+        listen: http://0.0.0.0:7770
+        connect: http://room_server:7770
+      database:
+        connection_string: {{ $connectionString }}dendrite_roomserver?sslmode=disable
+        max_open_conns: {{ $max_open_conns }}
+        max_idle_conns: {{ $max_idle_conns }}
+        conn_max_lifetime: {{ $conn_max_lifetime }}
+    sync_api:
+      internal_api:
+        listen: http://0.0.0.0:7773
+        connect: http://sync_api:7773
+      external_api:
+          listen: http://0.0.0.0:8073
+      database:
+        connection_string: {{ $connectionString }}dendrite_syncapi?sslmode=disable
+        max_open_conns: {{ $max_open_conns }}
+        max_idle_conns: {{ $max_idle_conns }}
+        conn_max_lifetime: {{ $conn_max_lifetime }}
+    user_api:
+      internal_api:
+        listen: http://0.0.0.0:7781
+        connect: http://user_api:7781
+      account_database:
+        connection_string: {{ $connectionString }}dendrite_userapi_accounts?sslmode=disable
+        max_open_conns: {{ $max_open_conns }}
+        max_idle_conns: {{ $max_idle_conns }}
+        conn_max_lifetime: {{ $conn_max_lifetime }}
+      device_database:
+        connection_string: {{ $connectionString }}dendrite_userapi_devices?sslmode=disable
+        max_open_conns: {{ $max_open_conns }}
+        max_idle_conns: {{ $max_idle_conns }}
+        conn_max_lifetime: {{ $conn_max_lifetime }}
+    tracing:
+      enabled: {{ .Values.dendrite.tracing.enabled }}
+      jaeger:
+{{- toYaml .Values.dendrite.tracing.jaeger | nindent 8 }}
+    logging:
+{{- toYaml .Values.dendrite.logging | nindent 6 }}

--- a/charts/incubator/dendrite/templates/dendrite-config.yaml
+++ b/charts/incubator/dendrite/templates/dendrite-config.yaml
@@ -1,6 +1,3 @@
-{{- $max_open_conns := default 10 .Values.dendrite.database.max_open_conns }}
-{{- $max_idle_conns := default 2 .Values.dendrite.database.max_idle_conns }}
-{{- $conn_max_lifetime := default -1 .Values.dendrite.database.conn_max_lifetime }}
 {{- $connectionString := "file:" -}}
 {{- if .Values.postgresql.enabled}}
 {{- $connectionString = print "postgresql://" .Values.postgresql.postgresqlUsername ":" .Values.postgresql.postgresqlPassword "@dendrite-postgresql/" -}}
@@ -26,9 +23,9 @@ stringData:
         use_naffka: true
         naffka_database:
           connection_string: {{ $connectionString }}dendrite_naffka?sslmode=disable
-          max_open_conns: {{ $max_open_conns }}
-          max_idle_conns: {{ $max_idle_conns }}
-          conn_max_lifetime: {{ $conn_max_lifetime }}
+          max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
+          max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
+          conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
       metrics:
         enabled: {{ default false .Values.dendrite.global.metrics.enabled }}
         basic_auth:
@@ -37,46 +34,31 @@ stringData:
       dns_cache:
         enabled: {{ default false .Values.dendrite.global.dns_cache.enabled }}
         cache_size: {{ default 256 .Values.dendrite.global.dns_cache.cache_size }}
-        cache_lifetime: {{ default 300 .Values.dendrite.global.dns_cache.cache_lifetime }}
-    # Configuration for the Appservice API.
+        cache_lifetime: {{ default "5m" .Values.dendrite.global.dns_cache.cache_lifetime }}
     app_service_api:
       internal_api:
         listen: http://0.0.0.0:7777
         connect: http://appservice_api:7777
       database:
         connection_string: {{ $connectionString }}dendrite_appservice?sslmode=disable
-        max_open_conns: {{ $max_open_conns }}
-        max_idle_conns: {{ $max_idle_conns }}
-        conn_max_lifetime: {{ $conn_max_lifetime }}
-      config_files:
-{{- toYaml .Values.dendrite.components.app_service_api.config_files | nindent 8 }}
-
-    # Configuration for the Client API.
+        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
+        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
+        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
+      config_files: {{- toYaml .Values.dendrite.components.app_service_api.config_files | nindent 8 }}
     client_api:
       internal_api:
         listen: http://0.0.0.0:7771
         connect: http://client_api:7771
       external_api:
         listen: http://0.0.0.0:8071
-
       registration_disabled: {{ default false .Values.dendrite.components.client_api.registration_disabled }}
       registration_shared_secret: {{ default "" .Values.dendrite.components.client_api.registration_shared_secret | quote }}
       enable_registration_captcha: {{ default false .Values.dendrite.components.client_api.captcha.enabled }}
-
-
-      # Settings for ReCAPTCHA.
       recaptcha_public_key: {{ default "" .Values.dendrite.components.client_api.captcha.recaptcha_public_key | quote }}
       recaptcha_private_key: {{ default "" .Values.dendrite.components.client_api.captcha.recaptcha_private_key | quote }}
       recaptcha_bypass_secret: {{ default "" .Values.dendrite.components.client_api.captcha.recaptcha_bypass_secret | quote }}
       recaptcha_siteverify_api: {{ default "" .Values.dendrite.components.client_api.captcha.recaptcha_siteverify_api | quote }}
-
-      # TURN server information that this homeserver should send to clients.
-      turn:
-{{- toYaml .Values.dendrite.components.client_api.turn | nindent 8 }}
-
-      # Settings for rate-limited endpoints. Rate limiting will kick in after the
-      # threshold number of "slots" have been taken by requests from a specific
-      # host. Each "slot" will be released after the cooloff time in milliseconds.
+      turn: {{- toYaml .Values.dendrite.components.client_api.turn | nindent 8 }}
       rate_limiting:
         enabled: {{ default true .Values.dendrite.components.client_api.rate_limiting.enabled }}
         threshold: {{ default 5 .Values.dendrite.components.client_api.rate_limiting.threshold }}
@@ -93,23 +75,18 @@ stringData:
         listen: http://0.0.0.0:8072
       database:
         connection_string: {{ $connectionString }}dendrite_federationapi?sslmode=disable
-        max_open_conns: {{ $max_open_conns }}
-        max_idle_conns: {{ $max_idle_conns }}
-        conn_max_lifetime: {{ $conn_max_lifetime }}
-      federation_certificates:
-{{- toYaml .Values.dendrite.components.federation_api.federation_certificates | nindent 8 }}
+        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
+        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
+        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
+      federation_certificates: {{- toYaml .Values.dendrite.components.federation_api.federation_certificates | nindent 8 }}
       send_max_retries: {{ default 16 .Values.dendrite.components.federation_api.send_max_retries }}
       disable_tls_validation: {{ default false .Values.dendrite.components.federation_api.disable_tls_validation }}
-      # Use the following proxy server for outbound federation traffic.
       proxy_outbound:
         enabled: {{ default false .Values.dendrite.components.federation_api.proxy_outbound.enabled }}
-
         protocol: {{ default "http" .Values.dendrite.components.federation_api.proxy_outbound.protocol | quote }}
-
         host: {{ default "localhost" .Values.dendrite.components.federation_api.proxy_outbound.host | quote }}
         port: {{ default 8080 .Values.dendrite.components.federation_api.proxy_outbound.port }}
-      key_perspectives:
-{{- toYaml .Values.dendrite.components.federation_api.key_perspectives | nindent 8 }}
+      key_perspectives: {{- toYaml .Values.dendrite.components.federation_api.key_perspectives | nindent 8 }}
       prefer_direct_fetch: {{ default false .Values.dendrite.components.federation_api.prefer_direct_fetch }}
     key_server:
       internal_api:
@@ -117,9 +94,9 @@ stringData:
         connect: http://key_server:7779
       database:
         connection_string: {{ $connectionString }}dendrite_keyserver?sslmode=disable
-        max_open_conns: {{ $max_open_conns }}
-        max_idle_conns: {{ $max_idle_conns }}
-        conn_max_lifetime: {{ $conn_max_lifetime }}
+        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
+        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
+        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
     media_api:
       internal_api:
         listen: http://0.0.0.0:7774
@@ -128,24 +105,23 @@ stringData:
         listen: http://0.0.0.0:8074
       database:
         connection_string: {{ $connectionString }}dendrite_mediaapi?sslmode=disable
-        max_open_conns: {{ $max_open_conns }}
-        max_idle_conns: {{ $max_idle_conns }}
-        conn_max_lifetime: {{ $conn_max_lifetime }}
+        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
+        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
+        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
       base_path: {{ default "/var/dendrite/media" .Values.dendrite.components.media_api.base_path | quote }}
       max_file_size_bytes: {{ default 10485760 .Values.dendrite.components.media_api.max_file_size_bytes }}
       dynamic_thumbnails: {{ default false .Values.dendrite.components.media_api.dynamic_thumbnails }}
       max_thumbnail_generators: {{ default 10 .Values.dendrite.components.media_api.max_thumbnail_generators }}
-      thumbnail_sizes:
-{{- toYaml .Values.dendrite.components.media_api.thumbnail_sizes | nindent 8 }}
+      thumbnail_sizes: {{- toYaml .Values.dendrite.components.media_api.thumbnail_sizes | nindent 8 }}
     room_server:
       internal_api:
         listen: http://0.0.0.0:7770
         connect: http://room_server:7770
       database:
         connection_string: {{ $connectionString }}dendrite_roomserver?sslmode=disable
-        max_open_conns: {{ $max_open_conns }}
-        max_idle_conns: {{ $max_idle_conns }}
-        conn_max_lifetime: {{ $conn_max_lifetime }}
+        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
+        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
+        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
     sync_api:
       internal_api:
         listen: http://0.0.0.0:7773
@@ -154,26 +130,24 @@ stringData:
           listen: http://0.0.0.0:8073
       database:
         connection_string: {{ $connectionString }}dendrite_syncapi?sslmode=disable
-        max_open_conns: {{ $max_open_conns }}
-        max_idle_conns: {{ $max_idle_conns }}
-        conn_max_lifetime: {{ $conn_max_lifetime }}
+        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
+        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
+        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
     user_api:
       internal_api:
         listen: http://0.0.0.0:7781
         connect: http://user_api:7781
       account_database:
         connection_string: {{ $connectionString }}dendrite_userapi_accounts?sslmode=disable
-        max_open_conns: {{ $max_open_conns }}
-        max_idle_conns: {{ $max_idle_conns }}
-        conn_max_lifetime: {{ $conn_max_lifetime }}
+        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
+        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
+        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
       device_database:
         connection_string: {{ $connectionString }}dendrite_userapi_devices?sslmode=disable
-        max_open_conns: {{ $max_open_conns }}
-        max_idle_conns: {{ $max_idle_conns }}
-        conn_max_lifetime: {{ $conn_max_lifetime }}
+        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
+        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
+        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
     tracing:
       enabled: {{ .Values.dendrite.tracing.enabled }}
-      jaeger:
-{{- toYaml .Values.dendrite.tracing.jaeger | nindent 8 }}
-    logging:
-{{- toYaml .Values.dendrite.logging | nindent 6 }}
+      jaeger: {{- toYaml .Values.dendrite.tracing.jaeger | nindent 8 }}
+    logging: {{- toYaml .Values.dendrite.logging | nindent 6 }}

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -67,7 +67,6 @@ dendrite:
   # @default -- See values.yaml
   matrix_key_secret:
     enabled: false
-    secretName: "dendrite-key"
     key: matrix_key.pem
   # -- Configure database connection parameters.
   # @default -- See values.yaml

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -1,0 +1,215 @@
+#
+# IMPORTANT NOTE
+#
+# This chart inherits from our common library chart. You can check the default
+# values/options here:
+# https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml
+#
+---
+image:
+  # -- image repository
+  repository: matrixdotorg/dendrite-monolith
+  # -- image tag
+  tag: "v0.5.1"
+  # -- image pull policy
+  pullPolicy: IfNotPresent
+
+# -- If added dendrite will start a HTTP and HTTPS listener
+# args:
+#   - "--tls-cert=server.crt"
+#   - "--tls-key=server.key"
+
+# -- Configures service settings for the chart.
+# @default -- See values.yaml
+service:
+  main:
+    ports:
+      # -- Configures the default HTTP listener for dendrite
+      # @default -- See values.yaml
+      http:
+        port: 8008
+      # -- Configures the HTTPS listener for dendrite
+      # @default -- See values.yaml
+      https:
+        enabled: true
+        port: 8448
+        protocol: HTTPS
+
+ingress:
+  # -- Enable and configure ingress settings for the chart under this key.
+  # @default -- See values.yaml
+  main:
+    enabled: false
+
+# -- Configure persistence settings for the chart under this key.
+# @default -- See values.yaml
+persistence:
+  media:
+    enabled: false
+    mountPath: &mediaPath /var/dendrite/media
+
+# Configuratio for Dendrite.
+# For more information see [the sample
+# denrite-config.yaml](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
+# @default -- See values.yaml
+dendrite:
+  # -- If enabled, use an existing secrets for the TLS certificate and key.
+  # Otherwise, to enable TLS a `server.crt` and `server.key` must be mounted at
+  # `/etc/dendrite`.
+  # @default -- See values.yaml
+  tls_secret:
+    enabled: false
+    secretName: "dendrite-tls"
+    crtKey: tls.crt
+    keyKey: tls.key
+  # -- If enabled, use an existing secret for matrix_key.pem. Otherwise a
+  # matrix_key.pem must be mounted to `/etc/dendrite`.
+  # @default -- See values.yaml
+  matrix_key_secret:
+    enabled: false
+    secretName: "dendrite-key"
+    key: matrix_key.pem
+  # -- Configure database connection parameters.
+  # @default -- See values.yaml
+  database:
+    max_open_conns: 100
+    max_idle_conns: 2
+    conn_max_lifetime: -1
+  # -- Configure the global settings for dendrite.
+  # @default -- See values.yaml
+  global:
+    # -- (required) Configure the server name for the dendrite instance.
+    # @default -- See values.yaml
+    server_name: localhost
+    # -- Configure the key_validity period
+    # @default -- See values.yaml
+    key_validity_period: 168h0m0s
+    # -- Configure the well-known server name and optional port
+    # @default -- See values.yaml
+    well_known_server_name: ""
+    # -- Configure the list of domains the server will trust as identity servers
+    # @default -- See the values.yaml
+    trusted_third_party_id_servers:
+      - matrix.org
+      - vector.im
+    # -- Configure prometheus metrics collection for dendrite.
+    # @default -- See values.yaml
+    metrics:
+      # -- If enabled, metrics collection will be enabled
+      # @default -- See values.yaml
+      enabled: false
+      basic_auth:
+        username: metrics
+        password: metrics
+    # -- Configure DNS cache.
+    # @default -- See values.yaml
+    dns_cache:
+      # -- If enabled, dns cache will be enabled.
+      # @default -- See values.yaml
+      enabled: false
+      cache_size: 256
+      cache_lifetime: 300
+  # -- Configure the dendrite components.
+  # @default -- See values.yaml
+  components:
+    # -- Configure the App Service API
+    # @default -- See values.yaml
+    app_service_api:
+      config_files: []
+    # -- Configure the Client API
+    client_api:
+      # -- Enable or disable registration for this homeserver.
+      # @default -- See values.yaml
+      registration_disabled: false
+      # -- Shared secret that allows registration, despite registration_disabled.
+      # @default -- See values.yaml
+      registration_shared_secret: ""
+      # -- Configure captcha for registration
+      # @default -- See values.yaml
+      captcha:
+        enabled: false
+        recaptcha_public_key: ""
+        recaptcha_private_key: ""
+        recaptcha_bypass_secret: ""
+        recaptcha_siteverify_api: ""
+      # -- Configure TURN
+      # @default -- See values.yaml
+      turn:
+        turn_user_lifetime: ""
+        turn_uris: []
+        turn_shared_secret: ""
+        turn_username: ""
+        turn_password: ""
+      # -- Configure rate limiting.
+      # @default -- values.yaml
+      rate_limiting:
+        enabled: true
+        threshold: 5
+        cooloff_ms: 500
+    # -- Configure the Federation API
+    # @default -- values.yaml
+    federation_api:
+      federation_certificates: []
+      send_max_retires: 16
+      disable_tls_validation: false
+      proxy_outbound:
+        enabled: false
+        protocol: http
+        host: localhost
+        port: 8080
+      key_perspectives:
+        - server_name: matrix.org
+          keys:
+            - key_id: ed25519:auto
+              public_key: Noi6WqcDj0QmPxCNQqgezwTlBKrfqehY1u2FyWP9uYw
+            - key_id: ed25519:a_RXGa
+              public_key: l8Hft5qXKn1vfHrg3p4+W8gELQVo8N13JkluMfmn2sQ
+      prefer_direct_fetch: false
+    # -- Configure the Media API
+    # @default -- values.yaml
+    media_api:
+      base_path: *mediaPath
+      max_file_size_bytes: 10485760
+      dynamic_thumbnails: false
+      max_thumbnail_generators: 10
+      thumbnail_sizes:
+        - width: 32
+          height: 32
+          method: crop
+        - width: 96
+          height: 96
+          method: crop
+        - width: 640
+          height: 480
+          method: scale
+  # -- Configure opentracing.
+  # @default -- See values.yaml
+  tracing:
+    enabled: false
+    jaeger:
+      serviceName: ""
+      disabled: false
+      rpc_metrics: false
+      tags: []
+      sampler: null
+      reporter: null
+      headers: null
+      baggage_restrictions: null
+      throttler: null
+  # -- Configure logging.
+  # @default -- See values.yaml
+  logging:
+    - type: file
+      level: info
+      params:
+        path: /var/log/dendrite
+
+postgresql:
+  # -- Enable and configure postgres as the database for dendrite.
+  # @default -- See value.yaml
+  enabled: false
+  postgresqlUsername: dendrite
+  postgresqlPassword: changeme
+  postgresqlDatabase: dendrite
+  persistence:
+    enabled: false

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -48,7 +48,7 @@ persistence:
     enabled: false
     mountPath: &mediaPath /var/dendrite/media
 
-# Configuratio for Dendrite.
+# -- Configuration for Dendrite.
 # For more information see [the sample
 # denrite-config.yaml](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
 # @default -- See values.yaml
@@ -78,16 +78,12 @@ dendrite:
   # @default -- See values.yaml
   global:
     # -- (required) Configure the server name for the dendrite instance.
-    # @default -- See values.yaml
     server_name: localhost
     # -- Configure the key_validity period
-    # @default -- See values.yaml
     key_validity_period: 168h0m0s
     # -- Configure the well-known server name and optional port
-    # @default -- See values.yaml
     well_known_server_name: ""
     # -- Configure the list of domains the server will trust as identity servers
-    # @default -- See the values.yaml
     trusted_third_party_id_servers:
       - matrix.org
       - vector.im
@@ -107,7 +103,7 @@ dendrite:
       # @default -- See values.yaml
       enabled: false
       cache_size: 256
-      cache_lifetime: 300
+      cache_lifetime: "5m"
   # -- Configure the dendrite components.
   # @default -- See values.yaml
   components:
@@ -118,10 +114,8 @@ dendrite:
     # -- Configure the Client API
     client_api:
       # -- Enable or disable registration for this homeserver.
-      # @default -- See values.yaml
       registration_disabled: false
       # -- Shared secret that allows registration, despite registration_disabled.
-      # @default -- See values.yaml
       registration_shared_secret: ""
       # -- Configure captcha for registration
       # @default -- See values.yaml


### PR DESCRIPTION
This is the initial version of a Dendrite helm chart that supports monolithic deployment.

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Adds a new chart for deploying [Dendrite](https://github.com/matrix-org/dendrite), a matrix homeserver. 

It only supports the monolithic deployment but the dendrite installation documentation states:
> For most deployments, it is recommended to run in monolith mode with PostgreSQL databases.

**Benefits**
- Easy configuration use the values.yaml file
- Quick to install

**Possible drawbacks**
- No support for polylith deployments

**Applicable issues**
- Closes #1269 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
