### PR TITLE
[vaultwarden] Use port names in ingress setup

### DIFF
--- a/charts/stable/vaultwarden/Chart.yaml
+++ b/charts/stable/vaultwarden/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.22.2
 description: Vaultwarden is a Bitwarden compatable server in Rust
 name: vaultwarden
-version: 3.3.1
+version: 3.3.2
 kubeVersion: ">=1.16.0-0"
 keywords:
 - Vaultwarden

--- a/charts/stable/vaultwarden/README.md
+++ b/charts/stable/vaultwarden/README.md
@@ -103,7 +103,7 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [3.2.2]
+### [3.3.2]
 
 #### Changed
 

--- a/charts/stable/vaultwarden/README.md
+++ b/charts/stable/vaultwarden/README.md
@@ -1,6 +1,6 @@
 # vaultwarden
 
-![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![AppVersion: 1.22.2](https://img.shields.io/badge/AppVersion-1.22.2-informational?style=flat-square)
+![Version: 3.3.2](https://img.shields.io/badge/Version-3.3.2-informational?style=flat-square) ![AppVersion: 1.22.2](https://img.shields.io/badge/AppVersion-1.22.2-informational?style=flat-square)
 
 Vaultwarden is a Bitwarden compatable server in Rust
 

--- a/charts/stable/vaultwarden/README.md
+++ b/charts/stable/vaultwarden/README.md
@@ -103,6 +103,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.2.2]
+
+#### Changed
+
+- Ingress config uses port names. Now there is no need to update port in both service and rember to change it in ingress
+
 ### [3.2.1]
 
 #### Added

--- a/charts/stable/vaultwarden/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/vaultwarden/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.2.2]
+
+#### Changed
+
+- Ingress config uses port names. Now there is no need to update port in both service and rember to change it in ingress
+
 ### [3.2.1]
 
 #### Added

--- a/charts/stable/vaultwarden/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/vaultwarden/README_CHANGELOG.md.gotmpl
@@ -9,7 +9,7 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [3.2.2]
+### [3.3.2]
 
 #### Changed
 

--- a/charts/stable/vaultwarden/values.yaml
+++ b/charts/stable/vaultwarden/values.yaml
@@ -44,15 +44,15 @@ ingress:
           - path: /
             pathType: Prefix
             service:
-              port: 80
+              port: http
           - path: /notifications/hub/negotiate
             pathType: Prefix
             service:
-              port: 80
+              port: http
           - path: /notifications/hub
             pathType: Prefix
             service:
-              port: 3012
+              port: websocket
 
 # -- Configure persistence settings for the chart under this key.
 # @default -- See values.yaml


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

DRY a bit ports setup in ingress.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

When changing port number in service ( for example to run as non root ). User is also required to override ingress ports setup. This can be avoided if we use port name.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
