### PR TITLE
[mealie] Fix postgresql subchart name

### DIFF
--- a/charts/stable/mealie/Chart.yaml
+++ b/charts/stable/mealie/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.5.1
 description: Mealie is a self hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in Vue for a pleasant user experience for the whole family.
 name: mealie
-version: 3.2.0
+version: 3.2.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - grocy

--- a/charts/stable/mealie/README.md
+++ b/charts/stable/mealie/README.md
@@ -1,6 +1,6 @@
 # mealie
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
+![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![AppVersion: v0.5.1](https://img.shields.io/badge/AppVersion-v0.5.1-informational?style=flat-square)
 
 Mealie is a self hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in Vue for a pleasant user experience for the whole family.
 
@@ -84,7 +84,7 @@ N/A
 | image.tag | string | `"v0.5.1"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
-| postgres | object | See values.yaml | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
+| postgresql | object | See values.yaml | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog

--- a/charts/stable/mealie/values.yaml
+++ b/charts/stable/mealie/values.yaml
@@ -45,7 +45,7 @@ persistence:
 # -- Enable and configure postgresql database subchart under this key.
 #    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
 # @default -- See values.yaml
-postgres:
+postgresql:
   enabled: false
   postgresqlUsername: mealie
   postgresqlPassword: mealie-pass


### PR DESCRIPTION
**Description of the change**

The subchart postgresql had a typo  in values file,  this was creating postgresql even though its off by default.

**Benefits**

The values file is fixed. The postgresql will created only when enabled=true in values file

**Possible drawbacks**

None

**Applicable issues**

- fixes #

**Additional information**

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)
