### PR TITLE
[openhab] update to openhab 3.2.0

### DIFF
--- a/charts/incubator/openhab/Chart.yaml
+++ b/charts/incubator/openhab/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 3.1.0
+appVersion: 3.2.0
 description: openhab helm package
 name: openhab
-version: 1.1.0
+version: 1.2.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - openhab

--- a/charts/incubator/openhab/README.md
+++ b/charts/incubator/openhab/README.md
@@ -1,6 +1,6 @@
 # openhab
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=flat-square)
 
 openhab helm package
 
@@ -78,7 +78,7 @@ N/A
 | env | string | `nil` | environment variables. See more environment variables in the [openhab image documentation](https://hub.docker.com/r/openhab/openhab). |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"openhab/openhab"` | image repository |
-| image.tag | string | `"3.1.0"` | image tag |
+| image.tag | string | `"3.2.0"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. Choose either -- a single volume for all data or separate volumes for each sub-directory. |
 | persistence.addons | object | `{"enabled":false,"mountPath":"/openhab/addons"}` | separate volumes |

--- a/charts/incubator/openhab/values.yaml
+++ b/charts/incubator/openhab/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: openhab/openhab
   # -- image tag
-  tag: 3.1.0
+  tag: 3.2.0
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
update to the latest stable openhab version 3.2.0

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)
