### PR TITLE
[blocky] update to blocky v0.17

### DIFF
--- a/charts/stable/blocky/Chart.yaml
+++ b/charts/stable/blocky/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.15
+appVersion: v0.17
 description: DNS proxy as ad-blocker for local network
 name: blocky
-version: 9.1.0
+version: 10.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - blocky

--- a/charts/stable/blocky/README.md
+++ b/charts/stable/blocky/README.md
@@ -1,6 +1,6 @@
 # blocky
 
-![Version: 9.1.0](https://img.shields.io/badge/Version-9.1.0-informational?style=flat-square) ![AppVersion: v0.15](https://img.shields.io/badge/AppVersion-v0.15-informational?style=flat-square)
+![Version: 10.0.0](https://img.shields.io/badge/Version-10.0.0-informational?style=flat-square) ![AppVersion: v0.17](https://img.shields.io/badge/AppVersion-v0.17-informational?style=flat-square)
 
 DNS proxy as ad-blocker for local network
 
@@ -75,20 +75,23 @@ N/A
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config | string | see URL to default config | Full list of options https://github.com/0xERR0R/blocky/blob/master/docs/config.yml |
+| config | string | see URL to default config | Full list of options https://github.com/0xERR0R/blocky/blob/v0.17/docs/config.yml |
 | controller.replicas | int | `1` | (int) Number of pods to load balance between |
 | controller.strategy | string | `"RollingUpdate"` | Set the controller upgrade strategy |
 | env | object | See below | environment variables. See [image docs](https://0xerr0r.github.io/blocky/installation/#run-with-docker) for more details. |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"spx01/blocky"` | image repository |
-| image.tag | string | `"v0.15"` | image tag |
+| image.tag | string | `"v0.17"` | image tag |
 | metrics.enabled | bool | See values.yaml | Enable and configure a Prometheus serviceMonitor for the chart under this key. |
 | metrics.prometheusRule | object | See values.yaml | Enable and configure Prometheus Rules for the chart under this key. |
 | metrics.prometheusRule.rules | list | See prometheusrules.yaml | Configure additionial rules for the chart under this key. |
-| metrics.serviceMonitor.interval | string | `"30s"` |  |
-| metrics.serviceMonitor.labels | object | `{}` |  |
-| metrics.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
+| metrics.serviceMonitor.interval | string | `"30s"` | Interval at which Prometheus should scrape metrics |
+| metrics.serviceMonitor.jobLabel | string | `""` | The Kubernetes `Endpoints` label to use as the Prometheus job name |
+| metrics.serviceMonitor.labels | object | `{}` | Additional labels for the Kubernetes `ServiceMonitor` object |
+| metrics.serviceMonitor.podTargetLabels | list | `[]` | PodTargetLabels transfers labels on the Kubernetes `Pod`` onto the created metrics. |
+| metrics.serviceMonitor.scrapeTimeout | string | `"10s"` | Timeout after which the scrape is ended |
+| metrics.serviceMonitor.targetLabels | list | `[]` | TargetLabels transfers labels from the Kubernetes `Service`` onto the created metrics. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | service | object | See values.yaml | Configures service settings for the chart. |
 
@@ -97,6 +100,16 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [10.0.0]
+
+#### Added
+
+- Parameters in `values.yaml` for specifying the `jobLabel`, `targetLabels`, and `podTargetLabels` fields on the Prometheus ServiceMonitor object.
+
+#### Changed
+
+- **BREAKING**: Updated Blocky image and AppVersion to v0.17. This version of Blocky has a few backwards-incompatible `config.yml` differences compared to v0.15. Update your `config` chart values to check the `upstream`, `queryLog`, `certFile`, and `keyFile` settings (if applicable).
 
 ### [9.0.0]
 

--- a/charts/stable/blocky/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/blocky/README_CHANGELOG.md.gotmpl
@@ -9,7 +9,7 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [Unreleased]
+### [10.0.0]
 
 #### Added
 

--- a/charts/stable/blocky/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/blocky/README_CHANGELOG.md.gotmpl
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### [Unreleased]
 
+#### Added
+
+- Parameters in `values.yaml` for specifying the `jobLabel`, `targetLabels`, and `podTargetLabels` fields on the Prometheus ServiceMonitor object.
+
 #### Changed
 
 - **BREAKING**: Updated Blocky image and AppVersion to v0.17. This version of Blocky has a few backwards-incompatible `config.yml` differences compared to v0.15. Update your `config` chart values to check the `upstream`, `queryLog`, `certFile`, and `keyFile` settings (if applicable).

--- a/charts/stable/blocky/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/blocky/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [Unreleased]
+
+#### Changed
+
+- **BREAKING**: Updated Blocky image and AppVersion to v0.17. This version of Blocky has a few backwards-incompatible `config.yml` differences compared to v0.15. Update your `config` chart values to check the `upstream`, `queryLog`, `certFile`, and `keyFile` settings (if applicable).
+
 ### [9.0.0]
 
 #### Changed

--- a/charts/stable/blocky/templates/servicemonitor.yaml
+++ b/charts/stable/blocky/templates/servicemonitor.yaml
@@ -21,4 +21,19 @@ spec:
       scrapeTimeout: {{ . }}
       {{- end }}
       path: /metrics
+  {{- with .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ . }}
+  {{- end }}
+  {{- with .Values.metrics.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- range . }}
+    - {{ . }}
+    {{- end }}
+  {{- end}}
+  {{- with .Values.metrics.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+    {{- range . }}
+    - {{ . }}
+    {{- end }}
+  {{- end}}
 {{- end }}

--- a/charts/stable/blocky/values.yaml
+++ b/charts/stable/blocky/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: spx01/blocky
   # -- image tag
-  tag: v0.15
+  tag: v0.17
   # -- image pull policy
   pullPolicy: IfNotPresent
 
@@ -87,27 +87,38 @@ metrics:
       #   labels:
       #     severity: critical
 
-# -- Full list of options https://github.com/0xERR0R/blocky/blob/master/docs/config.yml
+# -- Full list of options https://github.com/0xERR0R/blocky/blob/v0.17/docs/config.yml
 # @default -- see URL to default config
 config: |
   upstream:
     # these external DNS resolvers will be used. Blocky picks 2 random resolvers from the list for each query
     # format for resolver: [net:]host:[port][/path]. net could be empty (default, shortcut for tcp+udp), tcp+udp, tcp, udp, tcp-tls or https (DoH). If port is empty, default port will be used (53 for udp and tcp, 853 for tcp-tls, 443 for https (Doh))
-    externalResolvers:
+    # this configuration is mandatory, please define at least one external DNS resolver
+    default:
       - 46.182.19.48
       - 80.241.218.68
       - tcp-tls:fdns1.dismail.de:853
       - https://dns.digitale-gesellschaft.ch/dns-query
+    # optional: use client name (with wildcard support: * - sequence of any characters, [0-9] - range)
+    # or single ip address / client subnet as CIDR notation
+    laptop*:
+      - 123.123.123.123
 
-  # optional: custom IP address for domain name (with all sub-domains)
+  # optional: timeout to query the upstream resolver. Default: 2s
+  upstreamTimeout: 2s
+
+  # optional: custom IP address(es) for domain name (with all sub-domains). Multiple addresses must be separated by a comma
   # example: query "printer.lan" or "my.printer.lan" will return 192.168.178.3
   customDNS:
     mapping:
-      printer.lan: 192.168.178.3
+      printer.lan: 192.168.178.3,2001:0db8:85a3:08d3:1319:8a2e:0370:7344
 
-  # optional: definition, which DNS resolver(s) should be used for queries to the domain (with all sub-domains). Multiple resolvers must be separated by comma
+  # optional: definition, which DNS resolver(s) should be used for queries to the domain (with all sub-domains). Multiple resolvers must be separated by a comma
   # Example: Query client.fritz.box will ask DNS server 192.168.178.1. This is necessary for local network, to resolve clients by host name
   conditional:
+    # optional: replace domain in the query with other domain before resolver lookup in the mapping
+    rewrite:
+      example.com: fritz.box
     mapping:
       fritz.box: udp:192.168.178.1
       lan.net: udp:192.168.178.1,udp:192.168.178.2
@@ -123,12 +134,22 @@ config: |
         - http://sysctl.org/cameleon/hosts
         - https://zeustracker.abuse.ch/blocklist.php?download=domainblocklist
         - https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
+        - |
+          # inline definition with YAML literal block scalar style
+          # hosts format
+          someadsdomain.com
       special:
         - https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews/hosts
     # definition of whitelist groups. Attention: if the same group has black and whitelists, whitelists will be used to disable particular blacklist entries. If a group has only whitelist entries -> this means only domains from this list are allowed, all other domains will be blocked
     whiteLists:
       ads:
         - whitelist.txt
+        - |
+          # inline definition with YAML literal block scalar style
+          # hosts format
+          whitelistdomain.com
+          # this is a regex
+          /^banners?[_.-]/
     # definition: which groups should be applied for which client
     clientGroupsBlock:
       # default will be used, if no special definition for a client name exists
@@ -144,29 +165,52 @@ config: |
     # which response will be sent, if query is blocked:
     # zeroIp: 0.0.0.0 will be returned (default)
     # nxDomain: return NXDOMAIN as return code
-    # comma separated list of destination IP adresses (for example: 192.100.100.15, 2001:0db8:85a3:08d3:1319:8a2e:0370:7344). Should contain ipv4 and ipv6 to cover all query types. Useful with running web server on this address to display the "blocked" page.
+    # comma separated list of destination IP addresses (for example: 192.100.100.15, 2001:0db8:85a3:08d3:1319:8a2e:0370:7344). Should contain ipv4 and ipv6 to cover all query types. Useful with running web server on this address to display the "blocked" page.
     blockType: zeroIp
-    # optional: automatically list refresh period in minutes. Default: 4h.
+    # optional: TTL for answers to blocked domains
+    # default: 6h
+    blockTTL: 1m
+    # optional: automatically list refresh period (in duration format). Default: 4h.
     # Negative value -> deactivate automatically refresh.
     # 0 value -> use default
-    refreshPeriod: 0
+    refreshPeriod: 4h
+    # optional: timeout for list download (each url). Default: 60s. Use large values for big lists or slow internet connections
+    downloadTimeout: 4m
+    # optional: Download attempt timeout. Default: 60s
+    downloadAttempts: 5
+    # optional: Time between the download attempts. Default: 1s
+    downloadCooldown: 10s
+    # optional: if true, application startup will fail if at least one list can't be downloaded / opened. Default: false
+    failStartOnListError: false
 
   # optional: configuration for caching of DNS responses
   caching:
-    # amount in minutes, how long a response must be cached (min value).
+    # duration how long a response must be cached (min value).
     # If <=0, use response's TTL, if >0 use this value, if TTL is smaller
     # Default: 0
-    minTime: 5
-    # amount in minutes, how long a response must be cached (max value).
+    minTime: 5m
+    # duration how long a response must be cached (max value).
     # If <0, do not cache responses
     # If 0, use TTL
     # If > 0, use this value, if TTL is greater
     # Default: 0
     maxTime: -1
-    # if true, will preload DNS results for often used queries (names queried more than 5 times in a 2 hour time window)
+    # Max number of cache entries (responses) to be kept in cache (soft limit). Useful on systems with limited amount of RAM.
+    # Default (0): unlimited
+    maxItemsCount: 0
+    # if true, will preload DNS results for often used queries (default: names queried more than 5 times in a 2-hour time window)
     # this improves the response time for often used queries, but significantly increases external traffic
     # default: false
     prefetching: true
+    # prefetch track time window (in duration format)
+    # default: 120
+    prefetchExpires: 2h
+    # name queries threshold for prefetch
+    # default: 5
+    prefetchThreshold: 5
+    # Max number of domains to be kept in cache for prefetching (soft limit). Useful on systems with limited amount of RAM.
+    # Default (0): unlimited
+    prefetchMaxItemsCount: 0
 
   # optional: configuration of client name resolution
   clientLookup:
@@ -181,35 +225,41 @@ config: |
     clients:
       laptop:
         - 192.168.178.29
-
   # optional: configuration for prometheus metrics endpoint
-  # prometheus:
-  #   # enabled if true
-  #   enable: true
-  #   # url path, optional (default '/metrics')
-  #   path: /metrics
+  prometheus:
+    # enabled if true
+    enable: true
+    # url path, optional (default '/metrics')
+    path: /metrics
 
-  # optional: write query information (question, answer, client, duration etc) to daily csv file
-  # queryLog:
-  #   # directory (should be mounted as volume in docker)
-  #   dir: /logs
-  #   # if true, write one file per client. Writes all queries to single file otherwise
-  #   perClient: true
-  #   # if > 0, deletes log files which are older than ... days
-  #   logRetentionDays: 7
+  # optional: write query information (question, answer, client, duration etc.) to daily csv file
+  queryLog:
+    # optional one of: mysql, csv, csv-client. If empty, log to console
+    type: mysql
+    # directory (should be mounted as volume in docker) for csv, db connection string for mysql
+    target: db_user:db_password@tcp(db_host_or_ip:3306)/db_user?charset=utf8mb4&parseTime=True&loc=Local
+    # if > 0, deletes log files which are older than ... days
+    logRetentionDays: 7
 
   # optional: DNS listener port and bind ip address, default 53 (UDP and TCP). Example: 53, :53, 127.0.0.1:53
   port: 53
-  # optional: HTTP listener port, default 0 = no http listener. If > 0, will be used for prometheus metrics, pprof, REST API, DoH ...
+  # optional: Port for DoT (DNS-over-TLS) listener. Example: 853, 127.0.0.1:853
+  #tlsPort: 53
+  # optional: HTTPS listener port and bind ip address, default empty = no http listener. If > 0, will be used for prometheus metrics, pprof, REST API, DoH... Example: 443, :443, 127.0.0.1:443
   httpPort: 4000
-  # optional: HTTPS listener port, default 0 = no http listener. If > 0, will be used for prometheus metrics, pprof, REST API, DoH...
   #httpsPort: 443
   # mandatory, if https port > 0: path to cert and key file for SSL encryption
-  #httpsCertFile: server.crt
-  #httpsKeyFile: server.key
-  # optional: use this DNS server to resolve blacklist urls and upstream DNS servers (DOH). Useful if no DNS resolver is configured and blocky needs to resolve a host name. Format net:IP:port, net must be udp or tcp
+  #certFile: server.crt
+  #keyFile: server.key
+  # optional: use this DNS server to resolve blacklist urls and upstream DNS servers. Useful if no DNS resolver is configured and blocky needs to resolve a host name. Format net:IP:port, net must be udp or tcp
   bootstrapDns: tcp:1.1.1.1
+  # optional: Drop all AAAA query if set to true. Default: false
+  disableIPv6: false
   # optional: Log level (one from debug, info, warn, error). Default: info
   logLevel: info
   # optional: Log format (text or json). Default: text
   logFormat: text
+  # optional: log timestamps. Default: true
+  logTimestamp: true
+  # optional: obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy. Default: false
+  logPrivacy: false

--- a/charts/stable/blocky/values.yaml
+++ b/charts/stable/blocky/values.yaml
@@ -65,9 +65,18 @@ metrics:
   # @default -- See values.yaml
   enabled: false
   serviceMonitor:
+    # -- Interval at which Prometheus should scrape metrics
     interval: 30s
+    # -- Timeout after which the scrape is ended
     scrapeTimeout: 10s
+    # -- Additional labels for the Kubernetes `ServiceMonitor` object
     labels: {}
+    # -- The Kubernetes `Endpoints` label to use as the Prometheus job name
+    jobLabel: ""
+    # -- TargetLabels transfers labels from the Kubernetes `Service`` onto the created metrics.
+    targetLabels: []
+    # -- PodTargetLabels transfers labels on the Kubernetes `Pod`` onto the created metrics.
+    podTargetLabels: []
   # -- Enable and configure Prometheus Rules for the chart under this key.
   # @default -- See values.yaml
   prometheusRule:


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This PR updates the Blocky chart to use the latest released application version ([v0.17](https://github.com/0xERR0R/blocky/releases/tag/v0.17)). 

It also add support for the `jobLabel`, `targetLabels`, and `podTargetLabels` fields on the Prometheus service monitor.

**Benefits**

Bring the Helm chart up to date with the latest Blocky documentation to avoid confusion. This also enables new Blocky features including more control over caching, logging, and blocklists.

The `jobLabel`, `targetLabels`, and `podTargetLabels` fields on the Prometheus service monitor allow more control over how metrics are labeled, for example align with the conventions used in the [Blocky dashboard for Grafana](https://grafana.com/grafana/dashboards/13768).

**Possible drawbacks**

See the included Changelog for some details on backwards-compatibility of the application configuration file. Most users will need to make at least one change to their `values.yaml` or equivalent.

**Applicable issues**

N/A

**Additional information**

N/A

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
