### PR TITLE
[blocky] use container image direct from the application developer

### DIFF
--- a/charts/stable/blocky/Chart.yaml
+++ b/charts/stable/blocky/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.17
 description: DNS proxy as ad-blocker for local network
 name: blocky
-version: 10.0.0
+version: 10.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
 - blocky

--- a/charts/stable/blocky/README.md
+++ b/charts/stable/blocky/README.md
@@ -1,6 +1,6 @@
 # blocky
 
-![Version: 10.0.0](https://img.shields.io/badge/Version-10.0.0-informational?style=flat-square) ![AppVersion: v0.17](https://img.shields.io/badge/AppVersion-v0.17-informational?style=flat-square)
+![Version: 10.0.1](https://img.shields.io/badge/Version-10.0.1-informational?style=flat-square) ![AppVersion: v0.17](https://img.shields.io/badge/AppVersion-v0.17-informational?style=flat-square)
 
 DNS proxy as ad-blocker for local network
 
@@ -81,7 +81,7 @@ N/A
 | env | object | See below | environment variables. See [image docs](https://0xerr0r.github.io/blocky/installation/#run-with-docker) for more details. |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
-| image.repository | string | `"spx01/blocky"` | image repository |
+| image.repository | string | `"ghcr.io/0xerr0r/blocky"` | image repository |
 | image.tag | string | `"v0.17"` | image tag |
 | metrics.enabled | bool | See values.yaml | Enable and configure a Prometheus serviceMonitor for the chart under this key. |
 | metrics.prometheusRule | object | See values.yaml | Enable and configure Prometheus Rules for the chart under this key. |

--- a/charts/stable/blocky/README.md
+++ b/charts/stable/blocky/README.md
@@ -101,6 +101,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [10.0.1]
+
+#### Changed
+
+- Updated Blocky image to `ghcr.io/0xerr0r/blocky`, which is built (using GitHub Actions) by the application developer for each release.
+
 ### [10.0.0]
 
 #### Added

--- a/charts/stable/blocky/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/blocky/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [10.0.1]
+
+#### Changed
+
+- Updated Blocky image to `ghcr.io/0xerr0r/blocky`, which is built (using GitHub Actions) by the application developer for each release.
+
 ### [10.0.0]
 
 #### Added

--- a/charts/stable/blocky/values.yaml
+++ b/charts/stable/blocky/values.yaml
@@ -7,7 +7,7 @@
 
 image:
   # -- image repository
-  repository: spx01/blocky
+  repository: ghcr.io/0xerr0r/blocky
   # -- image tag
   tag: v0.17
   # -- image pull policy


### PR DESCRIPTION
It's possible that when this chart was first built, container images (or multi-arch images) were not available - but they are now. See https://github.com/0xERR0R/blocky/pkgs/container/blocky for images that include amd64, arm64, arm/v6, and arm/v7.

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This change changes the blocky helm chart to use container images built by the app maintainer.

**Benefits**

Container images direct from the source are published sooner and theoretically more reliable.

**Possible drawbacks**

unknown?

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
