### PR TITLE
[cryptpad] add default podSecurityContext

### DIFF
--- a/charts/incubator/cryptpad/Chart.yaml
+++ b/charts/incubator/cryptpad/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v4.12.0-nginx
 description: cryptpad helm package
 name: cryptpad
-version: 0.1.0
+version: 0.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - cryptpad

--- a/charts/incubator/cryptpad/values.yaml
+++ b/charts/incubator/cryptpad/values.yaml
@@ -76,3 +76,6 @@ persistence:
         mountPath: /cryptpad/data
       - path: datastore
         mountPath: /cryptpad/datastore
+
+podSecurityContext:
+  fsGroup: 4001  # https://github.com/xwiki-labs/cryptpad-docker/blob/72dd7030c1dc1c70b5ff3f53b8451f5af19a2927/Dockerfile-nginx#L25


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

As per https://github.com/xwiki-labs/cryptpad-docker/blob/72dd7030c1dc1c70b5ff3f53b8451f5af19a2927/Dockerfile-nginx#L25, the docker image for Cryptpad will spawn the cryptpad process with a non-root user: https://github.com/xwiki-labs/cryptpad-docker/blob/72dd7030c1dc1c70b5ff3f53b8451f5af19a2927/supervisord.conf#L26

Such unprivileged user will not be able to write in persistence volumes, which are mounted as root. To work around this, we set the fsGroup in accordance with what supervisord already does inside the image.

**Benefits**

This will allow the chart to work when the volumes are mounted with restrictive permissions.

I did not notice this during testing as I was using an `emptyDir`, which gets mounted with `0777` by default 😞 

**Possible drawbacks**

`fsGroup` is not the best practice out there, but I cannot figure out another way to make it work without tweaking the image.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
