### PR TITLE
[webtrees] Add new chart

### DIFF
--- a/charts/stable/webtrees/.helmignore
+++ b/charts/stable/webtrees/.helmignore
@@ -1,0 +1,27 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS file for Kubernetes
+OWNERS
+# helm-docs templates
+*.gotmpl

--- a/charts/stable/webtrees/Chart.yaml
+++ b/charts/stable/webtrees/Chart.yaml
@@ -20,6 +20,6 @@ dependencies:
     version: 4.2.0
     repository: https://library-charts.k8s-at-home.com
   - name: mariadb
-    version: 9.7.1
+    version: 10.2.0
     repository: https://charts.bitnami.com/bitnami
     condition: mariadb.enabled

--- a/charts/stable/webtrees/Chart.yaml
+++ b/charts/stable/webtrees/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+appVersion: 2.0.19
+description: Open-source online collaborative genealogy application
+name: webtrees
+version: 1.0.0
+kubeVersion: ">=1.16.0-0"
+keywords:
+  - webtrees
+  - genealogy
+  - family-tree
+icon: https://raw.githubusercontent.com/fisharebest/webtrees/main/resources/img/webtrees-icon.png
+sources:
+  - https://github.com/fisharebest/webtrees
+  - https://github.com/NathanVaughn/webtrees-docker
+maintainers:
+  - name: rogerrum
+    email: rogerrum@gmail.com
+dependencies:
+  - name: common
+    version: 4.2.0
+    repository: https://library-charts.k8s-at-home.com
+  - name: mariadb
+    version: 9.7.1
+    repository: https://charts.bitnami.com/bitnami
+    condition: mariadb.enabled

--- a/charts/stable/webtrees/README.md
+++ b/charts/stable/webtrees/README.md
@@ -1,0 +1,134 @@
+# webtrees
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 2.0.19](https://img.shields.io/badge/AppVersion-2.0.19-informational?style=flat-square)
+
+Open-source online collaborative genealogy application
+
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+
+## Source Code
+
+* <https://github.com/fisharebest/webtrees>
+* <https://github.com/NathanVaughn/webtrees-docker>
+
+## Requirements
+
+Kubernetes: `>=1.16.0-0`
+
+## Dependencies
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | mariadb | 9.7.1 |
+| https://library-charts.k8s-at-home.com | common | 4.2.0 |
+
+## TL;DR
+
+```console
+helm repo add k8s-at-home https://k8s-at-home.com/charts/
+helm repo update
+helm install webtrees k8s-at-home/webtrees
+```
+
+## Installing the Chart
+
+To install the chart with the release name `webtrees`
+
+```console
+helm install webtrees k8s-at-home/webtrees
+```
+
+## Uninstalling the Chart
+
+To uninstall the `webtrees` deployment
+
+```console
+helm uninstall webtrees
+```
+
+The command removes all the Kubernetes components associated with the chart **including persistent volumes** and deletes the release.
+
+## Configuration
+
+Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
+Other values may be used from the [values.yaml](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml) from the [common library](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common).
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```console
+helm install webtrees \
+  --set env.TZ="America/New York" \
+    k8s-at-home/webtrees
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart.
+
+```console
+helm install webtrees k8s-at-home/webtrees -f values.yaml
+```
+
+## Custom configuration
+
+N/A
+
+## Values
+
+**Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| env | object | See below | environment variables. See [monica documentation](https://raw.githubusercontent.com/monicahq/monica/master/.env.example) for more details. |
+| env.BASE_URL | string | `"https://webtrees.k8s-at-home.com"` | Base URL of the installation, with protocol. This needs to be in the form of http://webtrees.example.com |
+| env.DB_HOST | string | `nil` | Database hostname |
+| env.DB_NAME | string | `nil` | Database to connect to |
+| env.DB_PASS | string | `nil` | Database password |
+| env.DB_PORT | string | `"3306"` | Database server port |
+| env.DB_PREFIX | string | `"wt_"` | Prefix to give all tables in the database. Set this to a value of "" to have no table prefix. |
+| env.DB_TYPE | string | `"mysql"` | Database server type |
+| env.DB_USER | string | `nil` | Database username |
+| env.LANG | string | `"en-US"` | webtrees localization setting |
+| env.PRETTY_URLS | string | `"TRUE"` | Enable pretty URLs |
+| env.TZ | string | `"UTC"` | Set the container timezone |
+| env.WT_EMAIL | string | `nil` | Admin account email |
+| env.WT_NAME | string | `nil` | Admin account full name |
+| env.WT_PASS | string | `nil` | Admin account password |
+| env.WT_USER | string | `nil` | Admin account username |
+| image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
+| image.repository | string | `"ghcr.io/nathanvaughn/webtrees"` | image repository |
+| image.tag | string | `"2.0.19"` | image tag |
+| ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
+| mariadb | object | See values.yaml | Enable and configure mariadb database subchart under this key.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) |
+| persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
+| service | object | See values.yaml | Configures service settings for the chart. |
+
+## Changelog
+
+All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/commonREADME.md#Changelog).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [1.0.0]
+
+#### Added
+
+- N/A
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
+
+[1.0.0]: #1.0.0
+
+## Support
+
+- See the [Docs](https://docs.k8s-at-home.com/our-helm-charts/getting-started/)
+- Open an [issue](https://github.com/k8s-at-home/charts/issues/new/choose)
+- Ask a [question](https://github.com/k8s-at-home/organization/discussions)
+- Join our [Discord](https://discord.gg/sTMX7Vh) community
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/stable/webtrees/README.md.gotmpl
+++ b/charts/stable/webtrees/README.md.gotmpl
@@ -1,0 +1,146 @@
+{{- define "custom.repository.organization" -}}
+k8s-at-home
+{{- end -}}
+
+{{- define "custom.repository.url" -}}
+https://github.com/k8s-at-home/charts
+{{- end -}}
+
+{{- define "custom.helm.url" -}}
+https://k8s-at-home.com/charts/
+{{- end -}}
+
+{{- define "custom.helm.path" -}}
+{{ template "custom.repository.organization" . }}/{{ template "chart.name" . }}
+{{- end -}}
+
+{{- define "custom.notes" -}}
+**This chart is not maintained by the upstream project and any issues with the chart should be raised [here](https://github.com/k8s-at-home/charts/issues/new/choose)**
+{{- end -}}
+
+{{- define "custom.requirements" -}}
+## Requirements
+
+{{ template "chart.kubeVersionLine" . }}
+{{- end -}}
+
+{{- define "custom.dependencies" -}}
+## Dependencies
+
+{{ template "chart.requirementsTable" . }}
+{{- end -}}
+
+{{- define "custom.install.tldr" -}}
+## TL;DR
+
+```console
+helm repo add {{ template "custom.repository.organization" . }} {{ template "custom.helm.url" . }}
+helm repo update
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.install" -}}
+## Installing the Chart
+
+To install the chart with the release name `{{ template "chart.name" . }}`
+
+```console
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.uninstall" -}}
+## Uninstalling the Chart
+
+To uninstall the `{{ template "chart.name" . }}` deployment
+
+```console
+helm uninstall {{ template "chart.name" . }}
+```
+
+The command removes all the Kubernetes components associated with the chart **including persistent volumes** and deletes the release.
+{{- end -}}
+
+{{- define "custom.configuration.header" -}}
+## Configuration
+{{- end -}}
+
+{{- define "custom.configuration.readValues" -}}
+Read through the [values.yaml](./values.yaml) file. It has several commented out suggested values.
+Other values may be used from the [values.yaml](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml) from the [common library](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common).
+{{- end -}}
+
+{{- define "custom.configuration.example.set" -}}
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```console
+helm install {{ template "chart.name" . }} \
+  --set env.TZ="America/New York" \
+    {{ template "custom.helm.path" . }}
+```
+{{- end -}}
+
+{{- define "custom.configuration.example.file" -}}
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart.
+
+```console
+helm install {{ template "chart.name" . }} {{ template "custom.helm.path" . }} -f values.yaml
+```
+{{- end -}}
+
+{{- define "custom.valuesSection" -}}
+## Values
+
+**Important**: When deploying an application Helm chart you can add more values from our common library chart [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common)
+
+{{ template "chart.valuesTable" . }}
+{{- end -}}
+
+{{- define "custom.support" -}}
+## Support
+
+- See the [Docs](https://docs.k8s-at-home.com/our-helm-charts/getting-started/)
+- Open an [issue](https://github.com/k8s-at-home/charts/issues/new/choose)
+- Ask a [question](https://github.com/k8s-at-home/organization/discussions)
+- Join our [Discord](https://discord.gg/sTMX7Vh) community
+{{- end -}}
+
+{{ template "chart.header" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "custom.notes" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "custom.requirements" . }}
+
+{{ template "custom.dependencies" . }}
+
+{{ template "custom.install.tldr" . }}
+
+{{ template "custom.install" . }}
+
+{{ template "custom.uninstall" . }}
+
+{{ template "custom.configuration.header" . }}
+
+{{ template "custom.configuration.readValues" . }}
+
+{{ template "custom.configuration.example.set" . }}
+
+{{ template "custom.configuration.example.file" . }}
+
+{{ template "custom.custom.configuration" . }}
+
+{{ template "custom.valuesSection" . }}
+
+{{ template "custom.changelog" . }}
+
+{{ template "custom.support" . }}
+
+{{ template "helm-docs.versionFooter" . }}
+{{ "" }}

--- a/charts/stable/webtrees/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/webtrees/README_CHANGELOG.md.gotmpl
@@ -1,0 +1,27 @@
+{{- define "custom.changelog.header" -}}
+## Changelog
+{{- end -}}
+
+{{- define "custom.changelog" -}}
+{{ template "custom.changelog.header" . }}
+
+All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/commonREADME.md#Changelog).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [1.0.0]
+
+#### Added
+
+- N/A
+
+#### Changed
+
+- N/A
+
+#### Removed
+
+- N/A
+
+[1.0.0]: #1.0.0
+{{- end -}}

--- a/charts/stable/webtrees/README_CONFIG.md.gotmpl
+++ b/charts/stable/webtrees/README_CONFIG.md.gotmpl
@@ -1,0 +1,9 @@
+{{- define "custom.custom.configuration.header" -}}
+## Custom configuration
+{{- end -}}
+
+{{- define "custom.custom.configuration" -}}
+{{ template "custom.custom.configuration.header" . }}
+
+N/A
+{{- end -}}

--- a/charts/stable/webtrees/ci/ct-values.yaml
+++ b/charts/stable/webtrees/ci/ct-values.yaml
@@ -1,0 +1,21 @@
+env:
+  BASE_URL: https://webtrees.k8s-at-home.com
+  DB_HOST: webtrees-mariadb
+  DB_NAME: webtrees
+  DB_USER: webtrees
+  DB_PASS: webtreespass
+  WT_USER: admin
+  WT_NAME: Admin
+  WT_PASS: adminpass
+  WT_EMAIL: admin@k8s-at-home.com
+
+
+ingress:
+  main:
+    enabled: true
+
+fullnameOverride: webtrees
+
+mariadb:
+  enabled: true
+  fullnameOverride: webtrees-mariadb

--- a/charts/stable/webtrees/templates/NOTES.txt
+++ b/charts/stable/webtrees/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/stable/webtrees/templates/common.yaml
+++ b/charts/stable/webtrees/templates/common.yaml
@@ -1,0 +1,1 @@
+{{ include "common.all" . }}

--- a/charts/stable/webtrees/values.yaml
+++ b/charts/stable/webtrees/values.yaml
@@ -1,0 +1,86 @@
+#
+# IMPORTANT NOTE
+#
+# This chart inherits from our common library chart. You can check the default values/options here:
+# https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml
+#
+
+image:
+  # -- image repository
+  repository: ghcr.io/nathanvaughn/webtrees
+  # -- image tag
+  tag: "2.0.19"
+  # -- image pull policy
+  pullPolicy: IfNotPresent
+
+# -- environment variables. See [monica documentation](https://raw.githubusercontent.com/monicahq/monica/master/.env.example) for more details.
+# @default -- See below
+env:
+  # -- Set the container timezone
+  TZ: UTC
+  # -- Enable pretty URLs
+  PRETTY_URLS: "TRUE"
+  # -- webtrees localization setting
+  LANG: "en-US"
+  # -- Base URL of the installation, with protocol. This needs to be in the form of http://webtrees.example.com
+  BASE_URL: https://webtrees.k8s-at-home.com
+  # -- Database server type
+  DB_TYPE: "mysql"
+  # -- Database hostname
+  DB_HOST: # webtrees-mariadb
+  # -- Database server port
+  DB_PORT: "3306"
+  # -- Database username
+  DB_USER: # webtrees
+  # -- Database password
+  DB_PASS: # webtreespass
+  # -- Database to connect to
+  DB_NAME: # webtrees
+  # -- Prefix to give all tables in the database. Set this to a value of "" to have no table prefix.
+  DB_PREFIX: "wt_"
+  # -- Admin account username
+  WT_USER: # admin
+  # -- Admin account full name
+  WT_NAME:
+  # -- Admin account password
+  WT_PASS: # adminpass
+  # -- Admin account email
+  WT_EMAIL:
+
+# -- Configures service settings for the chart.
+# @default -- See values.yaml
+service:
+  main:
+    ports:
+      http:
+        port: 80
+
+ingress:
+  # -- Enable and configure ingress settings for the chart under this key.
+  # @default -- See values.yaml
+  main:
+    enabled: false
+
+# -- Configure persistence settings for the chart under this key.
+# @default -- See values.yaml
+persistence:
+  config:
+    enabled: false
+    mountPath: /var/www/webtrees/data/
+    # storageClass: ""
+
+# -- Enable and configure mariadb database subchart under this key.
+#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+# @default -- See values.yaml
+mariadb:
+  enabled: false
+  architecture: standalone
+  auth:
+    database: webtrees
+    username: webtrees
+    password: webtreespass
+    rootPassword: webtreesrootpass
+  primary:
+    persistence:
+      enabled: false
+      # storageClass: ""

--- a/charts/stable/webtrees/values.yaml
+++ b/charts/stable/webtrees/values.yaml
@@ -27,23 +27,23 @@ env:
   # -- Database server type
   DB_TYPE: "mysql"
   # -- Database hostname
-  DB_HOST: # webtrees-mariadb
+  DB_HOST:  # webtrees-mariadb
   # -- Database server port
   DB_PORT: "3306"
   # -- Database username
-  DB_USER: # webtrees
+  DB_USER:  # webtrees
   # -- Database password
-  DB_PASS: # webtreespass
+  DB_PASS:  # webtreespass
   # -- Database to connect to
-  DB_NAME: # webtrees
+  DB_NAME:  # webtrees
   # -- Prefix to give all tables in the database. Set this to a value of "" to have no table prefix.
   DB_PREFIX: "wt_"
   # -- Admin account username
-  WT_USER: # admin
+  WT_USER:  # admin
   # -- Admin account full name
   WT_NAME:
   # -- Admin account password
-  WT_PASS: # adminpass
+  WT_PASS:  # adminpass
   # -- Admin account email
   WT_EMAIL:
 

--- a/charts/stable/webtrees/values.yaml
+++ b/charts/stable/webtrees/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
-# -- environment variables. See [monica documentation](https://raw.githubusercontent.com/monicahq/monica/master/.env.example) for more details.
+# -- environment variables. See [webtrees-docker documentation](https://github.com/NathanVaughn/webtrees-docker#environment-variables) for more details.
 # @default -- See below
 env:
   # -- Set the container timezone


### PR DESCRIPTION

**Description of the change**

Add new chart for Open-source online collaborative genealogy application [(Webtrees)](https://www.webtrees.net/)

**Benefits**

The ability to deploy webtrees as a helm chart

**Possible drawbacks**

None

**Applicable issues**

- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
