### PR TITLE
[node-red] Upgrade to 2.1.4.

### DIFF
--- a/charts/stable/node-red/Chart.yaml
+++ b/charts/stable/node-red/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com
-  version: 4.2.0
+  version: 4.3.0

--- a/charts/stable/node-red/Chart.yaml
+++ b/charts/stable/node-red/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.3.5
+appVersion: 2.1.4
 description: Node-RED is low-code programming for event-driven applications
 name: node-red
-version: 9.1.0
+version: 10.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - nodered

--- a/charts/stable/node-red/README.md
+++ b/charts/stable/node-red/README.md
@@ -19,7 +19,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://library-charts.k8s-at-home.com | common | 4.2.0 |
+| https://library-charts.k8s-at-home.com | common | 4.3.0 |
 
 ## TL;DR
 
@@ -100,6 +100,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Changed
 
 - Upgrade to Node Red 2.x (2.1.4) upstream image.
+- Upgrade common dep to 4.3.0.
 
 ### [9.0.0]
 

--- a/charts/stable/node-red/README.md
+++ b/charts/stable/node-red/README.md
@@ -1,6 +1,6 @@
 # node-red
 
-![Version: 9.1.0](https://img.shields.io/badge/Version-9.1.0-informational?style=flat-square) ![AppVersion: 1.3.5](https://img.shields.io/badge/AppVersion-1.3.5-informational?style=flat-square)
+![Version: 10.0.0](https://img.shields.io/badge/Version-10.0.0-informational?style=flat-square) ![AppVersion: 2.1.4](https://img.shields.io/badge/AppVersion-2.1.4-informational?style=flat-square)
 
 Node-RED is low-code programming for event-driven applications
 
@@ -84,7 +84,7 @@ N/A
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"nodered/node-red"` | image repository |
-| image.tag | string | `"1.3.5"` | image tag |
+| image.tag | string | `"2.1.4"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | service | object | See values.yaml | Configures service settings for the chart. |
@@ -94,6 +94,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [10.0.0]
+
+#### Changed
+
+- Upgrade to Node Red 2.x (2.1.4) upstream image.
 
 ### [9.0.0]
 

--- a/charts/stable/node-red/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/node-red/README_CHANGELOG.md.gotmpl
@@ -9,6 +9,12 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [10.0.0]
+
+#### Changed
+
+- Upgrade to Node Red 2.x (2.1.4) upstream image.
+
 ### [9.0.0]
 
 #### Changed

--- a/charts/stable/node-red/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/node-red/README_CHANGELOG.md.gotmpl
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Changed
 
 - Upgrade to Node Red 2.x (2.1.4) upstream image.
+- Upgrade common dep to 4.3.0.
 
 ### [9.0.0]
 

--- a/charts/stable/node-red/values.yaml
+++ b/charts/stable/node-red/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: nodered/node-red
   # -- image tag
-  tag: 1.3.5
+  tag: 2.1.4
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

Upgrades Node Red to 2.1.4.

**Benefits**

Latest version!  Bug fixes.

**Possible drawbacks**

No known breaking changes, but is a major upstream version change.

**Additional information**

Related PR https://github.com/k8s-at-home/charts/pull/1351 to supply a 1.3.x latest patch version.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)
