### PR TITLE
[dendrite] Fix postgresql init scripts for dendrite

### DIFF
--- a/charts/incubator/dendrite/Chart.yaml
+++ b/charts/incubator/dendrite/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 0.5.1
 description: Dendrite Matrix Homeserver
 name: dendrite
-version: 1.0.1
+version: 1.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - dendrite
@@ -29,4 +29,8 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded `postgresql` chart dependency to version `10.14.4`.
+      description: Upgraded `postgresql` image version to "14.1.0"
+    - kind: fixed
+      description: `initdbScripts` are now actually loaded by `postgresql`
+    - kind: added
+      description: `postgresqlUsername` is used in `initdbScripts` rather than hardcoded value

--- a/charts/incubator/dendrite/Chart.yaml
+++ b/charts/incubator/dendrite/Chart.yaml
@@ -31,6 +31,6 @@ annotations:
     - kind: changed
       description: Upgraded `postgresql` image version to "14.1.0"
     - kind: fixed
-      description: `initdbScripts` are now actually loaded by `postgresql`
+      description: "`initdbScripts` are now actually actually loaded"
     - kind: added
-      description: `postgresqlUsername` is used in `initdbScripts` rather than hardcoded value
+      description: "`postgresqlUsername` is used in `initdbScripts` rather than hardcoded value"

--- a/charts/incubator/dendrite/README.md
+++ b/charts/incubator/dendrite/README.md
@@ -1,6 +1,6 @@
 # dendrite
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: 0.5.1](https://img.shields.io/badge/AppVersion-0.5.1-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: 0.5.1](https://img.shields.io/badge/AppVersion-0.5.1-informational?style=flat-square)
 
 Dendrite Matrix Homeserver
 
@@ -109,6 +109,9 @@ N/A
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | postgresql.enabled | bool | See value.yaml | Enable and configure postgres as the database for dendrite. |
+| postgresql.image.repository | string | `"bitnami/postgresql"` |  |
+| postgresql.image.tag | string | `"14.1.0"` |  |
+| postgresql.initdbScriptsConfigMap | string | `"dendrite-postgresql-init-scripts"` |  |
 | postgresql.persistence.enabled | bool | `false` |  |
 | postgresql.postgresqlDatabase | string | `"dendrite"` |  |
 | postgresql.postgresqlPassword | string | `"changeme"` |  |
@@ -119,19 +122,19 @@ N/A
 
 ## Changelog
 
-### Version 1.0.1
+### Version 1.0.2
 
 #### Added
 
-N/A
+* `postgresqlUsername` is used in `initdbScripts` rather than hardcoded value
 
 #### Changed
 
-* Upgraded `postgresql` chart dependency to version `10.14.4`.
+* Upgraded `postgresql` image version to "14.1.0"
 
 #### Fixed
 
-N/A
+* `initdbScripts` are now actually actually loaded
 
 ### Older versions
 

--- a/charts/incubator/dendrite/templates/common.yaml
+++ b/charts/incubator/dendrite/templates/common.yaml
@@ -38,13 +38,5 @@ subPath:
 {{- $_ := set .Values.persistence "dendrite-key" (include "dendrite.keyVolume" . | fromYaml) -}}
 {{- $_ := set .Values.persistence "dendrite-config" (include "dendrite.configVolume" . | fromYaml) -}}
 {{- $_ := set .Values.persistence "dendrite-tls" (include "dendrite.tlsVolume" . | fromYaml) -}}
-{{- define "postgresql.initdbScripts" -}}
-create_db.sh: |
-  #!/bin/sh
-  for db in userapi_accounts userapi_devices mediaapi syncapi roomserver keyserver federationapi appservice naffka; do
-  createdb -U dendrite -O dendrite dendrite_$db
-  done
-{{- end -}}
-{{- $_ := set .Values.postgresql "initdbScripts" (include "postgresql.initdbScripts" . | fromYaml) -}}
 
 {{ include "common.all" . }}

--- a/charts/incubator/dendrite/templates/postgresql-initdb.yaml
+++ b/charts/incubator/dendrite/templates/postgresql-initdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.postgresql.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: {{ .Values.postgresql.initdbScriptsConfigMap | quote }}
+data:
+  create-db.sh: |
+    #!/bin/sh
+    for db in userapi_accounts userapi_devices mediaapi syncapi roomserver keyserver federationapi appservice naffka; do
+    createdb -U {{ .Values.postgresql.postgresqlUsername }} -O {{ .Values.postgresql.postgresqlUsername }} dendrite_$db
+    done
+{{- end }}

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -201,8 +201,12 @@ postgresql:
   # -- Enable and configure postgres as the database for dendrite.
   # @default -- See value.yaml
   enabled: false
+  image:
+    repository: bitnami/postgresql
+    tag: "14.1.0"
   postgresqlUsername: dendrite
   postgresqlPassword: changeme
   postgresqlDatabase: dendrite
   persistence:
     enabled: false
+  initdbScriptsConfigMap: "dendrite-postgresql-init-scripts"


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Fix the init scripts for postgresql in the dendrite chart.

**Benefits**

- Using postgres now works as the initialisation scripts are correctly loaded
- Init scripts are parameterized and use the `postgresqlUsername` values instead of hardcoded "dendrite"

**Possible drawbacks**

- Databases initialised with postgres before version 14 that somehow go around no init scripts will need to update their database to verion 14

**Applicable issues**

- N/A, no issue was created

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
