### PR TITLE
[unifi] Upgraded unifi image to version 6.5.55.

### DIFF
--- a/charts/stable/unifi/Chart.yaml
+++ b/charts/stable/unifi/Chart.yaml
@@ -26,6 +26,8 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
-    - kind: changed
-      description: Upgraded `mongodb` chart dependency to version `10.30.12`.
+      description: Upgraded `jacobalberty/unifi` image to version `v6.5.55`.
+      links:
+        - name: Update to v6.5.55 to address log4j2 CVE
+          url: https://github.com/k8s-at-home/charts/issues/1382
+  artifacthub.io/containsSecurityUpdates: "true"

--- a/charts/stable/unifi/Chart.yaml
+++ b/charts/stable/unifi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v6.5.54
+appVersion: v6.5.55
 description: Ubiquiti Network's Unifi Controller
 name: unifi
 version: 4.6.0

--- a/charts/stable/unifi/Chart.yaml
+++ b/charts/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v6.5.55
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 4.6.0
+version: 4.6.1
 keywords:
   - ubiquiti
   - unifi

--- a/charts/stable/unifi/README.md
+++ b/charts/stable/unifi/README.md
@@ -1,6 +1,6 @@
 # unifi
 
-![Version: 4.6.0](https://img.shields.io/badge/Version-4.6.0-informational?style=flat-square) ![AppVersion: v6.5.54](https://img.shields.io/badge/AppVersion-v6.5.54-informational?style=flat-square)
+![Version: 4.6.1](https://img.shields.io/badge/Version-4.6.1-informational?style=flat-square) ![AppVersion: v6.5.55](https://img.shields.io/badge/AppVersion-v6.5.55-informational?style=flat-square)
 
 Ubiquiti Network's Unifi Controller
 
@@ -128,7 +128,7 @@ service:
 | env.UNIFI_UID | string | `"999"` | Specify the user ID the application will run as |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"jacobalberty/unifi"` | image repository |
-| image.tag | string | `"v6.5.54"` | image tag |
+| image.tag | string | `"v6.5.55"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | ingress.portal | object | See values.yaml | Enable and configure settings for the captive portal ingress under this key. |
 | mongodb | object | See values.yaml | Enable and configure mongodb database subchart under this key.    For more options see [mongodb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mongodb) |
@@ -145,7 +145,7 @@ service:
 
 ## Changelog
 
-### Version 4.6.0
+### Version 4.6.1
 
 #### Added
 
@@ -153,8 +153,7 @@ N/A
 
 #### Changed
 
-* Upgraded `common` chart dependency to version `4.3.0`.
-* Upgraded `mongodb` chart dependency to version `10.30.12`.
+* Upgraded `jacobalberty/unifi` image to version `v6.5.55`.
 
 #### Fixed
 

--- a/charts/stable/unifi/values.yaml
+++ b/charts/stable/unifi/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: jacobalberty/unifi
   # -- image tag
-  tag: v6.5.54
+  tag: v6.5.55
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Signed-off-by: Rickard Schoultz <rickard.schoultz@gmail.com>

**Description of the change**

unifi image upgraded from v6.5.54 to v6.5.55, per request urged by the unifi repo maintainer.

**Benefits**

Earlier versions than 6.5.55 are subject a remote code execution vulnerability (CVE-2021-44228 as well as CVE-2021-45046).

**Possible drawbacks**

N/A

**Applicable issues**

- fixes #1382

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

