### PR TITLE
[ghost] Fix database string to match generated svc

### DIFF
--- a/charts/stable/ghost/Chart.yaml
+++ b/charts/stable/ghost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.27.2
 description: Ghost is a blogging and publishing software
 name: ghost
-version: 1.1.1
+version: 1.1.2
 kubeVersion: ">=1.19.0-0"
 keywords:
   - ghost
@@ -26,7 +26,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed PVC creation.
-      links:
-        - name: GitHub Issue
-          url: https://github.com/k8s-at-home/charts/issues/1358
+      description: Fixed database host to match mariadb-svc

--- a/charts/stable/ghost/README.md
+++ b/charts/stable/ghost/README.md
@@ -1,6 +1,6 @@
 # ghost
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 4.27.2](https://img.shields.io/badge/AppVersion-4.27.2-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 4.27.2](https://img.shields.io/badge/AppVersion-4.27.2-informational?style=flat-square)
 
 Ghost is a blogging and publishing software
 
@@ -80,7 +80,7 @@ N/A
 | env.NODE_ENV | string | `"production"` |  |
 | env.database__client | string | `"mysql"` |  |
 | env.database__connection__database | string | `"ghost"` |  |
-| env.database__connection__host | string | `"mariadb"` |  |
+| env.database__connection__host | string | `"ghost-mariadb"` |  |
 | env.database__connection__password | string | `"ghost"` |  |
 | env.database__connection__user | string | `"ghost"` |  |
 | env.url | string | `"http://some-ghost.example.com"` |  |
@@ -100,7 +100,7 @@ N/A
 
 ## Changelog
 
-### Version 1.1.1
+### Version 1.1.2
 
 #### Added
 
@@ -112,7 +112,7 @@ N/A
 
 #### Fixed
 
-* Fixed PVC creation.
+* Fixed database host to match mariadb-svc
 
 ### Older versions
 

--- a/charts/stable/ghost/values.yaml
+++ b/charts/stable/ghost/values.yaml
@@ -17,7 +17,7 @@ image:
 env:
   url: "http://some-ghost.example.com"
   database__client: mysql
-  database__connection__host: mariadb
+  database__connection__host: ghost-mariadb
   database__connection__user: ghost
   database__connection__password: ghost
   database__connection__database: ghost


### PR DESCRIPTION
**Description of the change**

Fixed the database string in values to work out of the box

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Better out-of-the-box experience.

<!-- What benefits will be realized by the code change? -->

**Additional information**

I was unable to generate helm docs.

```
 ./hack/gen-helm-docs.sh stable ghost
-] Copying templates to /home/sky/Github/k8s-at-home-charts/charts/stable/ghost
INFO[2022-01-23T13:18:58+02:00] Found Chart directories [.]                  
INFO[2022-01-23T13:18:58+02:00] Generating README Documentation for chart /home/sky/Github/k8s-at-home-charts/charts/stable/ghost 
WARN[2022-01-23T13:18:58+02:00] Error generating gotemplates for chart /home/sky/Github/k8s-at-home-charts/charts/stable/ghost: template: /home/sky/Github/k8s-at-home-charts/charts/stable/ghost:120: function "fromYaml" not defined
```

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
