### PR TITLE
[maddy] enable configuring storage and imap

### DIFF
--- a/charts/stable/maddy/Chart.yaml
+++ b/charts/stable/maddy/Chart.yaml
@@ -26,6 +26,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: `alias` content moved from `maddy.alias` to `maddy.config_files.alias`
+      description: **Breaking**: `alias` content moved from `maddy.alias` to `maddy.config_files.alias`
     - kid: added
       description: additional settings for imap and local_mailboxes under `extra_settings`.

--- a/charts/stable/maddy/Chart.yaml
+++ b/charts/stable/maddy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v0.5.2
 description: Maddy Mail Server
 name: maddy
-version: 1.0.0
+version: 2.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - maddy
@@ -25,5 +25,7 @@ dependencies:
   condition: postgresql.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial version
+    - kind: changed
+      description: `alias` content moved from `maddy.alias` to `maddy.config_files.alias`
+    - kid: added
+      description: additional settings for imap and local_mailboxes under `extra_settings`.

--- a/charts/stable/maddy/README.md
+++ b/charts/stable/maddy/README.md
@@ -1,6 +1,6 @@
 # maddy
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: v0.5.2](https://img.shields.io/badge/AppVersion-v0.5.2-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: v0.5.2](https://img.shields.io/badge/AppVersion-v0.5.2-informational?style=flat-square)
 
 Maddy Mail Server
 
@@ -81,7 +81,6 @@ about how to do this.
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"foxcpp/maddy"` | image repository |
 | image.tag | string | chart.appVersion | image tag |
-| maddy.alias | string | `"## Replace 'cat' with any domain to 'dog'.\n## E.g. cat@example.net -> dog@example.net\n# cat: dog\n\n## Replace cat@example.org with cat@example.com.\n## Takes priority over the previous line.\n#cat@example.org: cat@example.com\n"` | Alias file used in smtp_rule See [alias examples](https://maddy.email/man/_generated_maddy-filters.5/). |
 | maddy.auth.ldap | object | See [See Maddy auth](https://maddy.email/man/_generated_maddy-auth.5/#configuration-directives_5) | If type is ldap the following options are required |
 | maddy.auth.ldap."bind plain" | string | `"\"cn=maddy,ou=people,dc=maddy,dc=test\" \"123456\""` | Specify initial bind credentials. Not required ('bind off') if DN template is used. |
 | maddy.auth.ldap.base_dn | string | `"\"ou=people,dc=maddy,dc=test\""` | Specify base_dn to lookup DN. |
@@ -92,6 +91,9 @@ about how to do this.
 | maddy.auth.ldap.starttls | string | `"off"` | Whether to upgrade connection to TLS using STARTTLS. |
 | maddy.auth.ldap.urls | string | `"ldap://maddy.test:389"` | URLs of the directory servers to use. First available server is used - no load-balancing is done. |
 | maddy.auth.type | string | `"sql"` | Where to store authorised users. Valid values are `sql` and `ldap` |
+| maddy.config_files.alias | string | `"## Replace 'cat' with any domain to 'dog'.\n## E.g. cat@example.net -> dog@example.net\n# cat: dog\n\n## Replace cat@example.org with cat@example.com.\n## Takes priority over the previous line.\n#cat@example.org: cat@example.com\n"` | Alias file used in smtp_rule See [alias examples](https://maddy.email/man/_generated_maddy-filters.5/). |
+| maddy.extra_settings.imap | object | `{}` | Additional settings for imap backend |
+| maddy.extra_settings.local_mailboxes | object | `{}` | Additional settings for local_mailboxes storage |
 | maddy.hostname | string | `"mx.example.com"` | Hostname the service will listen to (incoming SMTP and IMAP) |
 | maddy.primary_domain | string | `"example.com"` | Primary domain - will be included in SMTP protocol |
 | maddy.secondary_domains | string | `nil` | Space separated list of additional domains this server handles |
@@ -115,11 +117,11 @@ about how to do this.
 
 ## Changelog
 
-### Version 1.0.0
+### Version 2.0.0
 
 #### Added
 
-* Initial version
+N/A
 
 #### Changed
 

--- a/charts/stable/maddy/files/maddy.conf
+++ b/charts/stable/maddy/files/maddy.conf
@@ -92,6 +92,10 @@ storage.imapsql local_mailboxes {
 {{- else }}
     {{- fail (printf "Not a valid sql type (%s)" .Values.maddy.sql.type ) }}
 {{- end }}
+    # Other settings
+    {{- range $option, $value := .Values.maddy.extra_settings.local_mailboxes }}
+    {{ $option }} {{ tpl $value $ }}
+    {{- end }}
 }
 
 # ----------------------------------------------------------------------------
@@ -116,7 +120,11 @@ hostname $(hostname)
 # ----------------------------------------------------------------------------
 # IMAP endpoints
 
-imap tls://0.0.0.0:993 tcp://0.0.0.0:143 {
+imap tls://0.0.0.0:{{ .Values.service.main.ports.imaps.port }} tcp://0.0.0.0:{{ .Values.service.main.ports.imap.port }} {
     auth &local_authdb
     storage &local_mailboxes
+    # Other settings
+    {{- range $option, $value := .Values.maddy.extra_settings.imap }}
+    {{ $option }} {{ tpl $value $ }}
+    {{- end }}
 }

--- a/charts/stable/maddy/templates/common.yaml
+++ b/charts/stable/maddy/templates/common.yaml
@@ -32,8 +32,10 @@ configmap:
     data:
       maddy.conf: |
         {{ tpl (.Files.Get "files/maddy.conf") . | nindent 8 }}
-      aliases: |
-        {{ tpl (.Values.maddy.alias) . | nindent 8 }}
+      {{- range $configfile, $configfilecontent := .Values.maddy.config_files }}
+      {{ tpl $configfile $ }}: |
+        {{ tpl $configfilecontent $ | nindent 8 }}
+      {{- end }}
 
 persistence:
   config:

--- a/charts/stable/maddy/values.yaml
+++ b/charts/stable/maddy/values.yaml
@@ -100,16 +100,29 @@ maddy:
       custom: |
         # Rule block example
 
-  # -- Alias file used in smtp_rule
-  # See [alias examples](https://maddy.email/man/_generated_maddy-filters.5/).
-  alias: |
-    ## Replace 'cat' with any domain to 'dog'.
-    ## E.g. cat@example.net -> dog@example.net
-    # cat: dog
+  config_files:
+    # -- Alias file used in smtp_rule
+    # See [alias examples](https://maddy.email/man/_generated_maddy-filters.5/).
+    alias: |
+      ## Replace 'cat' with any domain to 'dog'.
+      ## E.g. cat@example.net -> dog@example.net
+      # cat: dog
 
-    ## Replace cat@example.org with cat@example.com.
-    ## Takes priority over the previous line.
-    #cat@example.org: cat@example.com
+      ## Replace cat@example.org with cat@example.com.
+      ## Takes priority over the previous line.
+      #cat@example.org: cat@example.com
+
+  extra_settings:
+    # -- Additional settings for local_mailboxes storage
+    local_mailboxes: {}
+      # imap_filter: |
+      #   {
+      #       command /etc/maddy/sieve.sh {account_name}
+      #   }
+    # -- Additional settings for imap backend
+    imap: {}
+      # debug: yes
+      # io_debug: yes
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml


### PR DESCRIPTION
**Description of the change**

- Enable configuring storage and imap backends
- Support for additional config files
  - (disruptive change) Move alias files to `config_files `section

**Benefits**

More flexibility configuring email server

**Possible drawbacks**

Disruptive change. It could be made concurrent but I would like to avoid keeping the glue code for the old name

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes NA

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
