### PR TITLE
[traefik-forward-auth] Fix condition for .Values.secret

### DIFF
--- a/charts/stable/traefik-forward-auth/Chart.yaml
+++ b/charts/stable/traefik-forward-auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik-forward-auth
 description: A minimal forward authentication service that provides OAuth/SSO login and authentication for the traefik reverse proxy/load balancer
 type: application
-version: 1.0.10
+version: 1.0.11
 appVersion: 2.2.0
 keywords:
   - traefik

--- a/charts/stable/traefik-forward-auth/templates/deployment.yaml
+++ b/charts/stable/traefik-forward-auth/templates/deployment.yaml
@@ -116,6 +116,7 @@ spec:
                   name: {{ $fullName }}
                   key: secret
               {{- end }}
+              {{- end }}
             {{- with .Values.providers}}
             {{- if .google.enabled }}
             {{- if .google.clientId }}
@@ -181,7 +182,6 @@ spec:
             {{- if .genericOauth.tokenStyle }}
             - name: PROVIDERS_GENERIC_OAUTH_TOKEN_STYLE
               value: {{ .genericOauth.tokenStyle | quote }}
-          {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
**Description of the change**

Setting `secret: "-"` to no create a secret removes _all_ env vars becuse the if is closed in the wrong place. This PR fixes that and just omits `SECRET` env var if `secret: "-"`.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
