### PR TITLE
[puppeteer] update readme

### DIFF
--- a/charts/stable/puppeteer/Chart.yaml
+++ b/charts/stable/puppeteer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v13.3.2
 description: Headless Chrome Node.js API
 name: puppeteer
-version: 1.0.0
+version: 1.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - puppeteer
@@ -24,4 +24,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
+      description: Updated README.

--- a/charts/stable/puppeteer/README_CONFIG.md.gotmpl
+++ b/charts/stable/puppeteer/README_CONFIG.md.gotmpl
@@ -1,11 +1,18 @@
 {{- define "custom.custom.configuration.header" -}}
-## Sample code to connect to Puppeteer
+## Special Instructions
 {{- end -}}
 
 {{- define "custom.custom.configuration" -}}
 {{ template "custom.custom.configuration.header" . }}
+### **Important!**
 
+```console
+You may need special headers to connect from outside of the cluster. Intra cluster works fine.
 ```
+
+### Sample code to connect to Puppeteer
+
+```javascript
 const puppeteer = require('puppeteer-core')
 const dns = require('dns').promises;
 
@@ -28,5 +35,16 @@ const dns = require('dns').promises;
       console.error(err)
     })
 })()
+```
+
+### Default chromium flags in image
+
+```javascript
+'--disable-dev-shm-usage',
+'--disable-setuid-sandbox',
+'--no-sandbox',
+'--remote-debugging-address=0.0.0.0',
+'--remote-debugging-port=4000',
+'--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS  X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/ 85.0.4183.121 Safari/537.36'
 ```
 {{- end -}}


### PR DESCRIPTION
Updating the readme until I can figure what chromium flags and/or headers are needed to connect from outside the cluster. 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
