### PR TITLE
[sonarr] add metrics config subpath when config has subPath specified

### DIFF
--- a/charts/stable/sonarr/Chart.yaml
+++ b/charts/stable/sonarr/Chart.yaml
@@ -22,5 +22,5 @@ dependencies:
     version: 4.3.0
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Updated exportarr to v1.0.0
+    - kind: added
+      description: Inherit persistence.config.subPath in metrics exporter

--- a/charts/stable/sonarr/Chart.yaml
+++ b/charts/stable/sonarr/Chart.yaml
@@ -22,5 +22,5 @@ dependencies:
     version: 4.3.0
 annotations:
   artifacthub.io/changes: |
-    - kind: added
+    - kind: changed
       description: Inherit persistence.config.subPath in metrics exporter

--- a/charts/stable/sonarr/Chart.yaml
+++ b/charts/stable/sonarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v3.0.6.1342
 description: Smart PVR for newsgroup and bittorrent users
 name: sonarr
-version: 16.0.0
+version: 16.0.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - sonarr

--- a/charts/stable/sonarr/README.md
+++ b/charts/stable/sonarr/README.md
@@ -104,7 +104,7 @@ N/A
 
 #### Added
 
-N/A
+* Supported persistence.config.subPath in metrics exporter
 
 #### Changed
 

--- a/charts/stable/sonarr/README.md
+++ b/charts/stable/sonarr/README.md
@@ -1,6 +1,6 @@
 # sonarr
 
-![Version: 16.0.0](https://img.shields.io/badge/Version-16.0.0-informational?style=flat-square) ![AppVersion: v3.0.6.1342](https://img.shields.io/badge/AppVersion-v3.0.6.1342-informational?style=flat-square)
+![Version: 16.0.1](https://img.shields.io/badge/Version-16.0.1-informational?style=flat-square) ![AppVersion: v3.0.6.1342](https://img.shields.io/badge/AppVersion-v3.0.6.1342-informational?style=flat-square)
 
 Smart PVR for newsgroup and bittorrent users
 
@@ -100,7 +100,7 @@ N/A
 
 ## Changelog
 
-### Version 16.0.0
+### Version 16.0.1
 
 #### Added
 

--- a/charts/stable/sonarr/templates/common.yaml
+++ b/charts/stable/sonarr/templates/common.yaml
@@ -29,6 +29,9 @@ additionalContainers:
       - name: config
         mountPath: /config
         readOnly: true
+        {{ if .Values.persistence.config.subPath }}
+        subPath: {{ .Values.persistence.config.subPath }}
+        {{ end }}
       {{ end }}
 
 service:


### PR DESCRIPTION
**Description of the change**

If persistence.config.subPath is specified for the main Sonarr container and metrics is enabled, the exporter is unable to find /config/config.xml because the Deployment generated is missing the corresponding subPath entry.

This change adds the subpath if it is specified.

**Benefits**

Allows exporter container to find config.xml when values specified as:

    persistence:
      config:
        enabled: true
        existingClaim: media-config-lh-pvc
        subPath: sonarr

**Possible drawbacks**

None

**Applicable issues**

See 
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1417 

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
