### PR TITLE
[lancache] Add probes for LanCache DNS.

### DIFF
--- a/charts/incubator/lancache/Chart.yaml
+++ b/charts/incubator/lancache/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: LanCache Monolithic - a caching proxy server for game download content
 name: lancache
-version: 0.3.0
+version: 0.4.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - lancache
@@ -21,5 +21,5 @@ dependencies:
     version: 4.3.0
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
+    - kind: added
+      description: Added probes for LanCache DNS container.

--- a/charts/incubator/lancache/templates/common.yaml
+++ b/charts/incubator/lancache/templates/common.yaml
@@ -44,6 +44,45 @@ additionalContainers:
       - name: dns
         containerPort: 53
         protocol: UDP
+    livenessProbe:
+      exec:
+        command:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+
+            # Check if LanCache DNS entries are set up.
+            dig @127.0.0.1 "${LANCACHE_DNSDOMAIN}" SOA | grep localhost
+
+            # Check if upstream DNS server is reachable.
+            dig "${LANCACHE_DNSDOMAIN}" SOA
+    readinessProbe:
+      exec:
+        command:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+
+            # Check if LanCache DNS entries are set up.
+            dig @127.0.0.1 "${LANCACHE_DNSDOMAIN}" SOA | grep localhost
+
+            # Check if upstream DNS server is reachable.
+            dig "${LANCACHE_DNSDOMAIN}" SOA
+    startupProbe:
+      exec:
+        command:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+
+            # Check if LanCache DNS entries are set up.
+            dig @127.0.0.1 "${LANCACHE_DNSDOMAIN}" SOA | grep localhost
+
+            # Check if upstream DNS server is reachable.
+            dig "${LANCACHE_DNSDOMAIN}" SOA
 
 service:
   dns:

--- a/charts/incubator/lancache/values.yaml
+++ b/charts/incubator/lancache/values.yaml
@@ -40,7 +40,7 @@ service:
         port: 53
 
 # -- LanCache uses custom upstream nameservers, overridable with the `UPSTREAM_DNS` variable.
-dnsPolicy: 'None'
+dnsPolicy: None
 dnsConfig:
   nameservers:
     - 127.0.0.1


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Add probes for the LanCache DNS container.

**Benefits**

Improve DNS availability.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

