### PR TITLE
[pod-gateway] Permit overriding DNSPolicy

### DIFF
--- a/charts/stable/pod-gateway/Chart.yaml
+++ b/charts/stable/pod-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.6
 description: Admision controller to change the default gateway and DNS server of PODs
 name: pod-gateway
-version: 5.2.0
+version: 5.2.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - pod-gateway

--- a/charts/stable/pod-gateway/Chart.yaml
+++ b/charts/stable/pod-gateway/Chart.yaml
@@ -21,4 +21,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
+      description: Added option to override mutated pod's DNSPolicy.

--- a/charts/stable/pod-gateway/templates/webhook-deployment.yaml
+++ b/charts/stable/pod-gateway/templates/webhook-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             # Static
             - --tls-cert-file-path=/tls/tls.crt
             - --tls-key-file-path=/tls/tls.key
-            - --DNSPolicy=DNS={{ .Values.DNSPolicy }}
+            - --DNSPolicy={{ .Values.DNSPolicy }}
             # Init container
             - --initImage={{ .Values.image.repository }}:{{ .Values.image.tag }}
             - --initImagePullPol={{ .Values.image.pullPolicy }}

--- a/charts/stable/pod-gateway/templates/webhook-deployment.yaml
+++ b/charts/stable/pod-gateway/templates/webhook-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             # Static
             - --tls-cert-file-path=/tls/tls.crt
             - --tls-key-file-path=/tls/tls.key
-            - --DNSPolicy=None
+            - --DNSPolicy=DNS={{ .Values.DNSPolicy }}
             # Init container
             - --initImage={{ .Values.image.repository }}:{{ .Values.image.tag }}
             - --initImagePullPol={{ .Values.image.pullPolicy }}

--- a/charts/stable/pod-gateway/values.yaml
+++ b/charts/stable/pod-gateway/values.yaml
@@ -18,8 +18,8 @@ image:
 # It must match VXLAN_GATEWAY_IP in settings.sh
 DNS: 172.16.0.1
 
-# -- The DNSPolicy to apply to the POD. Only when set to "None" will the 
-# DNS value above apply. To avoid altering POD DNS (i.e., to allow 
+# -- The DNSPolicy to apply to the POD. Only when set to "None" will the
+# DNS value above apply. To avoid altering POD DNS (i.e., to allow
 # initContainers to use DNS before the the VXLAN is up), set to "ClusterFirst"
 DNSPolicy: None
 

--- a/charts/stable/pod-gateway/values.yaml
+++ b/charts/stable/pod-gateway/values.yaml
@@ -18,6 +18,11 @@ image:
 # It must match VXLAN_GATEWAY_IP in settings.sh
 DNS: 172.16.0.1
 
+# -- The DNSPolicy to apply to the POD. Only when set to "None" will the 
+# DNS value above apply. To avoid altering POD DNS (i.e., to allow 
+# initContainers to use DNS before the the VXLAN is up), set to "ClusterFirst"
+DNSPolicy: None
+
 # -- cluster name used to derive the gateway full name
 clusterName: "cluster.local"
 


### PR DESCRIPTION
**Description of the change**

Hey gang! pod-gateway is a work of genius! This PR introduces a small optional changes to allow the operator to alter the `DNSPolicy` on the mutated pod.

Why? In my use-case, I mutate pods which run initContainers, and these initContainers require working DNS / network connectivity. Without this change, the webhook will always apply `DNSPolicy: None` to the pod, and then explicitly specify the VXLAN gateway endpoint as the DNS server using `dnsConfig`. This only works when the sidecar is up though, and so breaks DNS resolution for initContainers.

If a user doesn't care about routing DNS traffic over the gateway, they can set `DNSPolicy: ClusterFirst`, which will effectively ignore the `dnsConfig` values, and cause the pod to use the clusterDNS (_which is Kubernetes' default pod behavior_)

**Benefits**

Users who (a) need initContainers to have DNS and (b) don't care about routing this DNS traffic over the gateway can now do so.

**Possible drawbacks**

None


**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
