### PR TITLE
[paperless] chore: switch to paperless-ngx project

### DIFF
--- a/charts/stable/paperless/Chart.yaml
+++ b/charts/stable/paperless/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.0
 description: Paperless - Index and archive all of your scanned paper documents
 name: paperless
-version: 9.0.0
+version: 8.4.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - paperless

--- a/charts/stable/paperless/Chart.yaml
+++ b/charts/stable/paperless/Chart.yaml
@@ -2,18 +2,20 @@ apiVersion: v2
 appVersion: 1.5.0
 description: Paperless - Index and archive all of your scanned paper documents
 name: paperless
-version: 8.3.0
+version: 9.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - paperless
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/paperless
 icon: https://avatars.githubusercontent.com/u/47271576?s=200&v=4
 sources:
-  - https://github.com/jonaswinkler/paperless-ng
+  - https://github.com/paperless-ngx/paperless-ngx
 maintainers:
   - name: mr-onion-2
   - name: jonnobrow
     email: jonathan@jonnobrow.co.uk
+  - name: morremeyer
+    email: charts@mor.re
 dependencies:
   - name: common
     repository: https://library-charts.k8s-at-home.com
@@ -29,8 +31,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
-    - kind: changed
-      description: Upgraded `postgresql` chart dependency to version `10.14.4`.
-    - kind: changed
-      description: Upgraded `redis` chart dependency to version `15.6.10`.
+      description: This is a non-breaking change, but an important organizational update. Moved image and source links to the community fork paperless-ngx. See https://github.com/jonaswinkler/paperless-ng/issues/1599 and https://github.com/jonaswinkler/paperless-ng/issues/1632.

--- a/charts/stable/paperless/Chart.yaml
+++ b/charts/stable/paperless/Chart.yaml
@@ -31,4 +31,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: This is a non-breaking change, but an important organizational update. Moved image and source links to the community fork paperless-ngx. See https://github.com/jonaswinkler/paperless-ng/issues/1599 and https://github.com/jonaswinkler/paperless-ng/issues/1632.
+      description: Changed image and source links to the community fork paperless-ngx. See https://github.com/jonaswinkler/paperless-ng/issues/1599 and https://github.com/jonaswinkler/paperless-ng/issues/1632.

--- a/charts/stable/paperless/README.md
+++ b/charts/stable/paperless/README.md
@@ -8,7 +8,7 @@ Paperless - Index and archive all of your scanned paper documents
 
 ## Source Code
 
-* <https://github.com/jonaswinkler/paperless-ng>
+* <https://github.com/paperless-ngx/paperless-ngx>
 
 ## Requirements
 

--- a/charts/stable/paperless/values.yaml
+++ b/charts/stable/paperless/values.yaml
@@ -7,15 +7,16 @@
 
 image:
   # -- image repository
-  repository: jonaswinkler/paperless-ng
+  repository: ghcr.io/paperless-ngx/paperless-ngx
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: 1.5.0
+  # @default -- chart.appVersion
+  tag:
 
 # -- See the following files for additional environment variables:
-# https://github.com/jonaswinkler/paperless-ng/tree/master/docker/compose/
-# https://github.com/jonaswinkler/paperless-ng/blob/master/paperless.conf.example
+# https://github.com/paperless-ngx/paperless-ngx/tree/main/docker/compose/
+# https://github.com/paperless-ngx/paperless-ngx/blob/main/paperless.conf.example
 # @default -- See below
 env:
   # -- Project name


### PR DESCRIPTION
**Description of the change**

This switches to the community fork of paperless-ng. The tracking ticket in paperless-ngx is https://github.com/paperless-ngx/paperless-ngx/issues/68.

Please see the following references for the community discussion of the decision to fork:

* https://github.com/jonaswinkler/paperless-ng/issues/1599
* https://github.com/jonaswinkler/paperless-ng/issues/1632.

**Benefits**

Switch to the community maintained **paperless-ngx** fork.

**Possible drawbacks**

None that I am aware of.

**Additional information**

This is a non-breaking change for the paperless application itself, but as it changes the upstream, I've opted to bump the major version.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
