### PR TITLE
[blocky]: Upgrade appVersion and use it from chart.

### DIFF
--- a/charts/stable/blocky/Chart.yaml
+++ b/charts/stable/blocky/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.17
+appVersion: v0.18
 description: DNS proxy as ad-blocker for local network
 name: blocky
-version: 10.1.0
+version: 10.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - blocky
@@ -22,4 +22,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
+      description: Upgraded `appversion` to version `0.18` and made it use Chart.appversion by default for ease of maintenance.

--- a/charts/stable/blocky/values.yaml
+++ b/charts/stable/blocky/values.yaml
@@ -9,7 +9,8 @@ image:
   # -- image repository
   repository: ghcr.io/0xerr0r/blocky
   # -- image tag
-  tag: v0.17
+  # @default -- chart.appVersion
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

Upgraded the chart to use appVersion from Chart rather than values by default.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Easy of maintenance

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

Not sure if there is any

<!-- Describe any known limitations with your change -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
