### PR TITLE
[photoprism] Add MariaDB support to Photoprism

### DIFF
--- a/charts/stable/photoprism/Chart.yaml
+++ b/charts/stable/photoprism/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "20211018"
 description: PhotoPrism® is a server-based application for browsing, organizing and sharing your personal photo collection
 name: photoprism
-version: 6.3.0
+version: 6.4.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - photos
@@ -21,7 +21,11 @@ dependencies:
   - name: common
     repository: https://library-charts.k8s-at-home.com
     version: 4.3.0
+  - name: mariadb
+    version: 10.2.0
+    repository: https://charts.bitnami.com/bitnami
+    condition: mariadb.enabled
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
+      description: Added MariaDB database support

--- a/charts/stable/photoprism/Chart.yaml
+++ b/charts/stable/photoprism/Chart.yaml
@@ -28,4 +28,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Added MariaDB database support and bumped appVersion to 20220121
+      description: Bumped application version to `20220121`.
+    - kind: added
+      description: Added MariaDB database support.

--- a/charts/stable/photoprism/Chart.yaml
+++ b/charts/stable/photoprism/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "20211018"
+appVersion: "20220121"
 description: PhotoPrism® is a server-based application for browsing, organizing and sharing your personal photo collection
 name: photoprism
 version: 6.4.0

--- a/charts/stable/photoprism/Chart.yaml
+++ b/charts/stable/photoprism/Chart.yaml
@@ -28,4 +28,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Added MariaDB database support
+      description: Added MariaDB database support and bumped appVersion to 20220121

--- a/charts/stable/photoprism/README.md
+++ b/charts/stable/photoprism/README.md
@@ -82,6 +82,11 @@ N/A
 | env.PHOTOPRISM_ORIGINALS_PATH | string | `"/photoprism/originals"` | Photoprism originals path |
 | env.PHOTOPRISM_PUBLIC | string | `"false"` | Disable authentication / password protection |
 | env.PHOTOPRISM_STORAGE_PATH | string | `"/photoprism/storage"` | Photoprism storage path |
+| env.PHOTOPRISM_DATABASE_DRIVER | string | `"sqlite"` | Database driver (sqlite, mysql) |
+| env.PHOTOPRISM_DATABASE_SERVER | string | `"photoprism-mariadb:3306"` | Database host incl. port |
+| env.PHOTOPRISM_DATABASE_NAME | string | `"photoprism"` | Database schema name |
+| env.PHOTOPRISM_DATABASE_USER | string | `"photoprism"` | Database user name |
+| env.PHOTOPRISM_DATABASE_PASSWORD | string | `"photoprism"` | Database user password |
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | env.UID | string | `nil` | Sets UID Photoprism runs under. |
 | env.UMASK | string | `nil` | Sets UMASK. |
@@ -89,6 +94,7 @@ N/A
 | image.repository | string | `"photoprism/photoprism"` | image repository |
 | image.tag | string | `"20211018"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
+| mariadb | object | See values.yaml | Enable and configure mariadb database subchart under this key.    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | service | object | See values.yaml | Configures service settings for the chart. |
 

--- a/charts/stable/photoprism/values.yaml
+++ b/charts/stable/photoprism/values.yaml
@@ -32,6 +32,16 @@ env:
   GID:  # 1000
   # -- Sets UMASK.
   UMASK:  # 0000
+  # -- Database driver (sqlite, mysql)
+  PHOTOPRISM_DATABASE_DRIVER: sqlite
+  # -- Database host incl. port
+  PHOTOPRISM_DATABASE_SERVER: photoprism-mariadb:3306
+  # -- Database schema name
+  PHOTOPRISM_DATABASE_NAME: photoprism
+  # -- Database user name
+  PHOTOPRISM_DATABASE_USER: photoprism
+  # -- Database user password
+  PHOTOPRISM_DATABASE_PASSWORD: photoprism
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml
@@ -57,3 +67,19 @@ persistence:
   originals:
     enabled: false
     mountPath: "/photoprism/originals"
+
+# -- Enable and configure mariadb database subchart under this key.
+#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+# @default -- See values.yaml
+mariadb:
+  enabled: false
+  architecture: standalone
+  auth:
+    database: photoprism
+    username: photoprism
+    password: photoprism
+    rootPassword: photoprism
+  primary:
+    persistence:
+      enabled: false
+      # storageClass: ""

--- a/charts/stable/photoprism/values.yaml
+++ b/charts/stable/photoprism/values.yaml
@@ -9,7 +9,8 @@ image:
   # -- image repository
   repository: photoprism/photoprism
   # -- image tag
-  tag: "20211018"
+  # @default -- chart.appVersion
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

Add support for MariaDB database backend to Photoprism for increased app performance. The style of the change was copied from the Webtrees chart, which uses the Bitnami MariaDB chart. All options are passed to Photoprism by env vars.

The default behaviour has been retained (i.e. SQLite remains the default backend).

https://docs.photoprism.app/getting-started/config-options/#database-connection

**Benefits**

Photoprism will be able to use MariaDB as well as SQLite, which will offer better performance for large photo libraries.

**Possible drawbacks**

None

**Additional information**

I'm not sure if the `README.md` is partially generated by CI, but I documented the new params in `values.yaml` and also in `README.md` in case it wasn't automagically re-generated. Happy to rework this if necessary.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.