### PR TITLE
[warrior] New incubator chart for ArchiveTeam warrior

### DIFF
--- a/charts/incubator/warrior/.helmignore
+++ b/charts/incubator/warrior/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS file for Kubernetes
+OWNERS
+# helm-docs templates
+*.gotmpl

--- a/charts/incubator/warrior/Chart.yaml
+++ b/charts/incubator/warrior/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+appVersion: v0.9
+description: The Archive Team Warrior is a virtual archiving appliance. You can run it to help with the Archive Team archiving efforts. It will download sites and upload them to our archive—and it’s really easy to do!
+name: warrior
+version: v0.9
+kubeVersion: ">=1.16.0-0"
+keywords:
+  - warrior
+  - archiveteam
+home: https://github.com/k8s-at-home/charts/tree/master/charts/incubator/warrior
+# icon: https://avatars1.githubusercontent.com/u/3368377?s=400&v=4
+sources:
+  - https://wiki.archiveteam.org/index.php/ArchiveTeam_Warrior
+  - https://github.com/ArchiveTeam/warrior-dockerfile
+maintainers:
+  - name: stimmerman
+    email: sander@red9.nl
+dependencies:
+  - name: common
+    repository: https://library-charts.k8s-at-home.com
+    version: 4.3.0
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Upgraded `common` chart dependency to version `4.3.0`.

--- a/charts/incubator/warrior/Chart.yaml
+++ b/charts/incubator/warrior/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - warrior
   - archiveteam
 home: https://github.com/k8s-at-home/charts/tree/master/charts/incubator/warrior
-# icon: https://avatars1.githubusercontent.com/u/3368377?s=400&v=4
+icon: https://camo.githubusercontent.com/782d076bd3542f1e91abe60274e7fac9f63f586f8f6a27a13e16425fb8fd4608/68747470733a2f2f7777772e617263686976657465616d2e6f72672f696d616765732f662f66332f417263686976655f7465616d2e706e67
 sources:
   - https://wiki.archiveteam.org/index.php/ArchiveTeam_Warrior
   - https://github.com/ArchiveTeam/warrior-dockerfile

--- a/charts/incubator/warrior/Chart.yaml
+++ b/charts/incubator/warrior/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.0.0
+appVersion: latest
 description: The Archive Team Warrior is a virtual archiving appliance. You can run it to help with the Archive Team archiving efforts. It will download sites and upload them to our archive—and it’s really easy to do!
 name: warrior
 version: 1.0.0
@@ -21,5 +21,5 @@ dependencies:
     version: 4.3.0
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
+    - kind: added
+      description: Initial chart version.

--- a/charts/incubator/warrior/Chart.yaml
+++ b/charts/incubator/warrior/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v0.9
+appVersion: v1.0.0
 description: The Archive Team Warrior is a virtual archiving appliance. You can run it to help with the Archive Team archiving efforts. It will download sites and upload them to our archive—and it’s really easy to do!
 name: warrior
-version: v0.9
+version: 1.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - warrior

--- a/charts/incubator/warrior/README_CONFIG.md.gotmpl
+++ b/charts/incubator/warrior/README_CONFIG.md.gotmpl
@@ -1,0 +1,9 @@
+{{- define "custom.custom.configuration.header" -}}
+## Custom configuration
+{{- end -}}
+
+{{- define "custom.custom.configuration" -}}
+{{ template "custom.custom.configuration.header" . }}
+
+N/A
+{{- end -}}

--- a/charts/incubator/warrior/templates/NOTES.txt
+++ b/charts/incubator/warrior/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/incubator/warrior/templates/common.yaml
+++ b/charts/incubator/warrior/templates/common.yaml
@@ -1,0 +1,1 @@
+{{ include "common.all" . }}

--- a/charts/incubator/warrior/values.yaml
+++ b/charts/incubator/warrior/values.yaml
@@ -9,9 +9,10 @@ image:
   # -- image repository
   repository: atdr.meo.ws/archiveteam/warrior-dockerfile
   # -- image tag
-  tag: latest
+  # @default -- chart.appVersion
+  tag:
   # -- image pull policy
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml

--- a/charts/incubator/warrior/values.yaml
+++ b/charts/incubator/warrior/values.yaml
@@ -1,0 +1,35 @@
+#
+# IMPORTANT NOTE
+#
+# This chart inherits from our common library chart. You can check the default values/options here:
+# https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml
+#
+
+image:
+  # -- image repository
+  repository: atdr.meo.ws/archiveteam/warrior-dockerfile
+  # -- image tag
+  tag: latest
+  # -- image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Configures service settings for the chart.
+# @default -- See values.yaml
+service:
+  main:
+    ports:
+      http:
+        port: 8001
+
+ingress:
+  # -- Enable and configure ingress settings for the chart under this key.
+  # @default -- See values.yaml
+  main:
+    enabled: false
+
+# -- Configure persistence settings for the chart under this key.
+# @default -- See values.yaml
+persistence:
+  config:
+    enabled: false
+    mountPath: /projects


### PR DESCRIPTION
**Description of the change**
Adds the ArchiveTeam warrior appliance as a new chart.

**Benefits**
I could not find a Helm chart anywhere to deploy their container. Might as well add it using the k8s-at-home framework.

**Possible drawbacks**
The image published is only tagged with 'latest'.

**Additional information**
See here for any configuration of the container: https://github.com/ArchiveTeam/warrior-dockerfile