### PR TITLE
[torbridge] Add new chart for Tor project obfs4 bridge

### DIFF
--- a/charts/incubator/torbridge/.helmignore
+++ b/charts/incubator/torbridge/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OWNERS file for Kubernetes
+OWNERS
+# helm-docs templates
+*.gotmpl

--- a/charts/incubator/torbridge/Chart.yaml
+++ b/charts/incubator/torbridge/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+appVersion: "0.10"
+description: Tor obfs4 bridge to help censored users connect to the Tor network.
+name: torbridge
+version: 1.0.0
+kubeVersion: ">=1.16.0-0"
+keywords:
+  - bridge
+  - privacy
+  - security
+  - tor
+sources:
+  - https://community.torproject.org/relay/setup/bridge/docker/
+  - https://gitlab.torproject.org/tpo/anti-censorship/docker-obfs4-bridge/
+icon: https://community.torproject.org/static/images/tor-logo@2x.png?h=16ad42bc
+maintainers:
+  - name: stimmerman
+    email: sander@red9.nl
+dependencies:
+  - name: common
+    version: 4.3.0
+    repository: https://library-charts.k8s-at-home.com
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: Initial chart version.

--- a/charts/incubator/torbridge/README_CONFIG.md.gotmpl
+++ b/charts/incubator/torbridge/README_CONFIG.md.gotmpl
@@ -1,0 +1,18 @@
+{{- define "custom.custom.configuration.header" -}}
+## Custom configuration
+{{- end -}}
+
+{{- define "custom.custom.configuration" -}}
+{{ template "custom.custom.configuration.header" . }}
+
+Make sure that both ports are forwarded in your firewall for the Tor bridge to work.
+To use your new bridge in Tor Browser, you need its "bridge line". Here's how you can get your bridge line:
+
+`kubectl exec POD_NAME -- get-bridge-line`
+
+This will return a string similar to the following:
+```
+obfs4 1.2.3.4:1234 B0E566C9031657EA7ED3FC9D248E8AC4F37635A4 cert=OYWq67L7MDApdJCctUAF7rX8LHvMxvIBPHOoAp0+YXzlQdsxhw6EapaMNwbbGICkpY8CPQ iat-mode=0
+```
+
+{{- end -}}

--- a/charts/incubator/torbridge/templates/NOTES.txt
+++ b/charts/incubator/torbridge/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "common.notes.defaultNotes" . -}}

--- a/charts/incubator/torbridge/templates/common.yaml
+++ b/charts/incubator/torbridge/templates/common.yaml
@@ -1,0 +1,1 @@
+{{ include "common.all" . }}

--- a/charts/incubator/torbridge/values.yaml
+++ b/charts/incubator/torbridge/values.yaml
@@ -1,0 +1,62 @@
+#
+# IMPORTANT NOTE
+#
+# This chart inherits from our common library chart. You can check the default values/options here:
+# https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common/values.yaml
+#
+
+image:
+  # -- image repository
+  repository: thetorproject/obfs4-bridge
+  # -- image tag
+  tag: "0.10"
+  # -- image pull policy
+  pullPolicy: IfNotPresent
+
+# @default -- See below
+env:
+  # -- Your bridge's Tor port.
+  # @default -- 9001
+  OR_PORT: 9001
+  # -- Your bridge's obfs4 port.
+  # @default -- 993
+  PT_PORT: 993
+  # -- Your email address.
+  # @default -- someone@example.com
+  EMAIL: someone@example.com
+  # -- If you want, you could change the nickname of your bridge
+  # @default -- DockerObfs4Bridge
+  NICKNAME: DockerObfs4Bridge
+  # -- Activate additional variables processing
+  # @default -- 1 (true)
+  OBFS4_ENABLE_ADDITIONAL_VARIABLES: 1
+  # -- Disable IPv6 for the bridge
+  # @default -- 1 (true)
+  OBFS4V_AddressDisableIPv6: 1
+
+# -- Configures service settings for the chart.
+# @default -- See values.yaml
+service:
+  main:
+    enabled: true
+    ports:
+      http:
+        enabled: false
+      or-tcp:
+        enabled: true
+        port: 9001
+        protocol: TCP
+        targetPort: 9001
+      pt-tcp:
+        enabled: true
+        port: 993
+        protocol: TCP
+        targetPort: 993
+    externalTrafficPolicy: Local
+
+# -- Configure persistence settings for the chart under this key.
+# @default -- See values.yaml
+persistence:
+  config:
+    enabled: true
+    mountPath: /var/lib/tor


### PR DESCRIPTION
**Description of the change**
This PR adds a helm chart for running the Tor project obfs4 bridge. It helps users in restricted countries with limited or censored internet to connect to the Tor network.

https://community.torproject.org/relay/setup/bridge/

**Benefits**
I could not find a good helm chart for running this container. I hope utilising the k8s-at-home chart framework that it's easier for others to run a tor bridge.

**Additional information**
Make sure to configure and open those ports to the internet for the bridge to work.
