### PR TITLE
[paperless] feat: upgrade to paperless-ngx 1.6.0

### DIFF
--- a/charts/stable/paperless/Chart.yaml
+++ b/charts/stable/paperless/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.5.0
+appVersion: 1.6.0
 description: Paperless - Index and archive all of your scanned paper documents
 name: paperless
-version: 8.4.0
+version: 8.5.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - paperless
@@ -31,4 +31,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Changed image and source links to the community fork paperless-ngx. See https://github.com/jonaswinkler/paperless-ng/issues/1599 and https://github.com/jonaswinkler/paperless-ng/issues/1632.
+      description: Upgrade to 1.6.0 and set default value for PAPERLESS_PORT to prevent CrashLoopBackoff. See https://github.com/paperless-ngx/paperless-ngx/issues/264.

--- a/charts/stable/paperless/values.yaml
+++ b/charts/stable/paperless/values.yaml
@@ -30,6 +30,8 @@ env:
   # PAPERLESS_TIME_ZONE: Europe/London
   # -- Database host to use
   PAPERLESS_DBHOST:
+  # -- Port to use
+  PAPERLESS_PORT: 8000
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml


### PR DESCRIPTION
**Description of the change**

Upgrades to paperless-ngx 1.6.0

**Benefits**

Makes 1.6.0 available per default

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

This also sets the default value for `PAPERLESS_PORT` which is needed to not break with 1.6.0. Please check https://github.com/paperless-ngx/paperless-ngx/issues/264 for detailed information.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
