### PR TITLE
[influxdb-exporter] update img to 0.9.0, use other port for UDP

### DIFF
--- a/charts/stable/influxdb-exporter/Chart.yaml
+++ b/charts/stable/influxdb-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.8.1
+appVersion: v0.9.0
 description: An exporter for metrics in the InfluxDB format, transforms them and exposes them for consumption by Prometheus.
 name: influxdb-exporter
-version: 1.0.1
+version: 1.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - influxdb-exporter
@@ -20,4 +20,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Add the description and custom configuration to the README.md
+      description: Update image to 0.9.0 (InfluxDB v2 clients support), use differnt port for UDP.

--- a/charts/stable/influxdb-exporter/templates/servicemonitor.yaml
+++ b/charts/stable/influxdb-exporter/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       {{- include "common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
-    - port: main
+    - port: http
       {{- with .Values.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
@@ -21,7 +21,7 @@ spec:
       scrapeTimeout: {{ . }}
       {{- end }}
       path: /metrics
-    - port: main
+    - port: http
       {{- with .Values.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/charts/stable/influxdb-exporter/values.yaml
+++ b/charts/stable/influxdb-exporter/values.yaml
@@ -31,6 +31,7 @@ service:
     ports:
       http:
         port: 9122
+        targetPort: 9122
   udp:
     enabled: true
     type: LoadBalancer
@@ -38,8 +39,8 @@ service:
     ports:
       udp:
         enabled: true
-        port: 9123
         protocol: UDP
+        port: 9123
         targetPort: 9123
 
 metrics:

--- a/charts/stable/influxdb-exporter/values.yaml
+++ b/charts/stable/influxdb-exporter/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: prom/influxdb-exporter
   # -- image tag
-  tag: v0.8.1
+  tag: v0.9.0
   # -- image pull policy
   pullPolicy: IfNotPresent
 
@@ -18,6 +18,10 @@ image:
 env:
   # -- Set the container timezone
   TZ: UTC
+
+# -- Override the args for the default container
+args:
+  - "--udp.bind-address=0.0.0.0:9123"
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml
@@ -30,12 +34,13 @@ service:
   udp:
     enabled: true
     type: LoadBalancer
+    loadBalancerIP: ""
     ports:
       udp:
         enabled: true
-        port: 9122
+        port: 9123
         protocol: UDP
-        targetPort: 9122
+        targetPort: 9123
 
 metrics:
   # -- Enable and configure prometheus-qbittorrent-exporter sidecar and Prometheus podMonitor.


### PR DESCRIPTION
**Description of the change**

- Update image to 0.9.0 (Support ingestion from InfluxDB v2 clients)
- Change default UDP port (on some config it's not supported using the same port for TCP and UDP)
- Fix ServiceMonitor port name

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

