### PR TITLE
[wikijs] Remove default empty env variables for wikijs - fixes #1455

### DIFF
--- a/charts/stable/wikijs/Chart.yaml
+++ b/charts/stable/wikijs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: version-2.5.201
 description: Make documentation a joy to write using Wiki.js's beautiful and intuitive interface!
 name: wikijs
-version: 6.2.0
+version: 6.2.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - wiki
@@ -22,4 +22,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
+      description: Removed the forced env {} so they can be populated elsewhere (envFrom secrets for example)

--- a/charts/stable/wikijs/values.yaml
+++ b/charts/stable/wikijs/values.yaml
@@ -21,24 +21,15 @@ image:
 env:
   # -- Set the container timezone
   TZ: UTC
-  # -- mysql, postgres, mariadb, mssql or sqlite
-  DB_TYPE: sqlite
-  # -- Path to the SQLite file
-  DB_FILEPATH: /app/wiki/data/db.sqlite
-  # -- Port of the database
-  DB_PORT:
-  # -- Username to connect to the database
-  DB_USER:
-  # -- Password to connect to the database
-  DB_PASS:
-  # -- Database name
-  DB_NAME:
-  # -- Set to either 1 or true to enable. (optional, off if omitted)
-  DB_SSL:
-  # -- Database CA certificate content, as a single line string (without spaces or new lines), without the prefix and suffix lines. (optional, requires 2.3+)
-  DB_SSL_CA:
-  # -- Path to the mapped file containing to the database password. (optional, replaces `DB_PASS`)
-  DB_PASS_FILE:
+  # DB_TYPE -- mysql, postgres, mariadb, mssql or sqlite
+  # DB_FILEPATH -- Path to the SQLite file
+  # DB_PORT -- Port of the database
+  # DB_USER -- Username to connect to the database
+  # DB_PASS -- Password to connect to the database
+  # DB_NAME -- Database name
+  # DB_SSL -- Set to either 1 or true to enable. (optional, off if omitted)
+  # DB_SSL_CA -- Database CA certificate content, as a single line string (without spaces or new lines), without the prefix and suffix lines. (optional, requires 2.3+)
+  # DB_PASS_FILE -- Path to the mapped file containing to the database password. (optional, replaces `DB_PASS`)
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml


### PR DESCRIPTION
Signed-off-by: Gavin Mogan <git@gavinmogan.com>

**Description of the change**

Remove default env variables for wikijs

**Benefits**

Allows env variables to be populated by secrets

**Possible drawbacks**

Anyone depending on the default values will have things break

**Applicable issues**

- fixes #1455

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
