### PR TITLE
[monica] Remove default empty env variables - along the same lines as #1455

### DIFF
--- a/charts/stable/monica/Chart.yaml
+++ b/charts/stable/monica/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3.7.0-apache
 description: A Personal Relationship Management tool to help you organize your social life
 name: monica
-version: 7.0.1
+version: 7.0.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - crm
@@ -25,4 +25,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded app to version `3.7.0-apache` from `3.1.1-apache`.
+      description: Removed the forced env {} so they can be populated elsewhere (envFrom secrets for example)

--- a/charts/stable/monica/values.yaml
+++ b/charts/stable/monica/values.yaml
@@ -21,21 +21,16 @@ env:
   TZ: UTC
   # -- Use `local` if you want to install Monica as a development version. Use `production` otherwise.
   APP_ENV: production
-  # -- The encryption key. This is the most important part of the application.
+  # APP_KEY -- The encryption key. This is the most important part of the application.
   # Keep this secure otherwise, everyone will be able to access your application.
   # Must be 32 characters long exactly.
   # Use `php artisan key:generate` or `echo -n 'base64:'; openssl rand -base64 32` to generate a random key.
-  APP_KEY:
   # -- The URL of your application.
   APP_URL: https://crm.k8s-at-home.com
-  # -- Database hostname
-  DB_HOST:  # monica-mariadb
-  # -- Database to connect to
-  DB_DATABASE:  # monica
-  # -- Database username
-  DB_USERNAME:  # monica
-  # -- Database password
-  DB_PASSWORD:  # monicapass
+  # DB_HOST -- Database hostname
+  # DB_DATABASE -- Database to connect to
+  # DB_USERNAME -- Database username
+  # DB_PASSWORD -- Database password
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml


### PR DESCRIPTION
**Description of the change**

Remove default env variables for monica

**Benefits**

Allows env variables to be populated by secrets

**Possible drawbacks**

Anyone depending on the default values will have things break

**Applicable issues**

- related to #1455 (wikijs)

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
