### PR TITLE
chore(homebridge): Set permissions for startup.sh to be executable

### DIFF
--- a/charts/stable/homebridge/Chart.yaml
+++ b/charts/stable/homebridge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.0
 description: A lightweight NodeJS server that emulates the iOS HomeKit API
 name: homebridge
-version: 4.3.0
+version: 4.3.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - homebridge
@@ -21,5 +21,5 @@ dependencies:
     version: 4.3.0
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
+    - kind: fixed
+      description: Set permissions for startup.sh to be executable

--- a/charts/stable/homebridge/templates/common.yaml
+++ b/charts/stable/homebridge/templates/common.yaml
@@ -10,6 +10,7 @@ type: "custom"
 volumeSpec:
   configMap:
     name: {{ include "common.names.fullname" . }}-config
+    defaultMode: 0755
 {{- end -}}
 {{- $_ := set .Values.persistence "homebridge-config" (include "homebridge.configVolume" . | fromYaml) -}}
 


### PR DESCRIPTION
**Description of the change**

Currently we allow configuration of `startup.sh` through the `config` stanza in `values.yaml`, however this file is mounted with default permissions and so is not actually executable and fails silently. This adds a `defaultMode` configuration to the volume config which ensures the file will be executable at startup. 

**Benefits**

Ensures users running Homebridge will be able to configure and execute the startup script through the Helm configuration (commonly used for bootstrapping things like setting NET_CAP on the node binary).

**Possible drawbacks**

No drawbacks, as this fixes intended behaviour.

**Applicable issues**

- fixes #1465

**Additional information**

**Checklist**
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
