### PR TITLE
uptime-kuma: update version to 1.13.1

### DIFF
--- a/charts/stable/uptime-kuma/Chart.yaml
+++ b/charts/stable/uptime-kuma/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.11.1
+appVersion: 1.13.1
 description: A fancy self-hosted monitoring tool for your websites and applications
 name: uptime-kuma
-version: 1.1.0
+version: 1.2.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - uptime-kuma

--- a/charts/stable/uptime-kuma/Chart.yaml
+++ b/charts/stable/uptime-kuma/Chart.yaml
@@ -21,6 +21,7 @@ dependencies:
     repository: https://library-charts.k8s-at-home.com
     version: 4.3.0
 annotations:
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded `common` chart dependency to version `4.3.0`.
+      description: Update appVersion to v1.13.1, including a security fix in v1.11.4 ('Update vulnerable packages') and v1.12.1 ('Update axios to 0.26.0 due to vulnerability')

--- a/charts/stable/uptime-kuma/values.yaml
+++ b/charts/stable/uptime-kuma/values.yaml
@@ -9,7 +9,8 @@ image:
   # -- image repository
   repository: louislam/uptime-kuma
   # -- image tag
-  tag: "1.11.1"
+  # @default -- chart.appVersion
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

- Update the version of uptime-kuma to 1.13.1
- Update the chart version to 1.2.0

**Benefits**

New version of application that contains multiple security fixes (in v1.11.4 and v1.12.1)

**Possible drawbacks**

New version might not be stable.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [-] ~~Variables have been documented in the `values.yaml` file.~~