### PR TITLE
[paperless] Updated values.yaml to add user/pass env

### DIFF
--- a/charts/stable/paperless/Chart.yaml
+++ b/charts/stable/paperless/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.0
 description: Paperless - Index and archive all of your scanned paper documents
 name: paperless
-version: 8.6.0
+version: 8.6.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - paperless
@@ -30,6 +30,8 @@ dependencies:
     condition: redis.enabled
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: Added admin username and password env variables to values.yaml
     - kind: changed
       description: Upgraded `postgresql` chart dependency to version `10.16.2`.
     - kind: changed

--- a/charts/stable/paperless/Chart.yaml
+++ b/charts/stable/paperless/Chart.yaml
@@ -32,7 +32,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Added admin username and password env variables to values.yaml
-    - kind: changed
-      description: Upgraded `postgresql` chart dependency to version `10.16.2`.
-    - kind: changed
-      description: Upgraded `redis` chart dependency to version `15.7.6`.

--- a/charts/stable/paperless/values.yaml
+++ b/charts/stable/paperless/values.yaml
@@ -32,6 +32,9 @@ env:
   PAPERLESS_DBHOST:
   # -- Port to use
   PAPERLESS_PORT: 8000
+  # -- Username and password for the root user
+  # PAPERLESS_ADMIN_USER: admin
+  # PAPERLESS_ADMIN_PASSWORD: admin
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml

--- a/charts/stable/paperless/values.yaml
+++ b/charts/stable/paperless/values.yaml
@@ -32,8 +32,9 @@ env:
   PAPERLESS_DBHOST:
   # -- Port to use
   PAPERLESS_PORT: 8000
-  # -- Username and password for the root user
+  # -- Username for the root user
   # PAPERLESS_ADMIN_USER: admin
+  # -- Password for the root user
   # PAPERLESS_ADMIN_PASSWORD: admin
 
 # -- Configures service settings for the chart.


### PR DESCRIPTION
**Description of the change**

Updated values.yaml to add user/pass environment variables. Took me a long time to find these variables, they really should be here for other people to find.

**Benefits**

Clear configuration docs

**Possible drawbacks**

none I can think of

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
