### PR TITLE
[miniflux] Upgrade miniflux to version 2.0.36

### DIFF
--- a/charts/stable/miniflux/Chart.yaml
+++ b/charts/stable/miniflux/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 2.0.35
+appVersion: 2.0.36
 description: Miniflux is a minimalist and opinionated feed reader.
 name: miniflux
-version: 4.6.0
+version: 4.6.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - miniflux
@@ -26,4 +26,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded `postgresql` chart dependency to version `10.16.2`.
+      description: Upgraded miniflux to version 2.0.36.

--- a/charts/stable/miniflux/README.md
+++ b/charts/stable/miniflux/README.md
@@ -1,6 +1,6 @@
 # miniflux
 
-![Version: 4.6.0](https://img.shields.io/badge/Version-4.6.0-informational?style=flat-square) ![AppVersion: 2.0.35](https://img.shields.io/badge/AppVersion-2.0.35-informational?style=flat-square)
+![Version: 4.6.1](https://img.shields.io/badge/Version-4.6.1-informational?style=flat-square) ![AppVersion: 2.0.36](https://img.shields.io/badge/AppVersion-2.0.36-informational?style=flat-square)
 
 Miniflux is a minimalist and opinionated feed reader.
 
@@ -85,7 +85,7 @@ N/A
 | env.TZ | string | `"UTC"` | Set the container timezone. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"miniflux/miniflux"` |  |
-| image.tag | string | `"2.0.35"` |  |
+| image.tag | string | `"2.0.36"` |  |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | postgresql | object | Enabled (see values.yaml for more details) | Enable and configure postgresql database subchart under this key.    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
 | probes | object | See values.yaml | Configures the probes for the main Pod. |
@@ -93,7 +93,7 @@ N/A
 
 ## Changelog
 
-### Version 4.6.0
+### Version 4.6.1
 
 #### Added
 
@@ -101,7 +101,7 @@ N/A
 
 #### Changed
 
-* Upgraded `postgresql` chart dependency to version `10.16.2`.
+* Upgraded miniflux to version 2.0.36.
 
 #### Fixed
 

--- a/charts/stable/miniflux/values.yaml
+++ b/charts/stable/miniflux/values.yaml
@@ -7,7 +7,8 @@
 
 image:
   repository: miniflux/miniflux
-  tag: 2.0.35
+  # @default -- chart.appVersion
+  tag:
   pullPolicy: IfNotPresent
 
 # -- environment variables. See [miniflux docs](https://miniflux.app/docs/configuration.html) for more details.


### PR DESCRIPTION
**Description of the change**

Upgrade miniflux to version 2.0.36.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
