### PR TITLE
[tdarr] Pass-through mountPath value

### DIFF
--- a/charts/stable/tdarr/Chart.yaml
+++ b/charts/stable/tdarr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.00.10
 description: Tdarr is a self hosted web-app for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers etc.
 name: tdarr
-version: 4.4.0
+version: 4.4.1
 keywords:
   - transcoding
   - remux
@@ -23,5 +23,5 @@ dependencies:
     version: 4.3.0
 annotations:
   artifacthub.io/changes: |
-    - kind: add
-      description: Explicitly Add PUID and PGID environment variables for server and node.
+    - kind: change
+      description: Ensure node mountPath matches server for media volume

--- a/charts/stable/tdarr/Chart.yaml
+++ b/charts/stable/tdarr/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.00.10
+appVersion: 2.00.18
 description: Tdarr is a self hosted web-app for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers etc.
 name: tdarr
 version: 4.4.1
@@ -25,3 +25,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: change
       description: Ensure node mountPath matches server for media volume
+    - kind: change
+      description: Update appVersion to 2.00.18

--- a/charts/stable/tdarr/README.md
+++ b/charts/stable/tdarr/README.md
@@ -105,6 +105,7 @@ N/A
 ### Version 4.4.1
 
 #### Added
+
 N/A
 
 #### Changed

--- a/charts/stable/tdarr/README.md
+++ b/charts/stable/tdarr/README.md
@@ -1,6 +1,6 @@
 # tdarr
 
-![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square) ![AppVersion: 2.00.10](https://img.shields.io/badge/AppVersion-2.00.10-informational?style=flat-square)
+![Version: 4.4.1](https://img.shields.io/badge/Version-4.4.1-informational?style=flat-square) ![AppVersion: 2.00.10](https://img.shields.io/badge/AppVersion-2.00.10-informational?style=flat-square)
 
 Tdarr is a self hosted web-app for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers etc.
 
@@ -101,6 +101,19 @@ N/A
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog
+
+### Version 4.4.1
+
+#### Added
+N/A
+
+#### Changed
+
+node mountPath for media now matches server
+
+#### Fixed
+
+N/A
 
 ### Version 4.4.0
 

--- a/charts/stable/tdarr/templates/common.yaml
+++ b/charts/stable/tdarr/templates/common.yaml
@@ -30,7 +30,7 @@ additionalContainers:
       {{ end }}
       {{ if .Values.persistence.media.enabled }}
       - name: media
-        mountPath: /media
+        mountPath: {{ .Values.persistence.media.mountPath }}
       {{ end }}
       {{ if .Values.persistence.shared.enabled }}
       - name: shared

--- a/charts/stable/tdarr/values.yaml
+++ b/charts/stable/tdarr/values.yaml
@@ -9,7 +9,8 @@ image:
   # -- image repository
   repository: haveagitgat/tdarr
   # -- image tag
-  tag: 2.00.10
+  # @default -- chart.appVersion
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

Simply changed the mountPath to a parameterized value so it lines up for media

**Benefits**

tdarr node mountPath will match the server and reduce the need for manual config outside yaml

**Possible drawbacks**

If I didn't do it right, it'll break something

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

I was trying to parameterize all additional volumeMounts as well for each key in persistence besides the already accounted for ones, but my inexperience with go templates was slowing me down so I figured this is a good enough start

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
