### PR TITLE
[audiobookshelf] Bump app version and change default image repo to ghcr

### DIFF
--- a/charts/stable/audiobookshelf/Chart.yaml
+++ b/charts/stable/audiobookshelf/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "1.6.69"
+appVersion: "2.0.3"
 description: Self-hosted audiobook server for managing and playing your audiobooks
 name: audiobookshelf
-version: 1.0.0
+version: 1.0.1
 kubeVersion: ">= 1.16.0-0"
 keywords:
   - audiobookshelf
@@ -21,5 +21,7 @@ dependencies:
     version: 4.3.0
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial version
+    - kind: changed
+      description: Updated Audiobookshelf image to latest
+    - kind: changed
+      description: Changed default image repository to ghcr

--- a/charts/stable/audiobookshelf/README.md
+++ b/charts/stable/audiobookshelf/README.md
@@ -1,6 +1,6 @@
 # audiobookshelf
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.6.69](https://img.shields.io/badge/AppVersion-1.6.69-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 2.0.3](https://img.shields.io/badge/AppVersion-2.0.3-informational?style=flat-square)
 
 Self-hosted audiobook server for managing and playing your audiobooks
 
@@ -85,6 +85,18 @@ N/A
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog
+
+### Version 1.0.1
+
+#### Added
+
+#### Changed
+
+* Updated container image to latest
+* Changed image repository to ghcr
+
+#### Fixed
+
 
 ### Version 1.0.0
 

--- a/charts/stable/audiobookshelf/values.yaml
+++ b/charts/stable/audiobookshelf/values.yaml
@@ -7,7 +7,7 @@
 
 image:
   # -- image repository
-  repository: advplyr/audiobookshelf
+  repository: ghcr.io/advplyr/audiobookshelf
   # -- image tag
   # @default -- chart.appVersion
   tag:


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Updated the app version to the latest 2x release and changed default image repository to ghcr as the author has started pushing images there.

**Benefits**

* No more dockerhub pulls.
* Latest app version 2x



**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
