### PR TITLE
[pod-gateway] Change default openvpn port to 1194

### DIFF
--- a/charts/stable/pod-gateway/Chart.yaml
+++ b/charts/stable/pod-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.6
 description: Admision controller to change the default gateway and DNS server of PODs
 name: pod-gateway
-version: 5.2.1
+version: 5.3.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - pod-gateway
@@ -21,4 +21,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Added option to override mutated pod's DNSPolicy.
+      description: Change default port for VPN to 1194

--- a/charts/stable/pod-gateway/README.md
+++ b/charts/stable/pod-gateway/README.md
@@ -1,6 +1,6 @@
 # pod-gateway
 
-![Version: 5.2.1](https://img.shields.io/badge/Version-5.2.1-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
+![Version: 5.3.0](https://img.shields.io/badge/Version-5.3.0-informational?style=flat-square) ![AppVersion: 1.2.6](https://img.shields.io/badge/AppVersion-1.2.6-informational?style=flat-square)
 
 Admision controller to change the default gateway and DNS server of PODs
 
@@ -101,9 +101,9 @@ certificates. It does not install it as dependency to avoid conflicts.
 |-----|------|---------|-------------|
 | DNS | string | `"172.16.0.1"` | IP address of the DNS server within the vxlan tunnel. All mutated PODs will get this as their DNS server. It must match VXLAN_GATEWAY_IP in settings.sh |
 | DNSPolicy | string | `"None"` | The DNSPolicy to apply to the POD. Only when set to "None" will the DNS value above apply. To avoid altering POD DNS (i.e., to allow initContainers to use DNS before the the VXLAN is up), set to "ClusterFirst" |
-| addons | object | `{"vpn":{"enabled":false,"networkPolicy":{"egress":[{"ports":[{"port":443,"protocol":"UDP"}],"to":[{"ipBlock":{"cidr":"0.0.0.0/0"}}]},{"to":[{"ipBlock":{"cidr":"10.0.0.0/8"}}]}],"enabled":true},"type":"openvpn"}}` |    IP: 10   ports:   - type: udp     port: 18289   - type: tcp     port: 18289 |
+| addons | object | `{"vpn":{"enabled":false,"networkPolicy":{"egress":[{"ports":[{"port":1194,"protocol":"UDP"}],"to":[{"ipBlock":{"cidr":"0.0.0.0/0"}}]},{"to":[{"ipBlock":{"cidr":"10.0.0.0/8"}}]}],"enabled":true},"type":"openvpn"}}` |    IP: 10   ports:   - type: udp     port: 18289   - type: tcp     port: 18289 |
 | addons.vpn.enabled | bool | `false` | Enable the VPN if you want to route through a VPN. You might also want to set VPN_BLOCK_OTHER_TRAFFIC to true for extra safeness in case the VPN does connect |
-| addons.vpn.networkPolicy | object | `{"egress":[{"ports":[{"port":443,"protocol":"UDP"}],"to":[{"ipBlock":{"cidr":"0.0.0.0/0"}}]},{"to":[{"ipBlock":{"cidr":"10.0.0.0/8"}}]}],"enabled":true}` |  wireguard: env: configFileSecret: openvpn |
+| addons.vpn.networkPolicy | object | `{"egress":[{"ports":[{"port":1194,"protocol":"UDP"}],"to":[{"ipBlock":{"cidr":"0.0.0.0/0"}}]},{"to":[{"ipBlock":{"cidr":"10.0.0.0/8"}}]}],"enabled":true}` |  wireguard: env: configFileSecret: openvpn |
 | clusterName | string | `"cluster.local"` | cluster name used to derive the gateway full name |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy of the gateway and inserted helper cotainers |
 | image.repository | string | `"ghcr.io/k8s-at-home/pod-gateway"` | image repository of the gateway and inserted helper containers |
@@ -115,7 +115,7 @@ certificates. It does not install it as dependency to avoid conflicts.
 | settings.VPN_BLOCK_OTHER_TRAFFIC | bool | `false` | Prevent non VPN traffic to leave the gateway |
 | settings.VPN_INTERFACE | string | `"tun0"` | If using a VPN, interface name created by it |
 | settings.VPN_LOCAL_CIDRS | string | `"10.0.0.0/8 192.168.0.0/16"` | Traffic to these IPs will be send through the K8S gateway |
-| settings.VPN_TRAFFIC_PORT | int | `443` | If VPN_BLOCK_OTHER_TRAFFIC is true, allow VPN traffic over this port |
+| settings.VPN_TRAFFIC_PORT | int | `1194` | If VPN_BLOCK_OTHER_TRAFFIC is true, allow VPN traffic over this port |
 | settings.VXLAN_GATEWAY_FIRST_DYNAMIC_IP | int | `20` | Keep a range of IPs for static assignment in nat.conf |
 | settings.VXLAN_ID | int | `42` | Vxlan ID to use |
 | settings.VXLAN_IP_NETWORK | string | `"172.16.0"` | VXLAN needs an /24 IP range not conflicting with K8S and local IP ranges |
@@ -132,7 +132,7 @@ certificates. It does not install it as dependency to avoid conflicts.
 
 ## Changelog
 
-### Version 5.2.1
+### Version 5.3.0
 
 #### Added
 
@@ -140,7 +140,7 @@ N/A
 
 #### Changed
 
-* Added option to override mutated pod's DNSPolicy.
+* Change default port for VPN to 1194
 
 #### Fixed
 

--- a/charts/stable/pod-gateway/values.yaml
+++ b/charts/stable/pod-gateway/values.yaml
@@ -52,7 +52,7 @@ settings:
   # -- Prevent non VPN traffic to leave the gateway
   VPN_BLOCK_OTHER_TRAFFIC: false
   # -- If VPN_BLOCK_OTHER_TRAFFIC is true, allow VPN traffic over this port
-  VPN_TRAFFIC_PORT: 443
+  VPN_TRAFFIC_PORT: 1194
   # -- Traffic to these IPs will be send through the K8S gateway
   VPN_LOCAL_CIDRS: "10.0.0.0/8 192.168.0.0/16"
 
@@ -91,7 +91,7 @@ addons:
               cidr: 0.0.0.0/0
           ports:
           # VPN traffic (default OpenVPN)
-          - port: 443
+          - port: 1194
             protocol: UDP
         # Allow any traffic within k8s
         - to:


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Change default openvpn port to 1194 as this is the default for UDP.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Be consistent: use matching default port for UDP.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
Changing defaults might affect some users.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1525

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
