### PR TITLE
[Photoprism] update image to 220302-impish

### DIFF
--- a/charts/stable/photoprism/Chart.yaml
+++ b/charts/stable/photoprism/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: "20220121"
+appVersion: "220302-impish"
 description: PhotoPrism® is a server-based application for browsing, organizing and sharing your personal photo collection
 name: photoprism
-version: 6.6.1
+version: 6.6.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - photos
@@ -29,6 +29,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.1
-    - kind: changed
-      description: Upgraded `mariadb` chart dependency to version 10.5.1
+      description: Updated photoprism to version 220302

--- a/charts/stable/photoprism/README.md
+++ b/charts/stable/photoprism/README.md
@@ -1,6 +1,6 @@
 # photoprism
 
-![Version: 6.6.1](https://img.shields.io/badge/Version-6.6.1-informational?style=flat-square) ![AppVersion: 20220121](https://img.shields.io/badge/AppVersion-20220121-informational?style=flat-square)
+![Version: 6.6.2](https://img.shields.io/badge/Version-6.6.2-informational?style=flat-square) ![AppVersion: 220302](https://img.shields.io/badge/AppVersion-220302-informational?style=flat-square)
 
 PhotoPrism® is a server-based application for browsing, organizing and sharing your personal photo collection
 


### PR DESCRIPTION
Update Photoprim image to `220302-impish`. There is no `220302` tag and the previous version `20220121` was also based on `21.10 (Impish Indri)` so this is just a simple version bump.