### PR TITLE
[onedrive] Update docker image to v2.4.17

### DIFF
--- a/charts/stable/onedrive/Chart.yaml
+++ b/charts/stable/onedrive/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: v2.4.14
+appVersion: v2.4.17
 description: A free Microsoft OneDrive Client which supports OneDrive Personal, OneDrive for Business, OneDrive for Office365, and SharePoint
 name: onedrive
-version: 2.3.2
+version: 2.3.3
 kubeVersion: ">=1.16.0-0"
 keywords:
   - onedrive
@@ -22,4 +22,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+      description: Upgraded docker / app image to v2.4.17

--- a/charts/stable/onedrive/values.yaml
+++ b/charts/stable/onedrive/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/wrmilling/onedrive-docker
   # -- image tag
-  tag: v2.0.5
+  tag: v2.4.17
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/onedrive/values.yaml
+++ b/charts/stable/onedrive/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/wrmilling/onedrive-docker
   # -- image tag
-  tag: v2.4.17
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

Bumping docker image version for OneDrive to v2.4.17. Docker image version now matches application version. 

**Benefits**

Latest code from upstream.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
