### PR TITLE
[blocky] - Add redis

### DIFF
--- a/charts/stable/blocky/Chart.yaml
+++ b/charts/stable/blocky/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 appVersion: v0.18
 description: DNS proxy as ad-blocker for local network
 name: blocky
-version: 10.2.3
-kubeVersion: ">=1.16.0-0"
+version: 10.3.0
+kubeVersion: ">=1.19.0-0"
 keywords:
   - blocky
   - adblock
@@ -20,7 +20,15 @@ dependencies:
   - name: common
     repository: https://library-charts.k8s-at-home.com
     version: 4.4.2
+  - name: redis
+    repository: https://charts.bitnami.com/bitnami
+    version: 16.9.1
+    condition: redis.enabled
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: Upgraded `common` chart dependency to version 4.4.2
+    - kind: added
+      description: Added `redis` dependency for use with multiple blocky replicas
+    - kind: changed
+      description: Added chart tests, modified default values and added default ingress for blocky api

--- a/charts/stable/blocky/README.md
+++ b/charts/stable/blocky/README.md
@@ -1,6 +1,6 @@
 # blocky
 
-![Version: 10.2.3](https://img.shields.io/badge/Version-10.2.3-informational?style=flat-square) ![AppVersion: v0.18](https://img.shields.io/badge/AppVersion-v0.18-informational?style=flat-square)
+![Version: 10.3.0](https://img.shields.io/badge/Version-10.3.0-informational?style=flat-square) ![AppVersion: v0.18](https://img.shields.io/badge/AppVersion-v0.18-informational?style=flat-square)
 
 DNS proxy as ad-blocker for local network
 
@@ -12,12 +12,13 @@ DNS proxy as ad-blocker for local network
 
 ## Requirements
 
-Kubernetes: `>=1.16.0-0`
+Kubernetes: `>=1.19.0-0`
 
 ## Dependencies
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://charts.bitnami.com/bitnami | redis | 16.9.1 |
 | https://library-charts.k8s-at-home.com | common | 4.4.2 |
 
 ## TL;DR
@@ -67,6 +68,15 @@ helm install blocky k8s-at-home/blocky -f values.yaml
 
 ## Custom configuration
 
+### [10.3.0]
+
+### Added
+
+- Add dependency for redis database as the application now supports it. [Redis - Blocky](https://0xerr0r.github.io/blocky/configuration/#redis)
+- The redis dependency increases the minimum latest version of k8s to version 1.19+
+
+### [10.2.3]
+
 N/A
 
 ## Values
@@ -75,7 +85,7 @@ N/A
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config | string | see URL to default config | Full list of options https://github.com/0xERR0R/blocky/blob/v0.17/docs/config.yml |
+| config | string | see URL to default config | Full list of options https://github.com/0xERR0R/blocky/blob/v0.18/docs/config.yml |
 | controller.replicas | int | `1` | (int) Number of pods to load balance between |
 | controller.strategy | string | `"RollingUpdate"` | Set the controller upgrade strategy |
 | env | object | See below | environment variables. See [image docs](https://0xerr0r.github.io/blocky/installation/#run-with-docker) for more details. |
@@ -83,6 +93,7 @@ N/A
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"ghcr.io/0xerr0r/blocky"` | image repository |
 | image.tag | string | chart.appVersion | image tag |
+| ingress | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | metrics.enabled | bool | See values.yaml | Enable and configure a Prometheus serviceMonitor for the chart under this key. |
 | metrics.prometheusRule | object | See values.yaml | Enable and configure Prometheus Rules for the chart under this key. |
 | metrics.prometheusRule.rules | list | See prometheusrules.yaml | Configure additionial rules for the chart under this key. |
@@ -93,19 +104,21 @@ N/A
 | metrics.serviceMonitor.scrapeTimeout | string | `"10s"` | Timeout after which the scrape is ended |
 | metrics.serviceMonitor.targetLabels | list | `[]` | TargetLabels transfers labels from the Kubernetes `Service`` onto the created metrics. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
+| redis | object | See values.yaml | Enable and configure redis subchart under this key. Useful if you're running more than one replica of blocky dns. For more options see [redis chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/redis) |
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog
 
-### Version 10.2.3
+### Version 10.3.0
 
 #### Added
 
-N/A
+* Added `redis` dependency for use with multiple blocky replicas
 
 #### Changed
 
 * Upgraded `common` chart dependency to version 4.4.2
+* Added chart tests, modified default values and added default ingress for blocky api
 
 #### Fixed
 

--- a/charts/stable/blocky/README_CONFIG.md.gotmpl
+++ b/charts/stable/blocky/README_CONFIG.md.gotmpl
@@ -5,5 +5,11 @@
 {{- define "custom.custom.configuration" -}}
 {{ template "custom.custom.configuration.header" . }}
 
-N/A
+### [10.3.0]
+
+### Added
+
+- Add dependency for redis database as the application now supports it. [Redis - Blocky](https://0xerr0r.github.io/blocky/configuration/#redis)
+- The redis dependency increases the minimum latest version of k8s to version 1.19+
+
 {{- end -}}

--- a/charts/stable/blocky/ci/ct-values.yaml
+++ b/charts/stable/blocky/ci/ct-values.yaml
@@ -1,0 +1,35 @@
+config: |
+  upstream:
+    default:
+      - tcp-tls:1.1.1.1:853
+      - tcp-tls:8.8.8.8:853
+
+  bootstrapDns: tcp+udp:1.1.1.1
+  redis:
+    address: blocky-redis-headless:6379
+    database: 2
+    required: true
+    connectionAttempts: 10
+    connectionCooldown: 3s
+
+service:
+  dns-udp:
+    enabled: true
+    type: NodePort
+    externalTrafficPolicy: Local
+    ports:
+      dns-udp:
+        enabled: true
+        port: 53
+        protocol: UDP
+        targetPort: 53
+
+redis:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: false
+  master:
+    persistence:
+      enabled: false
+  fullnameOverride: blocky-redis

--- a/charts/stable/blocky/values.yaml
+++ b/charts/stable/blocky/values.yaml
@@ -30,6 +30,7 @@ env:
 # @default -- See values.yaml
 service:
   main:
+    enabled: false
     ports:
       http:
         port: 4000
@@ -53,6 +54,19 @@ service:
         port: 53
         protocol: UDP
         targetPort: 53
+
+# -- Enable and configure ingress settings for the chart under this key.
+# @default -- See values.yaml
+ingress:
+  main:
+    enabled: false
+    hosts:
+      - host: blocky-api.local
+        paths:
+        - path: /
+          pathType: Prefix
+          service:
+            port: 4000
 
 # -- Configure persistence settings for the chart under this key.
 # @default -- See values.yaml
@@ -97,7 +111,16 @@ metrics:
       #   labels:
       #     severity: critical
 
-# -- Full list of options https://github.com/0xERR0R/blocky/blob/v0.17/docs/config.yml
+# -- Enable and configure redis subchart under this key.
+# Useful if you're running more than one replica of blocky dns.
+# For more options see [redis chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/redis)
+# @default -- See values.yaml
+redis:
+  enabled: false
+  # auth:
+  #   enabled: false
+
+# -- Full list of options https://github.com/0xERR0R/blocky/blob/v0.18/docs/config.yml
 # @default -- see URL to default config
 config: |
   upstream:
@@ -262,7 +285,7 @@ config: |
   #certFile: server.crt
   #keyFile: server.key
   # optional: use this DNS server to resolve blacklist urls and upstream DNS servers. Useful if no DNS resolver is configured and blocky needs to resolve a host name. Format net:IP:port, net must be udp or tcp
-  bootstrapDns: tcp:1.1.1.1
+  bootstrapDns: tcp+udp:1.1.1.1
   # optional: Drop all AAAA query if set to true. Default: false
   disableIPv6: false
   # optional: Log level (one from debug, info, warn, error). Default: info
@@ -273,3 +296,10 @@ config: |
   logTimestamp: true
   # optional: obfuscate log output (replace all alphanumeric characters with *) for user sensitive data like request domains or responses to increase privacy. Default: false
   logPrivacy: false
+  #redis:
+    #address: blocky-redis-headless:6379
+    #password: passwd
+    #database: 2
+    #required: true
+    #connectionAttempts: 10
+    #connectionCooldown: 3s


### PR DESCRIPTION
**Description of the change**

This updates the helm chart to support redis.

**Benefits**

It has been introduced in version 0.18 of blocky and is beneficial when using multiple replicas of blocky as the dns caches are synchronized and so are the blocky states.

**Possible drawbacks**

The redis chart bumps the minimum required version of k8s to 1.19+.

The default service would not be created in this version as I have put enabled to false.
This is only required if someone needs access to the blocky api endpoint.

**Applicable issues**

N/A
- fixes #

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
