### PR TITLE
[vikunja] Fix subpath in configmap to match persistence value

### DIFF
--- a/charts/stable/vikunja/Chart.yaml
+++ b/charts/stable/vikunja/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 0.17.0
 description: The to-do app to organize your life
 name: vikunja
-version: 5.5.2
+version: 5.5.3
 keywords:
   - vikunja
   - to-do
@@ -31,5 +31,5 @@ dependencies:
     condition: postgresql.enabled
 annotations:
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+    - kind: fixed
+      description: Fix subpath in configmap to match persistence value

--- a/charts/stable/vikunja/templates/configmap.yaml
+++ b/charts/stable/vikunja/templates/configmap.yaml
@@ -41,5 +41,5 @@ data:
             reverse_proxy localhost:80
         }
     }
-  Vikunja.yml: |-
+  Vikunja.yaml: |-
 {{ .Values.vikunja.config | indent 4 }}

--- a/charts/stable/vikunja/values.yaml
+++ b/charts/stable/vikunja/values.yaml
@@ -65,7 +65,7 @@ additionalContainers:
     volumeMounts:
       - name: vikunja-config
         mountPath: /etc/vikunja/config.yml
-        subPath: Vikunja.yml
+        subPath: Vikunja.yaml
       # - name: files
       #   mountPath: /app/vikunja/files
 


### PR DESCRIPTION
**Description of the change**

The value defined in the [template](https://github.com/k8s-at-home/charts/blob/master/charts/stable/vikunja/templates/configmap.yaml#L44) does not match the value in the [persistence](https://github.com/k8s-at-home/charts/blob/master/charts/stable/vikunja/templates/common.yaml#L18) so the mount doesn't work as expected.

This PR makes them match!

**Benefits**

Makes Vikunja Helm chart work as expected. 👍 

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.