### PR TITLE
[paperless] Bump to version 1.7.1

### DIFF
--- a/charts/stable/paperless/Chart.yaml
+++ b/charts/stable/paperless/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: ngx-1.7.0
+appVersion: 1.7.1
 description: Paperless - Index and archive all of your scanned paper documents
 name: paperless
-version: 8.8.2
+version: 8.8.3
 kubeVersion: ">=1.16.0-0"
 keywords:
   - paperless
@@ -32,4 +32,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+      description: Updated image to v1.7.1.

--- a/charts/stable/paperless/README.md
+++ b/charts/stable/paperless/README.md
@@ -1,6 +1,6 @@
 # paperless
 
-![Version: 8.8.2](https://img.shields.io/badge/Version-8.8.2-informational?style=flat-square) ![AppVersion: ngx-1.7.0](https://img.shields.io/badge/AppVersion-ngx--1.7.0-informational?style=flat-square)
+![Version: 8.8.3](https://img.shields.io/badge/Version-8.8.3-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
 
 Paperless - Index and archive all of your scanned paper documents
 
@@ -96,7 +96,7 @@ N/A
 
 ## Changelog
 
-### Version 8.8.2
+### Version 8.8.3
 
 #### Added
 
@@ -104,7 +104,7 @@ N/A
 
 #### Changed
 
-* Upgraded `common` chart dependency to version 4.4.2
+* Updated image to v1.7.1.
 
 #### Fixed
 


### PR DESCRIPTION
Signed-off-by: Simon Caron <simon.caron.8@gmail.com>

**Description of the change**

Bump version to 1.7.1

**Benefits**

Bugfixes

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
