### PR TITLE
[dendrite] Per-component database settings

### DIFF
--- a/charts/incubator/dendrite/Chart.yaml
+++ b/charts/incubator/dendrite/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: v0.8.1
+appVersion: v0.8.7
 description: Dendrite Matrix Homeserver
 name: dendrite
-version: 4.3.0
+version: 5.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - dendrite
@@ -83,3 +83,9 @@ annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: Enable database configuration on a per-API (component) level
+    - kind: changed
+      description: Bump dendrite to v0.8.7
+    - kind: changed
+      description: Set client api registration to disabled by default
+    - kind: fixed
+      description: Fix syncapi version pinning

--- a/charts/incubator/dendrite/Chart.yaml
+++ b/charts/incubator/dendrite/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v0.8.1
 description: Dendrite Matrix Homeserver
 name: dendrite
-version: 4.2.2
+version: 4.3.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - dendrite
@@ -82,20 +82,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2 for alias 'clientapi'
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2 for alias 'mediaapi'
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2 for alias 'syncapi'
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2 for alias 'roomserver'
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2 for alias 'federationapi'
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2 for alias 'keyserver'
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2 for alias 'userapi'
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2 for alias 'appserviceapi'
+      description: Enable database configuration on a per-API (component) level

--- a/charts/incubator/dendrite/templates/dendrite-config.yaml
+++ b/charts/incubator/dendrite/templates/dendrite-config.yaml
@@ -22,6 +22,9 @@ stringData:
       presence:
         enable_inbound: {{ default false .Values.dendrite.global.presence.enable_inbound}}
         enable_outbound: {{ default false .Values.dendrite.global.presence.enable_outbound }}
+      report_stats:
+        enabled: {{ default false .Values.dendrite.report_stats.enabled }}
+        endpoint: {{ default "https://matrix.org/report-usage-stats/push" .Values.dendrite.report_stats.endpoint }}
       server_notices:
         enabled: {{ default false .Values.dendrite.global.server_notices.enabled }}
         local_part: {{ default "_server" .Values.dendrite.global.server_notices.local_part | quote }}
@@ -63,7 +66,7 @@ stringData:
         connect: http://{{ include "common.names.fullname" . }}-clientapi:{{ .Values.clientapi.service.main.ports.internal.port }}
       external_api:
         listen: http://0.0.0.0:{{ .Values.clientapi.service.main.ports.external.port }}
-      registration_disabled: {{ default false .Values.clientapi.config.registration_disabled }}
+      registration_disabled: {{ default true .Values.clientapi.config.registration_disabled }}
       registration_shared_secret: {{ default "" .Values.clientapi.config.registration_shared_secret | quote }}
       enable_registration_captcha: {{ default false .Values.clientapi.config.captcha.enabled }}
       recaptcha_public_key: {{ default "" .Values.clientapi.config.captcha.recaptcha_public_key | quote }}
@@ -157,6 +160,7 @@ stringData:
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.userapi.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.userapi.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.userapi.database.conn_max_lifetime }}
+      bcrypt_cost: {{ default 10 .Values.userapi.config.bcrypt_cost }}
     tracing:
       enabled: {{ .Values.dendrite.tracing.enabled }}
       jaeger: {{- toYaml .Values.dendrite.tracing.jaeger | nindent 8 }}

--- a/charts/incubator/dendrite/templates/dendrite-config.yaml
+++ b/charts/incubator/dendrite/templates/dendrite-config.yaml
@@ -52,10 +52,10 @@ stringData:
         listen: http://0.0.0.0:{{ .Values.appserviceapi.service.main.ports.internal.port }}
         connect: http://{{ include "common.names.fullname" . }}-appserviceapi:{{ .Values.appserviceapi.service.main.ports.internal.port }}
       database:
-        connection_string: {{ $connectionString }}dendrite_appservice?sslmode=disable
-        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
-        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
-        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
+        connection_string: {{ default (print $connectionString "dendrite_appservice?sslmode=disable") .Values.appserviceapi.database.connection_string }}
+        max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.appserviceapi.database.max_open_conns }}
+        max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.appserviceapi.database.max_idle_conns }}
+        conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.appserviceapi.database.conn_max_lifetime }}
       config_files: {{- toYaml .Values.appserviceapi.config.config_files | nindent 8 }}
     client_api:
       internal_api:
@@ -82,10 +82,10 @@ stringData:
       external_api:
         listen: http://0.0.0.0:8072
       database:
-        connection_string: {{ $connectionString }}dendrite_federationapi?sslmode=disable
-        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
-        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
-        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
+        connection_string: {{ default (print $connectionString "dendrite_federationapi?sslmode=disable") .Values.federationapi.database.connection_string }}
+        max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.federationapi.database.max_open_conns }}
+        max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.federationapi.database.max_idle_conns }}
+        conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.federationapi.database.conn_max_lifetime }}
       federation_certificates: {{- toYaml .Values.federationapi.config.federation_certificates | nindent 8 }}
       send_max_retries: {{ default 16 .Values.federationapi.config.send_max_retries }}
       disable_tls_validation: {{ default false .Values.federationapi.config.disable_tls_validation }}
@@ -101,10 +101,10 @@ stringData:
         listen: http://0.0.0.0:7779
         connect: http://{{ include "common.names.fullname" . }}-keyserver:7779
       database:
-        connection_string: {{ $connectionString }}dendrite_keyserver?sslmode=disable
-        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
-        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
-        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
+        connection_string: {{ default (print $connectionString "dendrite_keyserver?sslmode=disable") .Values.keyserver.database.connection_string }}
+        max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.keyserver.database.max_open_conns }}
+        max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.keyserver.database.max_idle_conns }}
+        conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.keyserver.database.conn_max_lifetime }}
     media_api:
       internal_api:
         listen: http://0.0.0.0:7774
@@ -112,10 +112,10 @@ stringData:
       external_api:
         listen: http://0.0.0.0:8074
       database:
-        connection_string: {{ $connectionString }}dendrite_mediaapi?sslmode=disable
-        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
-        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
-        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
+        connection_string: {{ default (print $connectionString "dendrite_mediaapi?sslmode=disable") .Values.mediaapi.database.connection_string }}
+        max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.mediaapi.database.max_open_conns }}
+        max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.mediaapi.database.max_idle_conns }}
+        conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.mediaapi.database.conn_max_lifetime }}
       base_path: {{ default "/var/dendrite/media" .Values.mediaapi.config.base_path | quote }}
       max_file_size_bytes: {{ int ( default 10485760 .Values.mediaapi.config.max_file_size_bytes ) }}
       dynamic_thumbnails: {{ default false .Values.mediaapi.config.dynamic_thumbnails }}
@@ -124,19 +124,19 @@ stringData:
     mscs:
       mscs: {{ .Values.dendrite.global.mscs | toYaml | nindent 8 }}
       database:
-        connection_string: {{ $connectionString }}dendrite_mscs?sslmode=disable
-        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
-        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
-        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
+        connection_string: {{ default (print $connectionString "dendrite_mscs?sslmode=disable") .Values.mscs.database.connection_string }}
+        max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.mscs.database.max_open_conns }}
+        max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.mscs.database.max_idle_conns }}
+        conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.mscs.database.conn_max_lifetime }}
     room_server:
       internal_api:
         listen: http://0.0.0.0:7770
         connect: http://{{ include "common.names.fullname" . }}-roomserver:7770
       database:
-        connection_string: {{ $connectionString }}dendrite_roomserver?sslmode=disable
-        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
-        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
-        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
+        connection_string: {{ default (print $connectionString "dendrite_roomserver?sslmode=disable") .Values.roomserver.database.connection_string }}
+        max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.roomserver.database.max_open_conns }}
+        max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.roomserver.database.max_idle_conns }}
+        conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.roomserver.database.conn_max_lifetime }}
     sync_api:
       internal_api:
         listen: http://0.0.0.0:7773
@@ -144,19 +144,19 @@ stringData:
       external_api:
           listen: http://0.0.0.0:8073
       database:
-        connection_string: {{ $connectionString }}dendrite_syncapi?sslmode=disable
-        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
-        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
-        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
+        connection_string: {{ default (print $connectionString "dendrite_syncapi?sslmode=disable") .Values.syncapi.database.connection_string }}
+        max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.syncapi.database.max_open_conns }}
+        max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.syncapi.database.max_idle_conns }}
+        conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.syncapi.database.conn_max_lifetime }}
     user_api:
       internal_api:
         listen: http://0.0.0.0:7781
         connect: http://{{ include "common.names.fullname" . }}-userapi:7781
       account_database:
-        connection_string: {{ $connectionString }}dendrite_userapi_accounts?sslmode=disable
-        max_open_conns: {{ .Values.dendrite.database.max_open_conns }}
-        max_idle_conns: {{ .Values.dendrite.database.max_idle_conns }}
-        conn_max_lifetime: {{ .Values.dendrite.database.conn_max_lifetime }}
+        connection_string: {{ default (print $connectionString "dendrite_userapi_accounts?sslmode=disable") .Values.userapi.database.connection_string }}
+        max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.userapi.database.max_open_conns }}
+        max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.userapi.database.max_idle_conns }}
+        conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.userapi.database.conn_max_lifetime }}
     tracing:
       enabled: {{ .Values.dendrite.tracing.enabled }}
       jaeger: {{- toYaml .Values.dendrite.tracing.jaeger | nindent 8 }}

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -59,7 +59,7 @@ persistence:
     size: 1Gi
 
 # -- Configure the key server.
-# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
+# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
 # @default -- See values.yaml
 keyserver:
   image:
@@ -79,9 +79,24 @@ keyserver:
           enabled: true
           port: 7779
   args: "keyserver"
+  # -- Override general dendrite.database parameters.
+  # @default -- See values.yaml
+  database:
+    # -- Custom connection string
+    # @default -- file or derived from included postgresql deployment
+    connection_string: null
+    # -- Maximum open connections
+    # @default -- dendrite.database.max_open_conns
+    max_open_conns: null
+    # -- Maximum dile connections
+    # @default -- dendrite.database.max_idle_conns
+    max_idle_conns: null
+    # -- Maximum connection lifetime
+    # @default -- dendrite.database.conn_max_lifetime
+    conn_max_lifetime: null
 
 # -- Configure the app service api.
-# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
+# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
 # @default -- See values.yaml
 appserviceapi:
   image:
@@ -101,11 +116,26 @@ appserviceapi:
           enabled: true
           port: 7777
   args: "appservice"
+  # -- Override general dendrite.database parameters.
+  # @default -- See values.yaml
+  database:
+    # -- Custom connection string
+    # @default -- file or derived from included postgresql deployment
+    connection_string: null
+    # -- Maximum open connections
+    # @default -- dendrite.database.max_open_conns
+    max_open_conns: null
+    # -- Maximum dile connections
+    # @default -- dendrite.database.max_idle_conns
+    max_idle_conns: null
+    # -- Maximum connection lifetime
+    # @default -- dendrite.database.conn_max_lifetime
+    conn_max_lifetime: null
   config:
     config_files: []
 
 # -- Configuration for the client api component.
-# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
+# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
 # @default -- See values.yaml
 clientapi:
   image:
@@ -157,7 +187,7 @@ clientapi:
       cooloff_ms: 500
 
 # -- Configure the Federation API
-# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
+# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
 # @default -- values.yaml
 federationapi:
   image:
@@ -180,6 +210,21 @@ federationapi:
           enabled: true
           port: 8072
   args: "federationapi"
+  # -- Override general dendrite.database parameters.
+  # @default -- See values.yaml
+  database:
+    # -- Custom connection string
+    # @default -- file or derived from included postgresql deployment
+    connection_string: null
+    # -- Maximum open connections
+    # @default -- dendrite.database.max_open_conns
+    max_open_conns: null
+    # -- Maximum dile connections
+    # @default -- dendrite.database.max_idle_conns
+    max_idle_conns: null
+    # -- Maximum connection lifetime
+    # @default -- dendrite.database.conn_max_lifetime
+    conn_max_lifetime: null
   config:
     federation-certificates: []
     send-max_retires: 16
@@ -199,7 +244,7 @@ federationapi:
     prefer_direct_fetch: false
 
 # -- Configure the User API
-# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
+# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
 # @default -- values.yaml
 userapi:
   image:
@@ -219,9 +264,24 @@ userapi:
           enabled: true
           port: 7781
   args: "userapi"
+  # -- Override general dendrite.database parameters.
+  # @default -- See values.yaml
+  database:
+    # -- Custom connection string
+    # @default -- file or derived from included postgresql deployment
+    connection_string: null
+    # -- Maximum open connections
+    # @default -- dendrite.database.max_open_conns
+    max_open_conns: null
+    # -- Maximum dile connections
+    # @default -- dendrite.database.max_idle_conns
+    max_idle_conns: null
+    # -- Maximum connection lifetime
+    # @default -- dendrite.database.conn_max_lifetime
+    conn_max_lifetime: null
 
 # -- Configure the Sync API
-# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
+# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
 # @default -- values.yaml
 syncapi:
   image:
@@ -244,9 +304,24 @@ syncapi:
           enabled: true
           port: 8073
   args: "syncapi"
+  # -- Override general dendrite.database parameters.
+  # @default -- See values.yaml
+  database:
+    # -- Custom connection string
+    # @default -- file or derived from included postgresql deployment
+    connection_string: null
+    # -- Maximum open connections
+    # @default -- dendrite.database.max_open_conns
+    max_open_conns: null
+    # -- Maximum dile connections
+    # @default -- dendrite.database.max_idle_conns
+    max_idle_conns: null
+    # -- Maximum connection lifetime
+    # @default -- dendrite.database.conn_max_lifetime
+    conn_max_lifetime: null
 
 # -- Configure the Room Server
-# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
+# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
 # @default -- values.yaml
 roomserver:
   image:
@@ -266,9 +341,24 @@ roomserver:
           enabled: true
           port: 7770
   args: "roomserver"
+  # -- Override general dendrite.database parameters.
+  # @default -- See values.yaml
+  database:
+    # -- Custom connection string
+    # @default -- file or derived from included postgresql deployment
+    connection_string: null
+    # -- Maximum open connections
+    # @default -- dendrite.database.max_open_conns
+    max_open_conns: null
+    # -- Maximum dile connections
+    # @default -- dendrite.database.max_idle_conns
+    max_idle_conns: null
+    # -- Maximum connection lifetime
+    # @default -- dendrite.database.conn_max_lifetime
+    conn_max_lifetime: null
 
 # -- Configure the Media API
-# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
+# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
 # @default -- values.yaml
 mediaapi:
   image:
@@ -291,6 +381,21 @@ mediaapi:
           enabled: true
           port: 8074
   args: "mediaapi"
+  # -- Override general dendrite.database parameters.
+  # @default -- See values.yaml
+  database:
+    # -- Custom connection string
+    # @default -- file or derived from included postgresql deployment
+    connection_string: null
+    # -- Maximum open connections
+    # @default -- dendrite.database.max_open_conns
+    max_open_conns: null
+    # -- Maximum dile connections
+    # @default -- dendrite.database.max_idle_conns
+    max_idle_conns: null
+    # -- Maximum connection lifetime
+    # @default -- dendrite.database.conn_max_lifetime
+    conn_max_lifetime: null
   config:
     base_path: *mediaPath
     max_file_size_bytes: 10485760
@@ -307,9 +412,29 @@ mediaapi:
         height: 480
         method: scale
 
+# -- Configuration for experimental MSCs
+# For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
+# @default -- values.yaml
+mscs:
+  # -- Override general dendrite.database parameters.
+  # @default -- See values.yaml
+  database:
+    # -- Custom connection string
+    # @default -- file or derived from included postgresql deployment
+    connection_string: null
+    # -- Maximum open connections
+    # @default -- dendrite.database.max_open_conns
+    max_open_conns: null
+    # -- Maximum dile connections
+    # @default -- dendrite.database.max_idle_conns
+    max_idle_conns: null
+    # -- Maximum connection lifetime
+    # @default -- dendrite.database.conn_max_lifetime
+    conn_max_lifetime: null
+
 # -- Configuration for Dendrite.
 # For more information see [the sample
-# denrite-config.yaml](https://github.com/matrix-org/dendrite/blob/master/build/docker/config/dendrite-config.yaml)
+# denrite-config.yaml](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
 # @default -- See values.yaml
 dendrite:
   # -- Enable polylith deployment

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -279,6 +279,10 @@ userapi:
     # -- Maximum connection lifetime
     # @default -- dendrite.database.conn_max_lifetime
     conn_max_lifetime: null
+  config:
+    # -- bcrypt cost (2^[cost] = rounds)
+    # @default -- 10
+    bcrypt_cost: 10
 
 # -- Configure the Sync API
 # For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
@@ -289,7 +293,7 @@ syncapi:
     repository: matrixdotorg/dendrite-polylith
     # -- image tag
     # @default -- chart.appVersion
-    tag: latest
+    tag:
     # -- image pull policy
     pullPolicy: IfNotPresent
   service:
@@ -439,6 +443,13 @@ mscs:
 dendrite:
   # -- Enable polylith deployment
   polylithEnabled: false
+  # -- Usage statistics reporting configuration
+  report_stats:
+    # -- Enable or disable usage reporting
+    # @default -- false
+    enabled: false
+    # -- Push endpoint for usage statistics
+    endpoint: ""
   # -- If enabled, use an existing secrets for the TLS certificate and key.
   # Otherwise, to enable TLS a `server.crt` and `server.key` must be mounted at
   # `/etc/dendrite`.


### PR DESCRIPTION
**Description of the change**

This change allows database configuration to be set for each of the sub-components of Dendrite.

**Benefits**

This enabled use-cases such as:
- Use of a database other than SQLite or the included postgresql deployment
- Configure a completely separate database target for each component
- Configure database connection parameters per component

**Possible drawbacks**

None that I'm aware of. Backward compatibility is kept with the current logic.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.