### PR TITLE
[vaultwarden] Bump Vaultwarden App Version to 1.25.0

### DIFF
--- a/charts/stable/vaultwarden/Chart.yaml
+++ b/charts/stable/vaultwarden/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 1.24.0
+appVersion: 1.25.0
 description: Vaultwarden is a Bitwarden compatable server in Rust
 name: vaultwarden
-version: 4.2.2
+version: 4.2.3
 kubeVersion: ">=1.16.0-0"
 keywords:
   - Vaultwarden
@@ -30,4 +30,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+      description: Updated Vaultwarden App Version to v1.25.0.

--- a/charts/stable/vaultwarden/README.md
+++ b/charts/stable/vaultwarden/README.md
@@ -1,6 +1,6 @@
 # vaultwarden
 
-![Version: 4.2.2](https://img.shields.io/badge/Version-4.2.2-informational?style=flat-square) ![AppVersion: 1.24.0](https://img.shields.io/badge/AppVersion-1.24.0-informational?style=flat-square)
+![Version: 4.2.3](https://img.shields.io/badge/Version-4.2.3-informational?style=flat-square) ![AppVersion: 1.25.0](https://img.shields.io/badge/AppVersion-1.25.0-informational?style=flat-square)
 
 Vaultwarden is a Bitwarden compatable server in Rust
 
@@ -89,7 +89,7 @@ persistence:
 | env.DATA_FOLDER | string | `"config"` | Config dir |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"vaultwarden/server"` | image repository |
-| image.tag | string | `"1.24.0"` | image tag |
+| image.tag | string | chart.appVersion | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | mariadb.enabled | bool | `false` |  |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
@@ -99,7 +99,7 @@ persistence:
 
 ## Changelog
 
-### Version 4.2.2
+### Version 4.2.3
 
 #### Added
 
@@ -107,7 +107,7 @@ N/A
 
 #### Changed
 
-* Upgraded `common` chart dependency to version 4.4.2
+* Updated Vaultwarden App Version to v1.25.0.
 
 #### Fixed
 

--- a/charts/stable/vaultwarden/values.yaml
+++ b/charts/stable/vaultwarden/values.yaml
@@ -11,7 +11,8 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: 1.24.0
+  # @default -- chart.appVersion
+  tag:
 
 strategy:
   type: Recreate


### PR DESCRIPTION
Signed-off-by: Simon Caron <simon.caron.8@gmail.com>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Updated VaultWarden to the latest minor release 1.25.0.

**Benefits**

New feature!

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
