### PR TITLE
chore: bump unifi to v7.1.66

### DIFF
--- a/charts/stable/unifi/Chart.yaml
+++ b/charts/stable/unifi/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: v7.0.25
+appVersion: v7.1.66
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 4.9.2
+version: 4.10.0
 keywords:
   - ubiquiti
   - unifi
@@ -27,4 +27,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+      description: Upgraded unifi app to v7.1.66


### PR DESCRIPTION
Bump unifi to v7.1.66

Chart version is bumped to `4.10.0` as we are going up a minor version
for the unifi app.

Signed-off-by: Noel Georgi <git@frezbo.dev>