### PR TITLE
chore: fix unifi podsecurity context

### DIFF
--- a/charts/stable/unifi/Chart.yaml
+++ b/charts/stable/unifi/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v7.1.66
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 4.10.0
+version: 4.10.1
 keywords:
   - ubiquiti
   - unifi
@@ -27,4 +27,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded unifi app to v7.1.66
+      description: Set right fsGroup policy for unifi pod

--- a/charts/stable/unifi/values.yaml
+++ b/charts/stable/unifi/values.yaml
@@ -36,6 +36,11 @@ env:
   # STATDB_URI:  # mongodb://unifi-mongodb:27017/unifi_stat
   # DB_NAME:  # unifi
 
+# -- pod security context.
+# @default -- See below
+podSecurityContext:
+  fsGroup: 999
+
 # -- Configures service settings for the chart.
 # @default -- See values.yaml
 service:


### PR DESCRIPTION
Fix Unifi pod `fsGroup`

When CSI mounts the unifi data if the `fsGroup` is not set it would be
mointed as uid `0` and when the unifi process starts as uid `999`, it
won't be able to access the data, producing permission denied errors and
the app failing to start.

Fix the above issue by setting the right `fsGroup` as set by the default
environment variables.

Signed-off-by: Noel Georgi <git@frezbo.dev>