### PR TITLE
Revert "chore(deps): update actions/setup-python action to v4"

### DIFF
--- a/.github/workflows/charts-changelog.yaml
+++ b/.github/workflows/charts-changelog.yaml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v4.0.0
+        uses: actions/setup-python@v3.1.2
 
       - name: Annotate Charts.yaml for Renovate PR's
         if: inputs.isRenovatePR == 'true'


### PR DESCRIPTION
Reverts k8s-at-home/charts#1614

This bump has broken our workflows for now - error message is 
`Run actions/setup-python@v[4](https://github.com/k8s-at-home/charts/runs/6824036699?check_suite_focus=true#step:3:5).0.0
Error: The specified python version file at: /home/runner/work/charts/charts/.python-version does not exist`

Related issue below still outstanding:
https://github.com/actions/setup-python/issues/421

At work so don't have time to troubleshoot, thinking we roll back until there's a bit more clarity on best upgrade path from codeownersat setup-python.