### PR TITLE
[teamspeak] feat: Can now change metric exporter remote

### DIFF
--- a/charts/incubator/teamspeak/Chart.yaml
+++ b/charts/incubator/teamspeak/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 3.14.0
+appVersion: 3.13.6
 description: TeamSpeak Server
 name: teamspeak
-version: 0.5.2
+version: 0.6.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - teamspeak

--- a/charts/incubator/teamspeak/Chart.yaml
+++ b/charts/incubator/teamspeak/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: 3.13.7
+appVersion: 3.14.0
 description: TeamSpeak Server
 name: teamspeak
 version: 0.5.2
@@ -21,4 +21,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Can now change metric exporter remote
+      description: Adds support for setting the metric exporter remote

--- a/charts/incubator/teamspeak/Chart.yaml
+++ b/charts/incubator/teamspeak/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: 3.13.6
+appVersion: 3.13.7
 description: TeamSpeak Server
 name: teamspeak
 version: 0.5.2
@@ -21,4 +21,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+      description: Can now change metric exporter remote

--- a/charts/incubator/teamspeak/templates/common.yaml
+++ b/charts/incubator/teamspeak/templates/common.yaml
@@ -32,6 +32,8 @@ additionalContainers:
     args:
       - -listen
       - :{{ .Values.metrics.exporter.env.port }}
+      - -remote
+      - {{ .Values.metrics.exporter.env.remote }}
       {{- if .Values.metrics.exporter.env.enableChannelMetrics }}
       - -enablechannelmetrics
       {{- end }}

--- a/charts/incubator/teamspeak/values.yaml
+++ b/charts/incubator/teamspeak/values.yaml
@@ -105,6 +105,8 @@ metrics:
     env:
       # -- metrics port
       port: 9189
+      # -- TeamSpeak query endpoint
+      remote: localhost:10011
       # -- Set to true to enable gathering of channel metrics
       enableChannelMetrics: false
 


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

You can now specify the remote of the metric exporter for the teamspeak chart, this allows you to use it when running on non-standard query ports which is currently not possible.

**Benefits**

You will now be able to use the metric exporter when running teamspeak on non-standard query ports.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
