### PR TITLE
[adguard-home] Remove version tag

### DIFF
--- a/charts/stable/adguard-home/values.yaml
+++ b/charts/stable/adguard-home/values.yaml
@@ -37,7 +37,7 @@ image:
   # -- image repository
   repository: adguard/adguardhome
   # -- image tag
-  tag: v0.106.3
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Remove version specific to get latest version

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

Remove the version tag in Values.yaml, so latest version of adguard-home will be fetch by default


**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
