### PR TITLE
[mosquitto] Add per_listener_settings option

### DIFF
--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 2.0.11
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 4.3.2
+version: 4.4.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - mosquitto
@@ -22,5 +22,5 @@ dependencies:
     version: 4.4.2
 annotations:
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+    - kind: added
+      description: Added support for enabling `per_listener_settings`

--- a/charts/stable/mosquitto/templates/configmap.yaml
+++ b/charts/stable/mosquitto/templates/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 data:
   mosquitto.conf: |
+    per_listener_settings {{ .Values.perListenerSettings }}
     listener {{ .Values.service.main.ports.mqtt.port }}
     {{- if .Values.auth.enabled }}
     allow_anonymous false

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -28,6 +28,9 @@ auth:
   # -- By enabling this, `allow_anonymous` gets set to `false` in the mosquitto config.
   enabled: false
 
+# -- By enabling this, authentication and access control settings will be controlled on a per-listener basis
+perListenerSettings: false
+
 persistence:
   # -- Configure a persistent volume to place mosquitto data in.
   # When enabled, this enables `persistence` and `persistence_location` in the mosquitto config.


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Add per_listener_settings option

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1516 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
