### PR TITLE
uptime-kuma: update appVersion to 1.17.1 (chart version 1.3.5)

### DIFF
--- a/charts/stable/uptime-kuma/Chart.yaml
+++ b/charts/stable/uptime-kuma/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 1.17.0
+appVersion: 1.17.1
 description: A fancy self-hosted monitoring tool for your websites and applications
 name: uptime-kuma
-version: 1.3.4
+version: 1.3.5
 kubeVersion: ">=1.16.0-0"
 keywords:
   - uptime-kuma
@@ -24,4 +24,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: changed app version to 1.17.0
+      description: changed app version to 1.17.1


### PR DESCRIPTION
**Description of the change**

update-kuma appVersion increased to 1.17.1

**Benefits**

new version, bugfixes

**Possible drawbacks**

new version might contain new bugs...

**Applicable issues**

none

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] ~~Variables have been documented in the `values.yaml` file~~. No new values
