### PR TITLE
[calibre-web] Updating Calibre-Web Version and add option for ebook conversion binaries

### DIFF
--- a/charts/stable/calibre-web/Chart.yaml
+++ b/charts/stable/calibre-web/Chart.yaml
@@ -23,4 +23,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+      description: Updated Calibre-Web version and added option for ebook conversion binaries

--- a/charts/stable/calibre-web/Chart.yaml
+++ b/charts/stable/calibre-web/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: 0.6.12
+appVersion: 0.6.18
 description: Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 name: calibre-web
 version: 8.3.2

--- a/charts/stable/calibre-web/Chart.yaml
+++ b/charts/stable/calibre-web/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 0.6.18
 description: Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 name: calibre-web
-version: 8.3.2
+version: 8.3.3
 kubeVersion: ">=1.16.0-0"
 keywords:
   - calibre

--- a/charts/stable/calibre-web/README.md
+++ b/charts/stable/calibre-web/README.md
@@ -1,6 +1,6 @@
 # calibre-web
 
-![Version: 8.3.2](https://img.shields.io/badge/Version-8.3.2-informational?style=flat-square) ![AppVersion: 0.6.12](https://img.shields.io/badge/AppVersion-0.6.12-informational?style=flat-square)
+![Version: 8.3.3](https://img.shields.io/badge/Version-8.3.3-informational?style=flat-square) ![AppVersion: 0.6.18](https://img.shields.io/badge/AppVersion-0.6.18-informational?style=flat-square)
 
 Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 
@@ -82,22 +82,23 @@ N/A
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"linuxserver/calibre-web"` | image repository |
-| image.tag | string | `"version-0.6.12"` | image tag |
+| image.tag | string | `"version-0.6.18"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | service | object | See values.yaml | Configures service settings for the chart. |
 
 ## Changelog
 
-### Version 8.3.2
+### Version 8.3.3
 
 #### Added
 
-N/A
+Environment variable to inject calibre binaries for ebook conversion. 
+For more context see [here](https://github.com/linuxserver/docker-calibre-web#application-setup).
 
 #### Changed
 
-* Upgraded `common` chart dependency to version 4.4.2
+* Upgraded calibre-web version to 0.6.18
 
 #### Fixed
 

--- a/charts/stable/calibre-web/values.yaml
+++ b/charts/stable/calibre-web/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: version-0.6.12
+  tag: version-0.6.18
 
 # -- environment variables. See more environment variables in the [calibre-web documentation](https://github.com/linuxserver/docker-calibre-web#parameters).
 # @default -- See below
@@ -22,6 +22,10 @@ env:
   PUID: "1001"
   # -- Specify the group ID the application will run as
   PGID: "1001"
+  # -- uncomment to inject calibre binaries in container to use ebook file format convertion within calibre-web
+  # -- see: https://github.com/linuxserver/docker-calibre-web#application-setup
+  # -- To activate set "Calibre E-Book Converter" to "/usr/bin/ebook-convert" at basic configuration in admin page
+  #DOCKER_MODS: "linuxserver/calibre-web:calibre"
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml


### PR DESCRIPTION
**Description of the change**

This PR bumps the app version. It also introduces to environment variable of the underlying contrainer to quickly activate the ebook conversion. 

**Benefits**

New version and easy configuration. 

**Possible drawbacks**

none

**Applicable issues**

none

**Additional information**

none

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
