### PR TITLE
[prometheus-nut-exporter] Fix service monitor.

### DIFF
--- a/charts/stable/prometheus-nut-exporter/Chart.yaml
+++ b/charts/stable/prometheus-nut-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 1.1.1
 description: Prometheus NUT Exporter a service monitor to send NUT server metrics to a Prometheus instance.
 name: prometheus-nut-exporter
-version: 5.3.3
+version: 5.3.4
 kubeVersion: ">=1.16.0-0"
 keywords:
   - nut
@@ -21,5 +21,5 @@ dependencies:
     version: 4.4.2
 annotations:
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+    - kind: fixed
+      description: Fixed `ServiceMonitor` endpoints loop.

--- a/charts/stable/prometheus-nut-exporter/templates/servicemonitor.yaml
+++ b/charts/stable/prometheus-nut-exporter/templates/servicemonitor.yaml
@@ -15,8 +15,8 @@ spec:
     matchLabels:
       {{- include "common.labels.selectorLabels" . | nindent 6 }}
   endpoints:
-    - port: metrics
     {{- range .Values.metrics.serviceMonitor.targets }}
+    - port: metrics
       interval: {{ .interval }}
       scrapeTimeout: {{ .scrapeTimeout }}
       path: /metrics


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Fix endpoints in `ServiceMonitor`.

**Benefits**

Allow monitoring multiple NUT servers.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
