### PR TITLE
[prometheus-nut-exporter] Set `instance` label instead of `target`.

### DIFF
--- a/charts/stable/network-ups-tools/Chart.yaml
+++ b/charts/stable/network-ups-tools/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v2.7.4-2479-g86a32237
 description: Network UPS Tools is a collection of programs which provide a common interface for monitoring and administering UPS, PDU and SCD hardware.
 name: network-ups-tools
-version: 6.3.3
+version: 7.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - nut
@@ -23,4 +23,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+      description: `ServiceMonitor` now sets `instance` label instead of `target`.

--- a/charts/stable/network-ups-tools/templates/servicemonitor.yaml
+++ b/charts/stable/network-ups-tools/templates/servicemonitor.yaml
@@ -28,5 +28,5 @@ spec:
           - "localhost:{{ .Values.service.main.ports.server.port }}"
       relabelings:
         - sourceLabels: [__param_target]
-          targetLabel: target
+          targetLabel: instance
 {{- end }}

--- a/charts/stable/prometheus-nut-exporter/Chart.yaml
+++ b/charts/stable/prometheus-nut-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 1.1.1
 description: Prometheus NUT Exporter a service monitor to send NUT server metrics to a Prometheus instance.
 name: prometheus-nut-exporter
-version: 5.3.4
+version: 6.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - nut
@@ -21,5 +21,5 @@ dependencies:
     version: 4.4.2
 annotations:
   artifacthub.io/changes: |-
-    - kind: fixed
-      description: Fixed `ServiceMonitor` endpoints loop.
+    - kind: changed
+      description: `ServiceMonitor` now sets `instance` label instead of `target`.

--- a/charts/stable/prometheus-nut-exporter/templates/servicemonitor.yaml
+++ b/charts/stable/prometheus-nut-exporter/templates/servicemonitor.yaml
@@ -25,6 +25,6 @@ spec:
           - "{{ .hostname }}:{{ .port }}"
       relabelings:
         - sourceLabels: [__param_target]
-          targetLabel: target
+          targetLabel: instance
     {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

As far as I understand, Grafana groups by `instance` by default, so each NUT server should be in `instance`, otherwise `instance` will change with every pod rescheduling. This results in UPSs not being grouped when they should be.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

This makes the [example Grafana dashboard](https://grafana.com/grafana/dashboards/14371) work by default.

**Possible drawbacks**

Breaking change needs major version bump. Maybe I'm also understanding something wrong, since no chart in this repo currently replaces the `instance` label.

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
