### PR TITLE
[Dendrite] Polylith ingress and config fixes

### DIFF
--- a/charts/incubator/dendrite/Chart.yaml
+++ b/charts/incubator/dendrite/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: v0.8.7
+appVersion: v0.8.9
 description: Dendrite Matrix Homeserver
 name: dendrite
-version: 5.1.0
+version: 6.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - dendrite
@@ -82,6 +82,8 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `postgresql` chart dependency to version 11.6.12
+      description: Upgraded `dendrite` dependency to version 0.8.9
+    - kind: added
+      description: Added ingress for polylith mode
     - kind: changed
-      description: Upgraded `nats` chart dependency to version 0.17.1
+      description: "**Breaking**: Updated default config as per separate monolith/polylith samples"

--- a/charts/incubator/dendrite/ci/polylith-full-values.yaml
+++ b/charts/incubator/dendrite/ci/polylith-full-values.yaml
@@ -9,6 +9,9 @@ dendrite:
 
       qVzy2Cwokt15RjGy8OzFSq6z0JFmI6QX/1Zw1VP73uU=
       -----END MATRIX PRIVATE KEY-----
+  polylith_ingress:
+    enabled: true
+    host: matrix.k8s-at-home.org
 nats:
   enabled: true
 persistence:

--- a/charts/incubator/dendrite/templates/dendrite-config.yaml
+++ b/charts/incubator/dendrite/templates/dendrite-config.yaml
@@ -50,6 +50,13 @@ stringData:
         enabled: {{ default false .Values.dendrite.global.dns_cache.enabled }}
         cache_size: {{ default 256 .Values.dendrite.global.dns_cache.cache_size }}
         cache_lifetime: {{ default "5m" .Values.dendrite.global.dns_cache.cache_lifetime }}
+      {{- if not .Values.dendrite.polylithEnabled }}
+      database:
+        connection_string: {{ default (print $connectionString "dendrite?sslmode=disable") .Values.database.connection_string }}
+        max_open_conns: {{ default 100 .Values.database.max_open_conns }}
+        max_idle_conns: {{ default 5 .Values.database.max_idle_conns }}
+        conn_max_lifetime: {{default -1 .Values.database.conn_max_lifetime }}
+      {{- end }}
     app_service_api:
       {{- if .Values.dendrite.polylithEnabled }}
       internal_api:

--- a/charts/incubator/dendrite/templates/dendrite-config.yaml
+++ b/charts/incubator/dendrite/templates/dendrite-config.yaml
@@ -51,21 +51,25 @@ stringData:
         cache_size: {{ default 256 .Values.dendrite.global.dns_cache.cache_size }}
         cache_lifetime: {{ default "5m" .Values.dendrite.global.dns_cache.cache_lifetime }}
     app_service_api:
+      {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
         listen: http://0.0.0.0:{{ .Values.appserviceapi.service.main.ports.internal.port }}
-        connect: http://{{ include "common.names.fullname" . }}-appserviceapi:{{ .Values.appserviceapi.service.main.ports.internal.port }}
+        connect: http://{{ include "common.names.fullname" (index .Subcharts "appserviceapi") }}:{{ .Values.appserviceapi.service.main.ports.internal.port }}
       database:
         connection_string: {{ default (print $connectionString "dendrite_appservice?sslmode=disable") .Values.appserviceapi.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.appserviceapi.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.appserviceapi.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.appserviceapi.database.conn_max_lifetime }}
+      {{- end }}
       config_files: {{- toYaml .Values.appserviceapi.config.config_files | nindent 8 }}
     client_api:
+      {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
         listen: http://0.0.0.0:{{ .Values.clientapi.service.main.ports.internal.port }}
-        connect: http://{{ include "common.names.fullname" . }}-clientapi:{{ .Values.clientapi.service.main.ports.internal.port }}
+        connect: http://{{ include "common.names.fullname" (index .Subcharts "clientapi") }}:{{ .Values.clientapi.service.main.ports.internal.port }}
       external_api:
         listen: http://0.0.0.0:{{ .Values.clientapi.service.main.ports.external.port }}
+      {{- end }}
       registration_disabled: {{ default true .Values.clientapi.config.registration_disabled }}
       registration_shared_secret: {{ default "" .Values.clientapi.config.registration_shared_secret | quote }}
       enable_registration_captcha: {{ default false .Values.clientapi.config.captcha.enabled }}
@@ -78,10 +82,12 @@ stringData:
         enabled: {{ default true .Values.clientapi.config.rate_limiting.enabled }}
         threshold: {{ default 5 .Values.clientapi.config.rate_limiting.threshold }}
         cooloff_ms: {{ default 500 .Values.clientapi.config.rate_limiting.cooloff_ms }}
+        exempt_user_ids: {{ .Values.clientapi.config.exempt_user_ids }}
     federation_api:
+      {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
         listen: http://0.0.0.0:7772
-        connect: http://{{ include "common.names.fullname" . }}-federationapi:7772
+        connect: http://{{ include "common.names.fullname" (index $.Subcharts "federationapi") }}:7772
       external_api:
         listen: http://0.0.0.0:8072
       database:
@@ -89,29 +95,34 @@ stringData:
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.federationapi.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.federationapi.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.federationapi.database.conn_max_lifetime }}
+
       federation_certificates: {{- toYaml .Values.federationapi.config.federation_certificates | nindent 8 }}
-      send_max_retries: {{ default 16 .Values.federationapi.config.send_max_retries }}
-      disable_tls_validation: {{ default false .Values.federationapi.config.disable_tls_validation }}
       proxy_outbound:
         enabled: {{ default false .Values.federationapi.config.proxy_outbound.enabled }}
         protocol: {{ default "http" .Values.federationapi.config.proxy_outbound.protocol | quote }}
         host: {{ default "localhost" .Values.federationapi.config.proxy_outbound.host | quote }}
         port: {{ default 8080 .Values.federationapi.config.proxy_outbound.port }}
+      {{- end }}
+      send_max_retries: {{ default 16 .Values.federationapi.config.send_max_retries }}
+      disable_tls_validation: {{ default false .Values.federationapi.config.disable_tls_validation }}
       key_perspectives: {{- toYaml .Values.federationapi.config.key_perspectives | nindent 8 }}
       prefer_direct_fetch: {{ default false .Values.federationapi.config.prefer_direct_fetch }}
+    {{- if .Values.dendrite.polylithEnabled }}
     key_server:
       internal_api:
         listen: http://0.0.0.0:7779
-        connect: http://{{ include "common.names.fullname" . }}-keyserver:7779
+        connect: http://{{ include "common.names.fullname" (index $.Subcharts "keyserver") }}:7779
       database:
         connection_string: {{ default (print $connectionString "dendrite_keyserver?sslmode=disable") .Values.keyserver.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.keyserver.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.keyserver.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.keyserver.database.conn_max_lifetime }}
+    {{- end }}
     media_api:
+      {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
         listen: http://0.0.0.0:7774
-        connect: http://{{ include "common.names.fullname" . }}-mediaapi:7774
+        connect: http://{{ include "common.names.fullname" (index $.Subcharts "mediaapi") }}:7774
       external_api:
         listen: http://0.0.0.0:8074
       database:
@@ -119,6 +130,7 @@ stringData:
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.mediaapi.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.mediaapi.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.mediaapi.database.conn_max_lifetime }}
+      {{- end }}
       base_path: {{ default "/var/dendrite/media" .Values.mediaapi.config.base_path | quote }}
       max_file_size_bytes: {{ int ( default 10485760 .Values.mediaapi.config.max_file_size_bytes ) }}
       dynamic_thumbnails: {{ default false .Values.mediaapi.config.dynamic_thumbnails }}
@@ -126,24 +138,29 @@ stringData:
       thumbnail_sizes: {{- toYaml .Values.mediaapi.config.thumbnail_sizes | nindent 8 }}
     mscs:
       mscs: {{ .Values.dendrite.global.mscs | toYaml | nindent 8 }}
+      {{- if .Values.dendrite.polylithEnabled }}
       database:
         connection_string: {{ default (print $connectionString "dendrite_mscs?sslmode=disable") .Values.mscs.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.mscs.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.mscs.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.mscs.database.conn_max_lifetime }}
+      {{- end }}
+    {{- if .Values.dendrite.polylithEnabled }}
     room_server:
       internal_api:
         listen: http://0.0.0.0:7770
-        connect: http://{{ include "common.names.fullname" . }}-roomserver:7770
+        connect: http://{{ include "common.names.fullname" (index $.Subcharts "roomserver") }}:7770
       database:
         connection_string: {{ default (print $connectionString "dendrite_roomserver?sslmode=disable") .Values.roomserver.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.roomserver.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.roomserver.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.roomserver.database.conn_max_lifetime }}
+    {{- end }}
     sync_api:
+      {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
         listen: http://0.0.0.0:7773
-        connect: http://{{ include "common.names.fullname" . }}-syncapi:7773
+        connect: http://{{ include "common.names.fullname" (index $.Subcharts "syncapi") }}:7773
       external_api:
           listen: http://0.0.0.0:8073
       database:
@@ -151,15 +168,18 @@ stringData:
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.syncapi.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.syncapi.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.syncapi.database.conn_max_lifetime }}
+      {{- end }}
     user_api:
+      {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
         listen: http://0.0.0.0:7781
-        connect: http://{{ include "common.names.fullname" . }}-userapi:7781
+        connect: http://{{ include "common.names.fullname" (index $.Subcharts "userapi") }}:7781
       account_database:
         connection_string: {{ default (print $connectionString "dendrite_userapi_accounts?sslmode=disable") .Values.userapi.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.userapi.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.userapi.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.userapi.database.conn_max_lifetime }}
+      {{- end }}
       bcrypt_cost: {{ default 10 .Values.userapi.config.bcrypt_cost }}
     tracing:
       enabled: {{ .Values.dendrite.tracing.enabled }}

--- a/charts/incubator/dendrite/templates/dendrite-config.yaml
+++ b/charts/incubator/dendrite/templates/dendrite-config.yaml
@@ -2,6 +2,7 @@
 {{- if .Values.postgresql.enabled}}
 {{- $connectionString = print "postgresql://" .Values.postgresql.auth.username ":" .Values.postgresql.auth.password "@" (include "common.names.fullname" .)  "-postgresql/" -}}
 {{- end}}
+{{- $componentSpecificDatabaseConfig := or (.Values.polylithEnabled) (not .Values.postgresql.enabled) -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -50,7 +51,7 @@ stringData:
         enabled: {{ default false .Values.dendrite.global.dns_cache.enabled }}
         cache_size: {{ default 256 .Values.dendrite.global.dns_cache.cache_size }}
         cache_lifetime: {{ default "5m" .Values.dendrite.global.dns_cache.cache_lifetime }}
-      {{- if not .Values.dendrite.polylithEnabled }}
+      {{- if not $componentSpecificDatabaseConfig }}
       database:
         connection_string: {{ default (print $connectionString "dendrite?sslmode=disable") .Values.database.connection_string }}
         max_open_conns: {{ default 100 .Values.database.max_open_conns }}
@@ -61,7 +62,9 @@ stringData:
       {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
         listen: http://0.0.0.0:{{ .Values.appserviceapi.service.main.ports.internal.port }}
-        connect: http://{{ include "common.names.fullname" (index .Subcharts "appserviceapi") }}:{{ .Values.appserviceapi.service.main.ports.internal.port }}
+        connect: http://{{ include "common.names.fullname" (index $.Subcharts "appserviceapi") }}:{{ .Values.appserviceapi.service.main.ports.internal.port }}
+      {{- end }}
+      {{- if $componentSpecificDatabaseConfig }}
       database:
         connection_string: {{ default (print $connectionString "dendrite_appservice?sslmode=disable") .Values.appserviceapi.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.appserviceapi.database.max_open_conns }}
@@ -73,7 +76,7 @@ stringData:
       {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
         listen: http://0.0.0.0:{{ .Values.clientapi.service.main.ports.internal.port }}
-        connect: http://{{ include "common.names.fullname" (index .Subcharts "clientapi") }}:{{ .Values.clientapi.service.main.ports.internal.port }}
+        connect: http://{{ include "common.names.fullname" (index $.Subcharts "clientapi") }}:{{ .Values.clientapi.service.main.ports.internal.port }}
       external_api:
         listen: http://0.0.0.0:{{ .Values.clientapi.service.main.ports.external.port }}
       {{- end }}
@@ -97,18 +100,19 @@ stringData:
         connect: http://{{ include "common.names.fullname" (index $.Subcharts "federationapi") }}:7772
       external_api:
         listen: http://0.0.0.0:8072
-      database:
-        connection_string: {{ default (print $connectionString "dendrite_federationapi?sslmode=disable") .Values.federationapi.database.connection_string }}
-        max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.federationapi.database.max_open_conns }}
-        max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.federationapi.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.federationapi.database.conn_max_lifetime }}
-
       federation_certificates: {{- toYaml .Values.federationapi.config.federation_certificates | nindent 8 }}
       proxy_outbound:
         enabled: {{ default false .Values.federationapi.config.proxy_outbound.enabled }}
         protocol: {{ default "http" .Values.federationapi.config.proxy_outbound.protocol | quote }}
         host: {{ default "localhost" .Values.federationapi.config.proxy_outbound.host | quote }}
         port: {{ default 8080 .Values.federationapi.config.proxy_outbound.port }}
+      {{- end }}
+      {{- if $componentSpecificDatabaseConfig }}
+      database:
+        connection_string: {{ default (print $connectionString "dendrite_federationapi?sslmode=disable") .Values.federationapi.database.connection_string }}
+        max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.federationapi.database.max_open_conns }}
+        max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.federationapi.database.max_idle_conns }}
       {{- end }}
       send_max_retries: {{ default 16 .Values.federationapi.config.send_max_retries }}
       disable_tls_validation: {{ default false .Values.federationapi.config.disable_tls_validation }}
@@ -132,6 +136,8 @@ stringData:
         connect: http://{{ include "common.names.fullname" (index $.Subcharts "mediaapi") }}:7774
       external_api:
         listen: http://0.0.0.0:8074
+      {{- end }}
+      {{- if $componentSpecificDatabaseConfig }}
       database:
         connection_string: {{ default (print $connectionString "dendrite_mediaapi?sslmode=disable") .Values.mediaapi.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.mediaapi.database.max_open_conns }}
@@ -145,7 +151,7 @@ stringData:
       thumbnail_sizes: {{- toYaml .Values.mediaapi.config.thumbnail_sizes | nindent 8 }}
     mscs:
       mscs: {{ .Values.dendrite.global.mscs | toYaml | nindent 8 }}
-      {{- if .Values.dendrite.polylithEnabled }}
+      {{- if $componentSpecificDatabaseConfig }}
       database:
         connection_string: {{ default (print $connectionString "dendrite_mscs?sslmode=disable") .Values.mscs.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.mscs.database.max_open_conns }}
@@ -170,6 +176,8 @@ stringData:
         connect: http://{{ include "common.names.fullname" (index $.Subcharts "syncapi") }}:7773
       external_api:
           listen: http://0.0.0.0:8073
+      {{- end }}
+      {{- if $componentSpecificDatabaseConfig }}
       database:
         connection_string: {{ default (print $connectionString "dendrite_syncapi?sslmode=disable") .Values.syncapi.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.syncapi.database.max_open_conns }}
@@ -181,6 +189,8 @@ stringData:
       internal_api:
         listen: http://0.0.0.0:7781
         connect: http://{{ include "common.names.fullname" (index $.Subcharts "userapi") }}:7781
+      {{- end }}
+      {{- if $componentSpecificDatabaseConfig }}
       account_database:
         connection_string: {{ default (print $connectionString "dendrite_userapi_accounts?sslmode=disable") .Values.userapi.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.userapi.database.max_open_conns }}

--- a/charts/incubator/dendrite/templates/dendrite-config.yaml
+++ b/charts/incubator/dendrite/templates/dendrite-config.yaml
@@ -1,8 +1,8 @@
 {{- $connectionString := "file:" -}}
 {{- if .Values.postgresql.enabled}}
-{{- $connectionString = print "postgresql://" .Values.postgresql.auth.username ":" .Values.postgresql.auth.password "@" (include "common.names.fullname" .)  "-postgresql/" -}}
+{{- $connectionString = print "postgresql://" .Values.postgresql.auth.username ":" .Values.postgresql.auth.password "@" (include "common.names.fullname" $.Subcharts.postgresql) "/" -}}
 {{- end}}
-{{- $componentSpecificDatabaseConfig := or (.Values.polylithEnabled) (not .Values.postgresql.enabled) -}}
+{{- $componentSpecificDatabaseConfig := or .Values.dendrite.polylithEnabled (not .Values.postgresql.enabled) -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -35,7 +35,7 @@ stringData:
       jetstream:
         addresses:
           {{- if .Values.nats.enabled }}
-          - {{ template "common.names.fullname" . }}-nats:4222
+          - {{ template "common.names.fullname" $.Subcharts.nats }}:4222
           {{- else }}
           []
           {{- end }}
@@ -118,17 +118,19 @@ stringData:
       disable_tls_validation: {{ default false .Values.federationapi.config.disable_tls_validation }}
       key_perspectives: {{- toYaml .Values.federationapi.config.key_perspectives | nindent 8 }}
       prefer_direct_fetch: {{ default false .Values.federationapi.config.prefer_direct_fetch }}
-    {{- if .Values.dendrite.polylithEnabled }}
     key_server:
+      {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
         listen: http://0.0.0.0:7779
         connect: http://{{ include "common.names.fullname" (index $.Subcharts "keyserver") }}:7779
+      {{- end }}
+      {{- if $componentSpecificDatabaseConfig }}
       database:
         connection_string: {{ default (print $connectionString "dendrite_keyserver?sslmode=disable") .Values.keyserver.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.keyserver.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.keyserver.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.keyserver.database.conn_max_lifetime }}
-    {{- end }}
+      {{- end }}
     media_api:
       {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
@@ -158,17 +160,19 @@ stringData:
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.mscs.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.mscs.database.conn_max_lifetime }}
       {{- end }}
-    {{- if .Values.dendrite.polylithEnabled }}
     room_server:
+      {{- if .Values.dendrite.polylithEnabled }}
       internal_api:
         listen: http://0.0.0.0:7770
         connect: http://{{ include "common.names.fullname" (index $.Subcharts "roomserver") }}:7770
+      {{- end }}
+      {{- if $componentSpecificDatabaseConfig }}
       database:
         connection_string: {{ default (print $connectionString "dendrite_roomserver?sslmode=disable") .Values.roomserver.database.connection_string }}
         max_open_conns: {{ default .Values.dendrite.database.max_open_conns .Values.roomserver.database.max_open_conns }}
         max_idle_conns: {{ default .Values.dendrite.database.max_idle_conns .Values.roomserver.database.max_idle_conns }}
         conn_max_lifetime: {{ default .Values.dendrite.database.conn_max_lifetime .Values.roomserver.database.conn_max_lifetime }}
-    {{- end }}
+      {{- end }}
     sync_api:
       {{- if .Values.dendrite.polylithEnabled }}
       internal_api:

--- a/charts/incubator/dendrite/templates/ingress.yaml
+++ b/charts/incubator/dendrite/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.dendrite.polylith_ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}
+spec:
+  rules:
+    - host: {{ .Values.dendrite.polylith_ingress.host | quote }}
+      http:
+        paths:
+        - path: /_matrix/client/
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ include "common.names.fullname" (index $.Subcharts  "syncapi") }}
+              port:
+                number: {{ .Values.syncapi.service.main.ports.external.port }}
+        - path: /_matrix/client
+          pathType: Exact
+          backend:
+            service:
+              name: {{ include "common.names.fullname" (index $.Subcharts  "clientapi") }}
+              port:
+                number: {{ .Values.clientapi.service.main.ports.external.port }}
+        - path: /_matrix/federation
+          pathType: Exact
+          backend:
+            service:
+              name: {{ include "common.names.fullname" (index $.Subcharts  "federationapi") }}
+              port:
+                number: {{ .Values.federationapi.service.main.ports.external.port }}
+        - path: /_matrix/key
+          pathType: Exact
+          backend:
+            service:
+              name: {{ include "common.names.fullname" (index $.Subcharts  "federationapi") }}
+              port:
+                number: {{ .Values.federationapi.service.main.ports.external.port }}
+        - path: /_matrix/media
+          pathType: Exact
+          backend:
+            service:
+              name: {{ include "common.names.fullname" (index $.Subcharts  "mediaapi") }}
+              port:
+                number: {{ .Values.mediaapi.service.main.ports.external.port }}
+{{- end -}}

--- a/charts/incubator/dendrite/templates/ingress.yaml
+++ b/charts/incubator/dendrite/templates/ingress.yaml
@@ -3,6 +3,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
+  {{- if .Values.dendrite.polylith_ingress.annotations }}
+  annotations: {{ toYaml .Values.dendrite.polylith_ingress.annotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.dendrite.tls_secret.enabled }}
   tls:
@@ -14,36 +17,38 @@ spec:
     - host: {{ .Values.dendrite.polylith_ingress.host | quote }}
       http:
         paths:
-        - path: /_matrix/client/
-          pathType: Prefix
+        {{- range .Values.dendrite.polylith_ingress.syncapi_paths }}
+        - path: {{ . | quote }}
+          pathType: Exact
           backend:
             service:
               name: {{ include "common.names.fullname" (index $.Subcharts  "syncapi") }}
               port:
-                number: {{ .Values.syncapi.service.main.ports.external.port }}
+                number: {{ $.Values.syncapi.service.main.ports.external.port }}
+        {{- end }}
         - path: /_matrix/client
-          pathType: Exact
+          pathType: Prefix
           backend:
             service:
               name: {{ include "common.names.fullname" (index $.Subcharts  "clientapi") }}
               port:
                 number: {{ .Values.clientapi.service.main.ports.external.port }}
         - path: /_matrix/federation
-          pathType: Exact
+          pathType: Prefix
           backend:
             service:
               name: {{ include "common.names.fullname" (index $.Subcharts  "federationapi") }}
               port:
                 number: {{ .Values.federationapi.service.main.ports.external.port }}
         - path: /_matrix/key
-          pathType: Exact
+          pathType: Prefix
           backend:
             service:
               name: {{ include "common.names.fullname" (index $.Subcharts  "federationapi") }}
               port:
                 number: {{ .Values.federationapi.service.main.ports.external.port }}
         - path: /_matrix/media
-          pathType: Exact
+          pathType: Prefix
           backend:
             service:
               name: {{ include "common.names.fullname" (index $.Subcharts  "mediaapi") }}

--- a/charts/incubator/dendrite/templates/ingress.yaml
+++ b/charts/incubator/dendrite/templates/ingress.yaml
@@ -4,6 +4,12 @@ kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
 spec:
+  {{- if .Values.dendrite.tls_secret.enabled }}
+  tls:
+  - hosts:
+      - {{ .Values.dendrite.polylith_ingress.host | quote }}
+    secretName: {{ .Values.dendrite.tls_secret.existingSecret }}
+  {{- end }}
   rules:
     - host: {{ .Values.dendrite.polylith_ingress.host | quote }}
       http:

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -510,7 +510,7 @@ dendrite:
       #
       # For nginx uncomment these lines and add the annotations here:
       # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#use-regex
-      # - /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/messages)$ 
+      # - /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/messages)$
 
   # -- Configure database connection parameters.
   # @default -- See values.yaml

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -496,7 +496,21 @@ dendrite:
   polylith_ingress:
     enabled: false
     host: ""
-    annotations: []
+    annotations: {}
+    # -- Sync API Paths are a little tricky since they require regular expressions. Therefore
+    # the paths will depend on the ingress controller used. See values.yaml for nginx and traefik.
+    # @default -- See values.yaml
+    syncapi_paths: []
+      # For Traefik uncomment these lines
+      # - /_matrix/client/{version:.*?}/rooms/{roomid:.*?}/messages
+      # - /_matrix/client/{version:.*?}/keys/changes
+      # - /_matrix/client/{version:.*?}/user/{userid:.*?}/filter/{filterid:.*?}
+      # - /_matrix/client/{version:.*?}/user/{userid:.*?}/filter
+      # - /_matrix/client/{version:.*?}/sync
+      #
+      # For nginx uncomment these lines and add the annotations here:
+      # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#use-regex
+      # - /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/messages)$ 
 
   # -- Configure database connection parameters.
   # @default -- See values.yaml

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -59,6 +59,22 @@ persistence:
     accessMode: ReadWriteOnce
     size: 1Gi
 
+# -- Override general dendrite.database parameters.
+# @default -- See values.yaml
+database:
+  # -- Custom connection string
+  # @default -- file or derived from included postgresql deployment
+  connection_string: null
+  # -- Maximum open connections
+  # @default -- dendrite.database.max_open_conns
+  max_open_conns: null
+  # -- Maximum dile connections
+  # @default -- dendrite.database.max_idle_conns
+  max_idle_conns: null
+  # -- Maximum connection lifetime
+  # @default -- dendrite.database.conn_max_lifetime
+  conn_max_lifetime: null
+
 # -- Configure the key server.
 # For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
 # @default -- See values.yaml

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -37,7 +37,8 @@ service:
         protocol: HTTPS
 
 ingress:
-  # -- Enable and configure ingress settings for the chart under this key.
+  # -- (Monolith Only) Enable and configure ingress settings for the chart under
+  # this key.
   # @default -- See values.yaml
   main:
     enabled: false
@@ -115,6 +116,8 @@ appserviceapi:
         internal:
           enabled: true
           port: 7777
+  ingress:
+
   args: "appservice"
   # -- Override general dendrite.database parameters.
   # @default -- See values.yaml
@@ -185,6 +188,7 @@ clientapi:
       enabled: true
       threshold: 5
       cooloff_ms: 500
+      exempt_user_ids: []
 
 # -- Configure the Federation API
 # For more information see [the sample dendrite configuration](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.polylith.yaml)
@@ -459,6 +463,7 @@ dendrite:
     existingSecret: ""
     crtPath: tls.crt
     keyPath: tls.key
+
   matrix_key_secret:
     # -- Create matrix_key secret using the keyBody below.
     create: false
@@ -468,6 +473,15 @@ dendrite:
     existingSecret: ""
     # -- Field in the secret to get the key from
     secretPath: matrix_key.pem
+
+  # -- Enable and configure polylith ingress as per
+  # https://github.com/matrix-org/dendrite/blob/main/docs/nginx/polylith-sample.conf
+  # @default -- See values.yaml
+  polylith_ingress:
+    enabled: false
+    host: ""
+    annotations: []
+    tls: {}
 
   # -- Configure database connection parameters.
   # @default -- See values.yaml

--- a/charts/incubator/dendrite/values.yaml
+++ b/charts/incubator/dendrite/values.yaml
@@ -481,7 +481,6 @@ dendrite:
     enabled: false
     host: ""
     annotations: []
-    tls: {}
 
   # -- Configure database connection parameters.
   # @default -- See values.yaml


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Add an ingress configuration with correct routing for each polylith service.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Reduces the toil in getting a polylith setup ready to go.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
Config fixes may be breaking, although unlikely to be honest.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- closes #1600 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
