### PR TITLE
[pod-gateway]: Bump image versions

### DIFF
--- a/charts/stable/pod-gateway/Chart.yaml
+++ b/charts/stable/pod-gateway/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 1.2.6
+appVersion: v1.6.0
 description: Admision controller to change the default gateway and DNS server of PODs
 name: pod-gateway
-version: 5.4.2
+version: 5.5.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - pod-gateway
@@ -22,4 +22,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+      description: Upgraded `pod-gateway` tag dependency to v1.6.0
+    - kind: changed
+      description: Upgraded `gateway-admision-controller` tag dependency to v3.5.0

--- a/charts/stable/pod-gateway/templates/common.yaml
+++ b/charts/stable/pod-gateway/templates/common.yaml
@@ -32,7 +32,7 @@ initContainers:
   routes:
     name: "routes"
     # -- Image for the init container
-    image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+    image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
     # -- Will be set automatically
     # @default -- <image.pullPolicy>
     imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/stable/pod-gateway/values.yaml
+++ b/charts/stable/pod-gateway/values.yaml
@@ -11,7 +11,8 @@ image:
   # -- image pull policy of the gateway and inserted helper cotainers
   pullPolicy: IfNotPresent
   # -- image tag of the gateway and inserted helper containers
-  tag: v1.2.6
+  # @default -- chart.appVersion
+  tag:
 
 # -- IP address of the DNS server within the vxlan tunnel.
 # All mutated PODs will get this as their DNS server.
@@ -110,7 +111,7 @@ webhook:
     # -- image pullPolicy of the webhook
     pullPolicy: IfNotPresent
     # -- image tag of the webhook
-    tag: v3.3.2
+    tag: v3.5.0
 
   # -- number of webhook instances to deploy
   replicas: 1


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Updates the default images used by pod-gateway to the latest ones.

**Benefits**

Users don't have to manually update the images to get the latest version.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1684

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
