### PR TITLE
[teedy] PostgreSQL Config Fix

### DIFF
--- a/charts/stable/teedy/values.yaml
+++ b/charts/stable/teedy/values.yaml
@@ -68,9 +68,10 @@ persistence:
 # @default -- See values.yaml
 postgresql:
   enabled: false
-  postgresqlUsername: teedyuser
-  postgresqlPassword: teedypassword
-  postgresqlDatabase: teedydb
-  persistence:
-    enabled: false
-    # storageClass: ""
+  auth:
+    username: teedyuser
+    password: teedypassword
+    database: teedydb
+  primary:
+    persistence:
+      enabled: false

--- a/charts/stable/teedy/values.yaml
+++ b/charts/stable/teedy/values.yaml
@@ -75,3 +75,4 @@ postgresql:
   primary:
     persistence:
       enabled: false
+      # storageClass: ""


### PR DESCRIPTION
**Description of the change**

Fix the PostgreSQL sub-chart default config so that the values are actually applied to the sub-chart. Prior keys did not match the sub-chart's keys and had no effect on the deployment.

**Benefits**

PostgreSQL sub-chart configuration will actually affect the sub-chart without extensive modification and research. Set-up procedure will take less time.

**Possible drawbacks**

N/A.
