### PR TITLE
[jackett] Bumping jackett version to the latest stable version v0.20.1316

### DIFF
--- a/charts/stable/jackett/Chart.yaml
+++ b/charts/stable/jackett/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: v0.20.892
+appVersion: v0.20.1316
 description: API Support for your favorite torrent trackers
 name: jackett
 version: 11.5.2

--- a/charts/stable/jackett/Chart.yaml
+++ b/charts/stable/jackett/Chart.yaml
@@ -23,4 +23,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.4.2
+      description: description: Updated the docker image to the latest stable version version v0.20.1316

--- a/charts/stable/jackett/Chart.yaml
+++ b/charts/stable/jackett/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v0.20.1316
 description: API Support for your favorite torrent trackers
 name: jackett
-version: 11.5.2
+version: 11.6.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - jackett

--- a/charts/stable/jackett/README.md
+++ b/charts/stable/jackett/README.md
@@ -1,6 +1,6 @@
 # jackett
 
-![Version: 11.5.2](https://img.shields.io/badge/Version-11.5.2-informational?style=flat-square) ![AppVersion: v0.20.892](https://img.shields.io/badge/AppVersion-v0.20.892-informational?style=flat-square)
+![Version: 11.6.0](https://img.shields.io/badge/Version-11.6.0-informational?style=flat-square) ![AppVersion: v0.20.1316](https://img.shields.io/badge/AppVersion-v0.20.1316-informational?style=flat-square)
 
 API Support for your favorite torrent trackers
 
@@ -87,7 +87,7 @@ N/A
 
 ## Changelog
 
-### Version 11.5.2
+### Version 11.6.0
 
 #### Added
 
@@ -95,7 +95,7 @@ N/A
 
 #### Changed
 
-* Upgraded `common` chart dependency to version 4.4.2
+* Upgraded container inamge to v0.20.1316
 
 #### Fixed
 

--- a/charts/stable/jackett/README.md
+++ b/charts/stable/jackett/README.md
@@ -95,7 +95,7 @@ N/A
 
 #### Changed
 
-* Upgraded container inamge to v0.20.1316
+* Upgraded container image to v0.20.1316
 
 #### Fixed
 


### PR DESCRIPTION
Signed-off-by: SurgeVortex <ac.chris.ackerman@gmail.com>

**Description of the change**

Bumping the container image version to v0.20.1316

**Benefits**

Having the latest version has possible fixes and / or improvements which may increase security or improve performance, etc.

**Possible drawbacks**

There may be new bugs or regressions in the new version.

**Applicable issues**

**Additional information**

Closes #1704

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
