### PR TITLE
[ser2sock] use a headless service

### DIFF
--- a/charts/stable/ser2sock/Chart.yaml
+++ b/charts/stable/ser2sock/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: common
     repository: https://library-charts.k8s-at-home.com
-    version: 4.4.2
+    version: 4.5.0
 annotations:
   artifacthub.io/changes: |-
     - kind: changed

--- a/charts/stable/ser2sock/values.yaml
+++ b/charts/stable/ser2sock/values.yaml
@@ -29,6 +29,8 @@ env:
 # @default -- See values.yaml
 service:
   main:
+    type: ClusterIP
+    clusterIP: None
     ports:
       http:
         enabled: false


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Default to a headless service for ser2sock instead of a clusterIP load balancer

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Since these generally talk to individual instances of physical hardware, it is unlikely that a user intends load balancing of multiple instances to multiple devices. Using a headless service (`clusterIP: None`) removes the k8s load balancer and allows clients to talk directly to the ser2sock pod via the service name.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

Users who rely on the clusterIP load balancer will need to add `service.main.clusterIP: ` (no value) to return to the old behavior.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
