### PR TITLE
[mosquitto] Use appVersion as image tag by default

### DIFF
--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 2.0.14
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 4.5.0
+version: 4.5.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - mosquitto
@@ -23,4 +23,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Updated image version to 2.0.14
+      description: Use appVersion as image tag by default

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -9,7 +9,8 @@ image:
   # -- image repository
   repository: eclipse-mosquitto
   # -- image tag
-  tag: 2.0.11
+  # @default -- chart.appVersion
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Previous title was `Update container image in values.yaml to v2.0.14`

**Description of the change**

https://github.com/k8s-at-home/charts/pull/1702 bumped the appVersion but not the actual value.

**Benefits**

Same as https://github.com/k8s-at-home/charts/pull/1702 

**Possible drawbacks**

Same as https://github.com/k8s-at-home/charts/pull/1702 

**Applicable issues**
none

**Additional information**
none

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
