### PR TITLE
[mosquitto] Remove storage fields from configinc value

### DIFF
--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 2.0.14
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 4.7.0
+version: 4.8.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - mosquitto
@@ -23,4 +23,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.5.0
+      description: Remove some storage fields from the `persistence.configinc` value

--- a/charts/stable/mosquitto/README.md
+++ b/charts/stable/mosquitto/README.md
@@ -87,7 +87,7 @@ N/A
 
 ## Changelog
 
-### Version 4.7.0
+### Version 4.8.0
 
 #### Added
 
@@ -95,7 +95,7 @@ N/A
 
 #### Changed
 
-* Upgraded `common` chart dependency to version 4.5.0
+* Remove some storage fields from the `persistence.configinc` value
 
 #### Fixed
 

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -49,5 +49,3 @@ persistence:
   configinc:
     enabled: false
     mountPath: /mosquitto/configinc
-    accessMode: ReadWriteOnce
-    size: 100Mi


### PR DESCRIPTION
**Description of the change**

Persistent storage settings for `configinc` have been removed because they should not have been there in the first place as they are to be specified by the user.

**Benefits**

The chart is aligned to the best practices used in this repository.

**Possible drawbacks**

The user must now specify the storage manually.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ X] Variables have been documented in the `values.yaml` file.
