### PR TITLE
[mosquitto] Add option for selectively adding listener

### DIFF
--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 2.0.14
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 4.5.1
+version: 4.6.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - mosquitto
@@ -22,5 +22,5 @@ dependencies:
     version: 4.4.2
 annotations:
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Use appVersion as image tag by default
+    - kind: added
+      description: Option to disable adding of the listener option to the config

--- a/charts/stable/mosquitto/README.md
+++ b/charts/stable/mosquitto/README.md
@@ -80,21 +80,22 @@ N/A
 | image.repository | string | `"eclipse-mosquitto"` | image repository |
 | image.tag | string | chart.appVersion | image tag |
 | perListenerSettings | bool | `false` | By enabling this, authentication and access control settings will be controlled on a per-listener basis |
+| addListener | bool | `true` | When enabled the `listener` option is added to the mosquitto config. |
 | persistence.configinc | object | See values.yaml | Configure a persistent volume to place *.conf mosquitto-config-files in. When enabled, this gets set as `include_dir` in the mosquitto config. |
 | persistence.data | object | See values.yaml | Configure a persistent volume to place mosquitto data in. When enabled, this enables `persistence` and `persistence_location` in the mosquitto config. |
 | service | object | See values.yaml | Configures service settings for the chart. Normally this does not need to be modified. |
 
 ## Changelog
 
-### Version 4.5.1
+### Version 4.6.0
 
 #### Added
 
-N/A
+* Option to disable adding of the `listener` option to the config
 
 #### Changed
 
-* Use appVersion as image tag by default
+N/A
 
 #### Fixed
 

--- a/charts/stable/mosquitto/templates/configmap.yaml
+++ b/charts/stable/mosquitto/templates/configmap.yaml
@@ -9,7 +9,9 @@ metadata:
 data:
   mosquitto.conf: |
     per_listener_settings {{ .Values.perListenerSettings }}
+    {{- if .Values.addListener }}
     listener {{ .Values.service.main.ports.mqtt.port }}
+    {{- end}}
     {{- if .Values.auth.enabled }}
     allow_anonymous false
     {{- else }}

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -32,6 +32,10 @@ auth:
 # -- By enabling this, authentication and access control settings will be controlled on a per-listener basis
 perListenerSettings: false
 
+# -- When enabled, this adds the `listener` option to the mosquitto config.
+# Change this to false when using TLS.
+addListener: true
+
 persistence:
   # -- Configure a persistent volume to place mosquitto data in.
   # When enabled, this enables `persistence` and `persistence_location` in the mosquitto config.


### PR DESCRIPTION
**Description of the change**

Add an option to control adding of the `listener` option to mosquitto.conf. Using TLS in Mosquitto does not work if the `listener` option is present in the main mosquitto.conf. The linked issue has a longer description on the problem.

**Benefits**

TLS can be configured without having to manually edit the chart.

**Possible drawbacks**

None, the change is fully backwards compatible.

**Applicable issues**

- Fixes #1701

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X ] Variables have been documented in the `values.yaml` file.
