### PR TITLE
chore: bump unifi app to v7.1.68

### DIFF
--- a/charts/stable/unifi/Chart.yaml
+++ b/charts/stable/unifi/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: v7.1.66
+appVersion: v7.1.68
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 5.0.0
+version: 5.0.1
 keywords:
   - ubiquiti
   - unifi
@@ -27,4 +27,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `mongodb` chart dependency to version 12.1.22
+      description: Upgraded unifi app to v7.1.68

--- a/charts/stable/unifi/README.md
+++ b/charts/stable/unifi/README.md
@@ -1,6 +1,6 @@
 # unifi
 
-![Version: 4.10.1](https://img.shields.io/badge/Version-4.10.1-informational?style=flat-square) ![AppVersion: v7.1.66](https://img.shields.io/badge/AppVersion-v7.1.66-informational?style=flat-square)
+![Version: 4.10.1](https://img.shields.io/badge/Version-4.10.1-informational?style=flat-square) ![AppVersion: v7.1.68](https://img.shields.io/badge/AppVersion-v7.1.68-informational?style=flat-square)
 
 Ubiquiti Network's Unifi Controller
 


### PR DESCRIPTION
Bump Unifi to [v7.1.68](https://github.com/jacobalberty/unifi-docker/releases/tag/v7.1.68)

Signed-off-by: Noel Georgi <git@frezbo.dev>