### PR TITLE
[jellyfin] Update to 10.8.1 and fix typo in Chart.yaml homepage URL

### DIFF
--- a/charts/stable/jellyfin/Chart.yaml
+++ b/charts/stable/jellyfin/Chart.yaml
@@ -24,4 +24,6 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.5.1
+      description: Upgraded Jellyfin to 10.8.1
+    - kind: fixed
+      description: Fixed typo in homepage URL

--- a/charts/stable/jellyfin/Chart.yaml
+++ b/charts/stable/jellyfin/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 10.8.1
 description: Jellyfin is a Free Software Media System
 name: jellyfin
-version: 9.5.1
+version: 9.5.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - jellyfin

--- a/charts/stable/jellyfin/Chart.yaml
+++ b/charts/stable/jellyfin/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - jellyfin
   - plex
   - emby
-home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/Jellyfin
+home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/jellyfin
 icon: https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/icon-solid-black.svg
 sources:
   - https://hub.docker.com/r/jellyfin/jellyfin

--- a/charts/stable/jellyfin/Chart.yaml
+++ b/charts/stable/jellyfin/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: 10.7.7
+appVersion: 10.8.1
 description: Jellyfin is a Free Software Media System
 name: jellyfin
 version: 9.5.1

--- a/charts/stable/jellyfin/README.md
+++ b/charts/stable/jellyfin/README.md
@@ -88,6 +88,16 @@ N/A
 
 ## Changelog
 
+### Version 9.5.2
+
+#### Changed
+
+* Updated Jellyfin to 10.8.1
+
+#### Fixed
+
+* Fixed typo in homepage URL
+
 ### Version 9.5.1
 
 #### Added

--- a/charts/stable/jellyfin/README.md
+++ b/charts/stable/jellyfin/README.md
@@ -80,7 +80,7 @@ N/A
 | env.TZ | string | `"UTC"` | Set the container timezone |
 | image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
 | image.repository | string | `"jellyfin/jellyfin"` | image repository |
-| image.tag | string | `"10.7.7"` | image tag |
+| image.tag | string | `"10.8.1"` | image tag |
 | ingress.main | object | See values.yaml | Enable and configure ingress settings for the chart under this key. |
 | persistence | object | See values.yaml | Configure persistence settings for the chart under this key. |
 | podSecurityContext | object | `{}` | Configure the Security Context for the Pod |

--- a/charts/stable/jellyfin/values.yaml
+++ b/charts/stable/jellyfin/values.yaml
@@ -9,7 +9,8 @@ image:
   # -- image repository
   repository: jellyfin/jellyfin
   # -- image tag
-  tag: 10.8.1
+  # @default -- chart.appVersion
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/jellyfin/values.yaml
+++ b/charts/stable/jellyfin/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: jellyfin/jellyfin
   # -- image tag
-  tag: 10.7.7
+  tag: 10.8.1
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**
* Updates Jellyfin to 10.8.1
* Fixes typo in Chart.yaml homepage url (capital J instead of lower-case)

**Benefits**
* Updated version
* artifacthub.io homepage link will go to the right place now :)

**Possible drawbacks**
N/A

**Applicable issues**
N/A

**Additional information**
Not sure if 10.7.7 to 10.8.1 would warrant bumping the chart minor version instead of patch, can change it if so

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
