### PR TITLE
[onedrive] Update to 2.4.20 and use upstream docker image

### DIFF
--- a/charts/stable/onedrive/Chart.yaml
+++ b/charts/stable/onedrive/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: v2.4.17
+appVersion: 2.4.20
 description: A free Microsoft OneDrive Client which supports OneDrive Personal, OneDrive for Business, OneDrive for Office365, and SharePoint
 name: onedrive
-version: 2.4.0
+version: 2.4.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - onedrive
@@ -21,5 +21,7 @@ dependencies:
     version: 4.5.0
 annotations:
   artifacthub.io/changes: |-
+    - kind: changed
+      description: Moved to upstream docker image
     - kind: changed
       description: Upgraded `common` chart dependency to version 4.5.0

--- a/charts/stable/onedrive/Chart.yaml
+++ b/charts/stable/onedrive/Chart.yaml
@@ -23,5 +23,3 @@ annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: Moved to upstream docker image
-    - kind: changed
-      description: Upgraded `common` chart dependency to version 4.5.0

--- a/charts/stable/onedrive/values.yaml
+++ b/charts/stable/onedrive/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: driveone/onedrive
   # -- image tag
-  tag: 
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/onedrive/values.yaml
+++ b/charts/stable/onedrive/values.yaml
@@ -7,9 +7,9 @@
 
 image:
   # -- image repository
-  repository: ghcr.io/wrmilling/onedrive-docker
+  repository: driveone/onedrive
   # -- image tag
-  tag:
+  tag: 
   # -- image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

This updates the app to 2.4.20 and replaces my image with the upstream image. 

**Benefits**

I don't have to build the image anymore, upstream supports arm now!

**Possible drawbacks**

None known.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.