### PR TITLE
[homer]: update app version, switch to security context

### DIFF
--- a/charts/stable/homer/Chart.yaml
+++ b/charts/stable/homer/Chart.yaml
@@ -19,4 +19,9 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.5.0
+      description: Switch from env vars to security context object.
+    - kind: fixed
+      description: Upgraded app version to v22.07.2
+      links:
+        - name: GitHub Issue
+          url: https://github.com/k8s-at-home/charts/issues/1713

--- a/charts/stable/homer/Chart.yaml
+++ b/charts/stable/homer/Chart.yaml
@@ -1,11 +1,11 @@
 ---
 apiVersion: v2
-appVersion: 21.09.2
+appVersion: v22.07.2
 description: A dead simple static HOMepage for your servER to keep your services on hand, from a simple yaml configuration file.
 icon: https://raw.githubusercontent.com/bastienwirtz/homer/main/public/logo.png
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/homer
 name: homer
-version: 7.3.0
+version: 8.0.0
 kubeVersion: ">=1.16.0-0"
 sources:
   - https://github.com/bastienwirtz/homer

--- a/charts/stable/homer/values.yaml
+++ b/charts/stable/homer/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: b4bz/homer
   # -- image tag
-  tag: 21.09.2
+  tag: v22.07.2
   # -- image pull policy
   pullPolicy: IfNotPresent
 
@@ -18,10 +18,6 @@ image:
 env:
   # -- Set the container timezone
   TZ: UTC
-  # -- Specify the user ID the application will run as
-  UID: "911"
-  # -- Specify the group ID the application will run as
-  GID: "911"
 
 # -- Configures service settings for the chart.
 # @default -- See values.yaml
@@ -36,6 +32,12 @@ ingress:
   # @default -- See values.yaml
   main:
     enabled: false
+
+securityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+  runAsGroup: 1000
+  fsGroup: 1000
 
 # -- Configure persistence settings for the chart under this key.
 # @default -- See values.yaml

--- a/charts/stable/homer/values.yaml
+++ b/charts/stable/homer/values.yaml
@@ -34,8 +34,11 @@ ingress:
     enabled: false
 
 securityContext:
+  # -- Specify the user ID the application will run as
   runAsUser: 1000
+  # -- Enable validation that the container must run as non-root user
   runAsNonRoot: true
+  # -- Specify the group ID the application will run as
   runAsGroup: 1000
   fsGroup: 1000
 

--- a/charts/stable/homer/values.yaml
+++ b/charts/stable/homer/values.yaml
@@ -8,8 +8,8 @@
 image:
   # -- image repository
   repository: b4bz/homer
-  # -- image tag
-  tag: v22.07.2
+  # @default -- chart.appVersion
+  tag:
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/homer/values.yaml
+++ b/charts/stable/homer/values.yaml
@@ -40,7 +40,6 @@ securityContext:
   runAsNonRoot: true
   # -- Specify the group ID the application will run as
   runAsGroup: 1000
-  fsGroup: 1000
 
 # -- Configure persistence settings for the chart under this key.
 # @default -- See values.yaml


### PR DESCRIPTION
Signed-off-by: Pascal Iske <info@pascaliske.dev>

**Description of the change**

- Updated app version to `v22.07.2`
- The environment variables for asset permissions were removed and a security context object were configured for the correct file permissions of the apps assets.

**Benefits**

The code change allows the usage with newer app versions than `22.02.2`, e.g. `v22.06.1` and newer.

**Possible drawbacks**

Custom values of users need to switch from env variables to security context as well.

**Applicable issues**

- fixes #1713

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
