### PR TITLE
[node-red] upgrade to 3.0.2

### DIFF
--- a/charts/stable/node-red/Chart.yaml
+++ b/charts/stable/node-red/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 2.2.2
+appVersion: 3.0.2
 description: Node-RED is low-code programming for event-driven applications
 name: node-red
-version: 10.3.2
+version: 11.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - nodered
@@ -23,4 +23,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.5.2
+      description: Upgraded to Node Red 3.0.2 upstream image

--- a/charts/stable/node-red/README.md
+++ b/charts/stable/node-red/README.md
@@ -1,6 +1,6 @@
 # node-red
 
-![Version: 10.3.2](https://img.shields.io/badge/Version-10.3.2-informational?style=flat-square) ![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=flat-square)
+![Version: 11.0.0](https://img.shields.io/badge/Version-11.0.0-informational?style=flat-square) ![AppVersion: 3.0.2](https://img.shields.io/badge/AppVersion-3.0.2-informational?style=flat-square)
 
 Node-RED is low-code programming for event-driven applications
 
@@ -91,7 +91,7 @@ N/A
 
 ## Changelog
 
-### Version 10.3.2
+### Version 11.0.0
 
 #### Added
 
@@ -99,7 +99,7 @@ N/A
 
 #### Changed
 
-* Upgraded `common` chart dependency to version 4.5.2
+* Upgraded to Node Red 3.0.2 upstream image*
 
 #### Fixed
 


### PR DESCRIPTION
**Description of the change**

Upgrade node-red to 3.0.2

**Benefits**

latest version of node-red

**Possible drawbacks**

possible incompatibilities of existing flows when upgrading from an older version

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file. (**not applicable**)
