### PR TITLE
[transmission] Fixed icon URL in Chart.yml

### DIFF
--- a/charts/stable/transmission/Chart.yaml
+++ b/charts/stable/transmission/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v3.00
 description: Transmission is a cross-platform BitTorrent client
 name: transmission
-version: 8.4.2
+version: 8.4.3
 kubeVersion: ">=1.16.0-0"
 keywords:
   - transmission
@@ -24,5 +24,7 @@ dependencies:
     version: 4.5.2
 annotations:
   artifacthub.io/changes: |-
+    - kind: changed
+      description: Fixed icon URL
     - kind: changed
       description: Upgraded `common` chart dependency to version 4.5.2

--- a/charts/stable/transmission/Chart.yaml
+++ b/charts/stable/transmission/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - transmission
   - torrent
 home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/transmission
-icon: https://github.com/transmission/transmission/raw/master/extras/transmission-1920.jpg
+icon: https://raw.githubusercontent.com/transmission/transmission/main/extras/transmission-1920.jpg
 sources:
   - https://github.com/transmission/transmission
   - https://github.com/k8s-at-home/container-images


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Fixes icon url for tranmission chart

**Benefits**

Tranmission icon will be visible in apps like kubeapps

**Possible drawbacks**

NA

**Applicable issues**
NA

**Additional information**

NA

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.

