### PR TITLE
[jellyfin] Update minor version to 10.8.4

### DIFF
--- a/charts/stable/jellyfin/Chart.yaml
+++ b/charts/stable/jellyfin/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2
-appVersion: 10.8.1
+appVersion: 10.8.4
 description: Jellyfin is a Free Software Media System
 name: jellyfin
-version: 9.5.3
+version: 9.5.4
 kubeVersion: ">=1.16.0-0"
 keywords:
   - jellyfin
@@ -24,4 +24,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `common` chart dependency to version 4.5.2
+      description: Updated Jellyfin to 10.8.4

--- a/charts/stable/jellyfin/README.md
+++ b/charts/stable/jellyfin/README.md
@@ -88,7 +88,7 @@ N/A
 
 ## Changelog
 
-### Version 9.5.3
+### Version 9.5.4
 
 #### Added
 
@@ -96,7 +96,7 @@ N/A
 
 #### Changed
 
-* Upgraded `common` chart dependency to version 4.5.2
+* Updated Jellyfin to 10.8.4
 
 #### Fixed
 


### PR DESCRIPTION
**Description of the change**
* Updates Jellyfin to 10.8.4

**Benefits**
* Updated version

**Possible drawbacks**
N/A

**Applicable issues**
N/A

**Additional information**
N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
